### PR TITLE
Fix `not_after` miscalculation in western timezones

### DIFF
--- a/lib/ask/ecto_types/schedule.ex
+++ b/lib/ask/ecto_types/schedule.ex
@@ -158,7 +158,7 @@ defmodule Ask.Schedule do
   end
 
   def at_end_time(%Schedule{end_time: end_time, timezone: timezone}, %DateTime{} = date_time) do
-    {erlang_date, _} = date_time |> Timex.to_erl
+    {erlang_date, _} = date_time |> Timex.Timezone.convert(timezone) |> Timex.to_erl
     erlang_time = end_time |> Time.to_erl
     Timex.Timezone.resolve(timezone, {erlang_date, erlang_time})
   end

--- a/test/lib/ecto_types/schedule_test.exs
+++ b/test/lib/ecto_types/schedule_test.exs
@@ -129,4 +129,38 @@ defmodule Ask.ScheduleTest do
       assert time == DateTime.from_naive!(~N[2017-10-11 12:00:00], "Etc/UTC")
     end
   end
+
+  describe "at_end_time" do
+    test "bug with IVR schedule in Ecuador" do
+      schedule = %Ask.Schedule{
+        start_time: ~T[09:00:00],
+        end_time: ~T[20:00:00],
+        day_of_week: %Ask.DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: true, sat: true},
+        timezone: "America/Bogota", # The Ecuador survey actually used Bogota as timezone
+        blocked_days: []
+      }
+      start_time = DateTime.from_naive!(~N[2019-12-08 00:37:06], "Etc/UTC") # Dates in Verboice are shown in UTC
+
+      end_time = schedule
+      |> Schedule.at_end_time(start_time)
+
+      assert Elixir.Timex.equal?(end_time, DateTime.from_naive!(~N[2019-12-08 01:00:00], "Etc/UTC"))
+    end
+
+    test "bug with IVR schedule in Ecuador wouldn't happen in GMT+5" do
+      schedule = %Ask.Schedule{
+        start_time: ~T[09:00:00],
+        end_time: ~T[20:00:00],
+        day_of_week: %Ask.DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: true, sat: true},
+        timezone: "Etc/GMT+5",
+        blocked_days: []
+      }
+      start_time = DateTime.from_naive!(~N[2019-12-08 00:37:06], "Etc/UTC") # Dates in Verboice are shown in UTC
+
+      end_time = schedule
+      |> Schedule.at_end_time(start_time)
+
+      assert Elixir.Timex.equal?(end_time, DateTime.from_naive!(~N[2019-12-08 01:00:00], "Etc/UTC"))
+    end
+  end
 end


### PR DESCRIPTION
We'll have to cherry-pick this into the current main branch, too (0.24).

Fixes #1602