### PR TITLE
Provide a bucket id on the survey view

### DIFF
--- a/web/views/survey_view.ex
+++ b/web/views/survey_view.ex
@@ -75,6 +75,7 @@ defmodule Ask.SurveyView do
         [%{"store" => store, "value" => value} | conditions]
       end)
     %{
+      "id" => bucket.id,
       "condition" => condition,
       "quota" => bucket.quota,
       "count" => bucket.count


### PR DESCRIPTION
The bucket id on the survey view allows reletively easy access to the quota target. We need this for this:  https://github.com/ICTatRTI/surveda-status-alerter