### PR TITLE
Fix default for retry stat time in respondent

### DIFF
--- a/priv/repo/migrations/20191213131858_fix_default_for_retry_stat_time_in_respondents.exs
+++ b/priv/repo/migrations/20191213131858_fix_default_for_retry_stat_time_in_respondents.exs
@@ -1,0 +1,11 @@
+defmodule Ask.Repo.Migrations.FixDefaultForRetryStatTimeInRespondents do
+  use Ecto.Migration
+
+  def up do
+    execute "UPDATE respondents SET retry_stat_time = 'N/A' WHERE CHAR_LENGTH(retry_stat_time) > 10"
+  end
+
+  def down do
+    execute "UPDATE respondents SET retry_stat_time = NULL WHERE retry_stat_time = 'N/A'"
+  end
+end


### PR DESCRIPTION
For #1594 

The only current valid format is YYYYMMDDHH

Invalid values where set in 9a760ad