### PR TITLE
Add dockerised development instructions to README

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       HTTP_PORT: 80
       TERM: xterm
     ports:
-      - 4000:80
+      - 80
 
   webpack:
     build:
@@ -50,6 +50,6 @@ services:
   ngrok:
     image: wernight/ngrok
     ports:
-      - 4040:4040
+      - 4040
     environment:
       NGROK_PORT: 'app:80'


### PR DESCRIPTION
I've reworded the README with instructions to set up the development environment in Docker along with Guisso, Nuntium & Verboice