### PR TITLE
Allow surveys to be terminated in background processes

### DIFF
--- a/lib/ask.ex
+++ b/lib/ask.ex
@@ -1,10 +1,12 @@
 defmodule Ask do
   use Application
 
+
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
     import Supervisor.Spec
+
 
     Ask.PhoenixInstrumenter.setup()
     Ask.PrometheusExporter.setup()
@@ -38,7 +40,20 @@ defmodule Ask do
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Ask.Supervisor]
-    Supervisor.start_link(children, opts)
+    supervisor_result = Supervisor.start_link(children, opts)
+    survey_canceller_children = if Mix.env != :test && !IEx.started? do
+      [
+        GenStage.start_link(Ask.RespondentsCancellerProducer, nil, name: RespondentsCancellerProducer),
+        GenStage.start_link(Ask.RespondentsCancellerConsumer, 0, name: RespondentsCancellerConsumer_1),
+        GenStage.start_link(Ask.RespondentsCancellerConsumer, 0, name: RespondentsCancellerConsumer_2),
+        GenStage.start_link(Ask.RespondentsCancellerConsumer, 0, name: RespondentsCancellerConsumer_3)
+      ]
+    end
+
+    if Mix.env != :test && !IEx.started? do
+      Supervisor.start_link(survey_canceller_children, strategy: :rest_for_one)
+    end
+    supervisor_result
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -61,6 +61,8 @@
   "Cancel": "",
   "Cancelled": "",
   "Cancelled_survey": "",
+  "Cancelling": "",
+  "Cancelling_survey": "",
   "Cannot jump to a previous step or step outside section": "",
   "Cannot jump to end of section if there is no sections": "",
   "Change color scheme": "",

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,8 @@ defmodule Ask.Mixfile do
       {:pp, "~> 0.1.0", only: [:dev, :test]},
       {:bypass, "~> 0.8", only: :test},
       {:trailing_format_plug, "~> 0.0.7"},
-      {:plug_cowboy, "~> 1.0"}
+      {:plug_cowboy, "~> 1.0"},
+      {:gen_stage, "~> 0.14"}
    ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -21,6 +21,7 @@
   "ex_machina": {:hex, :ex_machina, "1.0.2", "1cc49e1a09e3f7ab2ecb630c17f14c2872dc4ec145d6d05a9c3621936a63e34f", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "gen_smtp": {:hex, :gen_smtp, "0.12.0", "97d44903f5ca18ca85cb39aee7d9c77e98d79804bbdef56078adcf905cb2ef00", [:rebar3], [], "hexpm"},
+  "gen_stage": {:hex, :gen_stage, "0.14.2", "6a2a578a510c5bfca8a45e6b27552f613b41cf584b58210f017088d3d17d0b14", [:mix], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "0.13.0", "bfaf44d9f133a6599886720f3937a7699466d23bb0cd7a88b6ba011f53c6f562", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -1513,14 +1513,18 @@ defmodule Ask.SurveyControllerTest do
       }
       session = Session.dump(session)
       r1 |> Ask.Respondent.changeset(%{session: session}) |> Repo.update!
-
       conn = post conn, project_survey_survey_path(conn, :stop, survey.project, survey)
-
+      canceller_pid = conn.assigns[:process_pid]
+      ref = Process.monitor(canceller_pid)
+      receive do
+        {:DOWN, ^ref, _, _, _} -> :task_is_down
+      end
       assert json_response(conn, 200)
       survey = Repo.get(Survey, survey.id)
       assert Survey.cancelled?(survey)
       assert length(Repo.all(from(r in Ask.Respondent, where: (r.state == "cancelled" and is_nil(r.session) and is_nil(r.timeout_at))))) == 4
       assert_receive [:cancel_message, ^test_channel, ^channel_state]
+
     end
 
     test "stops respondents only for the stopped survey", %{conn: conn, user: user} do
@@ -1545,9 +1549,12 @@ defmodule Ask.SurveyControllerTest do
       }
       session = Session.dump(session)
       r1 |> Ask.Respondent.changeset(%{session: session}) |> Repo.update!
-
       conn = post conn, project_survey_survey_path(conn, :stop, survey.project, survey)
-
+      canceller_pid = conn.assigns[:process_pid]
+      ref = Process.monitor(canceller_pid)
+      receive do
+        {:DOWN, ^ref, _, _, _} -> :task_is_down
+      end
       assert json_response(conn, 200)
       assert Repo.get(Survey, survey2.id).state == "running"
       assert length(Repo.all(from(r in Ask.Respondent, where: (r.state == "active" or r.state == "stalled" )))) == 6
@@ -2078,6 +2085,11 @@ defmodule Ask.SurveyControllerTest do
       survey = insert(:survey, project: project, state: "running")
 
       post conn, project_survey_survey_path(conn, :stop, survey.project, survey)
