### PR TITLE
Do not log verboice expired call event into SurveyLogger

### DIFF
--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -92,12 +92,12 @@ defmodule Ask.Runtime.Broker do
     end
   end
 
-  def contact_attempt_expired(respondent, reason) do
+  def contact_attempt_expired(respondent) do
     session = respondent.session
     if session do
       response = session
         |> Session.load
-        |> Session.contact_attempt_expired(reason)
+        |> Session.contact_attempt_expired
 
       update_respondent(respondent, response, nil)
     end

--- a/lib/ask/runtime/verboice_channel.ex
+++ b/lib/ask/runtime/verboice_channel.ex
@@ -193,7 +193,7 @@ defmodule Ask.Runtime.VerboiceChannel do
   defp match_channel(_, _), do: false
 
   defp channel_failed(respondent, "expired", _) do
-    Broker.contact_attempt_expired(respondent, "Call expired, will be retried in next schedule window")
+    Broker.contact_attempt_expired(respondent)
   end
 
   defp channel_failed(respondent, "failed", %{"CallStatusReason" => "Busy", "CallStatusCode" => code}) do

--- a/test/lib/runtime/verboice_channel_test.exs
+++ b/test/lib/runtime/verboice_channel_test.exs
@@ -503,15 +503,11 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, timeout] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      assert [enqueueing] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert enqueueing.survey_id == survey.id
       assert enqueueing.action_data == "Enqueueing call"
       assert enqueueing.action_type == "contact"
-
-      assert timeout.survey_id == survey.id
-      assert timeout.action_data == "Call expired, will be retried in next schedule window"
-      assert timeout.action_type == "contact"
 
       respondent = Repo.get(Respondent, respondent.id)
       refute respondent.stats.total_call_time


### PR DESCRIPTION
The issue was to remove the line of expired call from the interactions csv file. Talking with @waj we agreed that it didn't make sense to save a row with that scenario even, since it doesn't contribute anything in user's interaction history since the user was never contacted.

`reason` parameter in `Session.rety` was only being used in this case, so it was removed from the parameter list to avoid dead-code

for #1519