### PR TITLE
Ignore answers on non-active modes

### DIFF
--- a/lib/ask/runtime/nuntium_channel.ex
+++ b/lib/ask/runtime/nuntium_channel.ex
@@ -81,7 +81,7 @@ defmodule Ask.Runtime.NuntiumChannel do
     reply = case respondent do
       nil ->
         nil
-      _ ->
+      %Respondent{session: %{"current_mode" => %{"mode" => "sms"}}} ->
         case broker.sync_step(respondent, Flow.Message.reply(body), "sms") do
           {:reply, reply} ->
             update_stats(respondent, reply)
@@ -93,6 +93,8 @@ defmodule Ask.Runtime.NuntiumChannel do
             update_stats(respondent)
             nil
         end
+      _ ->
+        nil
     end
     json_reply = reply_to_messages(reply, from, respondent)
     SurvedaMetrics.increment_counter(:surveda_nuntium_incoming)

--- a/lib/ask/runtime/verboice_channel.ex
+++ b/lib/ask/runtime/verboice_channel.ex
@@ -265,7 +265,7 @@ defmodule Ask.Runtime.VerboiceChannel do
       nil ->
         hangup()
 
-      _ ->
+      %Respondent{session: %{"current_mode" => %{"mode" => "ivr"}}} ->
         response = case params["Digits"] do
           nil -> Flow.Message.answer()
           "timeout" -> Flow.Message.no_reply()
@@ -283,6 +283,9 @@ defmodule Ask.Runtime.VerboiceChannel do
           :end ->
             hangup()
         end
+
+      _ ->
+        hangup()
     end
 
     reply = response(response_content) |> generate


### PR DESCRIPTION
If a respondent sends an answer via a mode that's not the currently active one, we ignore that.

Fixes #1482