+      pid = conn.assigns[:process_pid]
+      ref = Process.monitor(pid)
+      receive do
+        {:DOWN, ^ref, _, _, _} -> :task_is_down
+      end
       log = ActivityLog|> Repo.one
 
       assert_survey_log(%{log: log, user: user, project: project, survey: survey, action: "stop", remote_ip: "192.168.0.128", metadata: %{"survey_name" => survey.name}})

--- a/web/controllers/survey_respondents_canceller.ex
+++ b/web/controllers/survey_respondents_canceller.ex
@@ -1,0 +1,123 @@
+defmodule Ask.RespondentsCancellerProducer do
+  use Ecto.Schema
+  import Ecto.Query
+
+  alias Ask.Respondent
+  alias Ask.Survey
+  alias Ask.Repo
+
+  use GenStage
+
+  def start_link(initial) do
+    GenStage.start_link(__MODULE__, initial, name: __MODULE__)
+  end
+
+  def init(survey_id) when not is_nil(survey_id)do
+    state = %{survey_ids: [survey_id], last_updated_respondent_id: 0}
+    {:producer, state}
+  end
+
+  def init(survey_id) when is_nil(survey_id)do
+    query = from(
+      s in Survey,
+      where: (s.state == "cancelling"),
+      select: s.id
+    )
+    survey_ids = query
+                 |> Repo.all
+
+    case survey_ids do
+      [] -> GenStage.stop(self(), :normal)
+      _-> :ok
+    end
+    state = %{survey_ids: survey_ids, last_updated_respondent_id: 0}
+
+    {:producer, state}
+  end
+
+  def handle_demand(_demand, state) do
+    respondents = get_respondents_for_update(state)
+    handle_respondents(respondents, state)
+  end
+
+  def handle_respondents(respondents, state) when length(respondents) > 0 do
+    last_id = List.last(respondents).id
+    new_state = %{survey_ids: state.survey_ids, last_updated_respondent_id: last_id}
+    {:noreply, respondents, new_state}
+  end
+
+
+  def handle_respondents(respondents, state) when length(respondents) == 0 do
+    state.survey_ids
+    |> Enum.each(
+         fn survey_id ->
+           survey = Repo.get(Survey, survey_id)
+           survey
+           |> Survey.changeset(%{"state": "terminated", "exit_code": 1, "exit_message": "Cancelled by user"})
+           |> Repo.update!
+         end
+       )
+
+    {:stop, :normal, state}
+  end
+
+  def get_respondents_for_update(state) do
+    query = from(
+      r in Respondent,
+      where: (
+        ((r.state == "active") or (r.state == "stalled")) and (r.survey_id in ^state.survey_ids) and (
+          r.id > ^state.last_updated_respondent_id)),
+      limit: 100,
+      order_by: [
+        asc: r.id
+      ]
+    )
+    Repo.all(query)
+  end
+end
+
+
+defmodule Ask.RespondentsCancellerConsumer do
+  use Ecto.Schema
+  alias Ask.RespondentsCancellerProducer
+  alias Ask.Respondent
+  alias Ask.Repo
+  alias Ask.Runtime.Session
+  use GenStage, restart: :transient
+
+  def start_link(_initial) do
+    GenStage.start_link(__MODULE__, :state, name: __MODULE__)
+  end
+
+  def init(state) do
+    {:consumer, state, subscribe_to: [{RespondentsCancellerProducer, max_demand: 50, min_demand: 1}]}
+  end
+
+  def handle_events(respondents, _from, state) do
+    sessions = respondents
+              |> Enum.map(&(&1.session))
+              |> Enum.reject(&is_nil/1)
+
+    sessions
+    |> Enum.each(
+         fn session ->
+           session
+           |> Session.load
+           |> Session.cancel
+         end
+       )
+
+    respondents
+    |> Enum.each(
+         fn respondent ->
+           respondent
+           |> Respondent.changeset(%{state: "cancelled", session: nil, timeout_at: nil})
+           |> Repo.update!
+         end
+       )
+
+    {:noreply, [], state}
+  end
+end
+
+

--- a/web/static/js/components/surveys/SurveyStatus.jsx
+++ b/web/static/js/components/surveys/SurveyStatus.jsx
@@ -143,6 +143,27 @@ class SurveyStatus extends PureComponent {
             break
         }
         break
+      case 'cancelling':
+        switch (survey.exitCode) {
+          case 0:
+            icon = 'done'
+            text = t('Completed', {context: 'survey'})
+            break
+
+          case 1:
+            icon = 'error'
+            text = t('Cancelling', {context: 'survey'})
+            tooltip = survey.exitMessage
+            break
+
+          default:
+            icon = 'error'
+            color = 'text-error'
+            text = t('Failed', {context: 'survey'})
+            tooltip = survey.exitMessage
+            break
+        }
+        break
 
       default:
         icon = 'warning'


### PR DESCRIPTION
Surveys were being stopped by a synchronous call triggered by the user. In a survey with a high number of respondents, this action cause the application to underperfom.
This feature will allow to stop surveys in background. 

Fixes #1517 