### PR TITLE
Added conditional to find alternative codes to some langs

### DIFF
--- a/web/static/js/language.js
+++ b/web/static/js/language.js
@@ -3,7 +3,7 @@ import iso6393 from 'iso-639-3'
 
 export function nameToCode(name: string): ?string {
   let match = iso6393.find(l => l.name == name)
-  return match ? match.iso6391 : null
+  return match ? (match.iso6391 || match.iso6393) : null
 }
 
 export function codeToName(code: string): ?string {


### PR DESCRIPTION
Solves #1423 

Basically some langs have no iso6391 code registered, for those langs we are now using iso6393 as a fallback. Fortunately the codeToName function had a the find prepared for both iso6393 and 6391 so no changes were needed there