### PR TITLE
Fix cancel survey tests

### DIFF
--- a/lib/ask.ex
+++ b/lib/ask.ex
@@ -42,12 +42,8 @@ defmodule Ask do
     opts = [strategy: :one_for_one, name: Ask.Supervisor]
     supervisor_result = Supervisor.start_link(children, opts)
     survey_canceller_children = if Mix.env != :test && !IEx.started? do
-      [
-        GenStage.start_link(Ask.RespondentsCancellerProducer, nil, name: RespondentsCancellerProducer),
-        GenStage.start_link(Ask.RespondentsCancellerConsumer, 0, name: RespondentsCancellerConsumer_1),
-        GenStage.start_link(Ask.RespondentsCancellerConsumer, 0, name: RespondentsCancellerConsumer_2),
-        GenStage.start_link(Ask.RespondentsCancellerConsumer, 0, name: RespondentsCancellerConsumer_3)
-      ]
+      # Start cancelling with survey_id = nil to check all surveys that must be cancelled
+      Ask.SurveyCanceller.start_cancelling(nil).processes
     end
 
     if Mix.env != :test && !IEx.started? do

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -4,8 +4,7 @@ defmodule Ask.SurveyController do
   alias Ask.{Project, Folder, Survey, Questionnaire, Logger, RespondentGroup, Respondent, Channel, ShortLink, ActivityLog}
   alias Ask.Runtime.Session
   alias Ecto.Multi
-  alias Ask.RespondentsCancellerProducer
-  alias Ask.RespondentsCancellerConsumer
+  alias Ask.SurveyCanceller
 
   def index(conn, %{"project_id" => project_id} = params) do
     project = conn
@@ -736,12 +735,6 @@ defmodule Ask.SurveyController do
     end
   end
 
-  defp cancel_messages_and_respondents(survey_id) do
-    GenStage.start_link(RespondentsCancellerProducer, survey_id, name: RespondentsCancellerProducer)
-    consumer_name = fn id -> String.to_atom("RespondentsCancellerConsumer_#{id}") end
-    Enum.map(1..3, consumer_name)
-    |> Enum.map(fn name -> GenStage.start_link(RespondentsCancellerConsumer, 0, name: name) end)
-    |> Enum.map(fn {:ok, pid} -> pid end)
-  end
+  defp cancel_messages_and_respondents(survey_id), do: SurveyCanceller.start_cancelling(survey_id).consumers_pids
 
 end


### PR DESCRIPTION
**survey_controller_test**
Tests where failing because where waiting on producer to stop instead of waiting for all the consumers. Tests failed because when running the asserts the consumers had not finished cancelling all the respondents

