### PR TITLE
Accumulate calls durations to calculate total call time

### DIFF
--- a/lib/ask/runtime/verboice_channel.ex
+++ b/lib/ask/runtime/verboice_channel.ex
@@ -228,7 +228,7 @@ defmodule Ask.Runtime.VerboiceChannel do
     Broker.channel_failed(respondent, status)
   end
 
-  def update_call_time_seconds(respondent, call_sid, call_time) do
+  defp update_call_time_seconds(respondent, call_sid, call_time) do
     stats = respondent.stats
     |> Stats.with_call_time(call_sid, call_time)
 

--- a/lib/ask/runtime/verboice_channel.ex
+++ b/lib/ask/runtime/verboice_channel.ex
@@ -228,19 +228,19 @@ defmodule Ask.Runtime.VerboiceChannel do
     Broker.channel_failed(respondent, status)
   end
 
-  def update_call_time_seconds(respondent, call_time) do
+  def update_call_time_seconds(respondent, call_sid, call_time) do
     stats = respondent.stats
-    |> Stats.total_call_time_seconds(call_time)
+    |> Stats.with_call_time(call_sid, call_time)
 
     respondent
     |> Respondent.changeset(%{stats: stats})
     |> Repo.update!
   end
 
-  def callback(conn, %{"path" => ["status", respondent_id, _token], "CallStatus" => status, "CallDuration" => call_duration_seconds} = params) do
+  def callback(conn, %{"path" => ["status", respondent_id, _token], "CallStatus" => status, "CallDuration" => call_duration_seconds, "CallSid" => call_sid} = params) do
     call_duration = call_duration_seconds |> String.to_integer
     respondent = Repo.get!(Respondent, respondent_id)
-                 |> update_call_time_seconds(call_duration)
+                 |> update_call_time_seconds(call_sid, call_duration)
     case status do
       "expired" ->
         # respondent is still being considered as active in Surveda

--- a/test/controllers/respondent_controller_test.exs
+++ b/test/controllers/respondent_controller_test.exs
@@ -11,7 +11,8 @@ defmodule Ask.RespondentControllerTest do
     "total_call_time" => nil,
     "total_call_time_seconds" => nil,
     "total_received_sms" => 0,
-    "total_sent_sms" => 0
+    "total_sent_sms" => 0,
+    "call_durations" => %{}
   }
 
   describe "normal" do
@@ -773,7 +774,7 @@ defmodule Ask.RespondentControllerTest do
       questionnaire = insert(:questionnaire, name: "test", project: project, steps: @dummy_steps)
       survey = insert(:survey, project: project, cutoff: 4, questionnaires: [questionnaire], state: "ready", schedule: completed_schedule(), mode: [["sms", "ivr"], ["mobileweb"], ["sms", "mobileweb"]])
       group_1 = insert(:respondent_group)
-      respondent_1 = insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group_1, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, attempts: %{sms: 1, mobileweb: 2, ivr: 3}})
+      respondent_1 = insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group_1, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}})
       insert(:response, respondent: respondent_1, field_name: "Smokes", value: "Yes")
       insert(:response, respondent: respondent_1, field_name: "Exercises", value: "No")
       insert(:response, respondent: respondent_1, field_name: "Perfect Number", value: "100")
@@ -797,7 +798,7 @@ defmodule Ask.RespondentControllerTest do
       assert line_2_disp == "Partial"
       assert line_2_total_sent_sms == "3"
       assert line_2_total_received_sms == "4"
-      assert line_2_total_call_time == "0m 12s"
+      assert line_2_total_call_time == "0m 57s"
       assert line_2_perfect_number == "100"
       assert line_2_section_order == ""
       assert line_2_sms_attempts == "1"

--- a/test/lib/ecto_types/stats_test.exs
+++ b/test/lib/ecto_types/stats_test.exs
@@ -212,6 +212,12 @@ defmodule Ask.StatsTest do
       assert Stats.total_call_time_seconds(stats) == 30
     end
 
+    test "resolves to new field in discrepancy with registered calls" do
+      stats = %Stats{total_call_time: 1.5, total_call_time_seconds: 30, call_durations: %{"1" => 25, "40" => 40, "any-kind-of-id" => 2, "zero-lenght" => 0}}
+
+      assert Stats.total_call_time_seconds(stats) == 97
+    end
+
     test "defaults old total_call_time to zero" do
       {:ok, stats} = Stats.load("{}")
 

--- a/test/lib/runtime/retries_histogram_test.exs
+++ b/test/lib/runtime/retries_histogram_test.exs
@@ -421,7 +421,7 @@ defmodule Ask.Runtime.RetriesHistogramTest do
   end
 
   defp call_failed(conn, respondent_id), do:
-    VerboiceChannel.callback(conn, %{"path" => ["status", respondent_id, "token"], "CallStatus" => "failed", "CallDuration" => "10", "CallStatusReason" => "some random reason", "CallStatusCode" => "42"})
+    VerboiceChannel.callback(conn, %{"path" => ["status", respondent_id, "token"], "CallStatus" => "failed", "CallDuration" => "10", "CallStatusReason" => "some random reason", "CallStatusCode" => "42", "CallSid" => "call-sid"})
 
   defp configure_retries_and_fallback(type, retries_hours, fallback_delay_hours) when type in ["sms", "mobileweb"] do
     flow = base_flow(type, retries_hours)

--- a/test/lib/runtime/verboice_channel_test.exs
+++ b/test/lib/runtime/verboice_channel_test.exs
@@ -201,7 +201,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == "active"
 
-      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "10", "CallStatusReason" => "some random reason", "CallStatusCode" => "42"})
+      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "10", "CallSid" => "6B8F5B7B-E412-46D3-96E1-688215F43CC3", "CallStatusReason" => "some random reason", "CallStatusCode" => "42"})
 
       :ok = logger |> GenServer.stop
 
@@ -224,7 +224,9 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       refute respondent.stats.total_call_time
-      assert respondent.stats.total_call_time_seconds == 10
+      refute respondent.stats.total_call_time_seconds
+      assert respondent.stats.call_durations
+      assert respondent.stats.call_durations["6B8F5B7B-E412-46D3-96E1-688215F43CC3"] == 10
 
       :ok = broker |> GenServer.stop
     end
@@ -250,7 +252,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == "active"
 
-      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "11", "CallStatusCode" => "42"})
+      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "11", "CallSid" => "some-id", "CallStatusCode" => "42"})
 
       :ok = logger |> GenServer.stop
 
@@ -273,7 +275,9 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       refute respondent.stats.total_call_time
-      assert respondent.stats.total_call_time_seconds == 11
+      refute respondent.stats.total_call_time_seconds
+      assert respondent.stats.call_durations
+      assert respondent.stats.call_durations["some-id"] == 11
 
       :ok = broker |> GenServer.stop
     end
@@ -300,7 +304,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == "active"
 
-      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "12", "CallStatusReason" => "some random reason"})
+      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "12", "CallSid" => "id with spaces", "CallStatusReason" => "some random reason"})
 
       :ok = logger |> GenServer.stop
 
@@ -323,7 +327,9 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       refute respondent.stats.total_call_time
-      assert respondent.stats.total_call_time_seconds == 12
+      refute respondent.stats.total_call_time_seconds
+      assert respondent.stats.call_durations
+      assert respondent.stats.call_durations["id with spaces"] == 12
 
       :ok = broker |> GenServer.stop
     end
@@ -350,7 +356,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == "active"
 
-      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "13"})
+      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "13", "CallSid" => "12345"})
 
       :ok = logger |> GenServer.stop
 
@@ -373,7 +379,9 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       refute respondent.stats.total_call_time
-      assert respondent.stats.total_call_time_seconds == 13
+      refute respondent.stats.total_call_time_seconds
+      assert respondent.stats.call_durations
+      assert respondent.stats.call_durations["12345"] == 13
 
       :ok = broker |> GenServer.stop
     end
@@ -400,7 +408,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == "active"
 
-      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "no-answer", "CallDuration" => "14", "CallStatusReason" => "another reason", "CallStatusCode" => "foo"})
+      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "no-answer", "CallDuration" => "14", "CallSid" => "1515", "CallStatusReason" => "another reason", "CallStatusCode" => "foo"})
 
       :ok = logger |> GenServer.stop
 
@@ -423,7 +431,9 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       refute respondent.stats.total_call_time
-      assert respondent.stats.total_call_time_seconds == 14
+      refute respondent.stats.total_call_time_seconds
+      assert respondent.stats.call_durations
+      assert respondent.stats.call_durations["1515"] == 14
 
       :ok = broker |> GenServer.stop
     end
@@ -450,7 +460,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == "active"
 
-      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "busy", "CallDuration" => "15", "CallStatusReason" => "yet another reason", "CallStatusCode" => "bar"})
+      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "busy", "CallDuration" => "15", "CallSid" => "1", "CallStatusReason" => "yet another reason", "CallStatusCode" => "bar"})
 
       :ok = logger |> GenServer.stop
 
@@ -473,7 +483,9 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       refute respondent.stats.total_call_time
-      assert respondent.stats.total_call_time_seconds == 15
+      refute respondent.stats.total_call_time_seconds
+      assert respondent.stats.call_durations
+      assert respondent.stats.call_durations["1"] == 15
 
       :ok = broker |> GenServer.stop
     end
@@ -501,7 +513,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       assert 1 == %{survey_id: survey.id} |> RetryStat.stats() |> RetryStat.count(%{attempt: 1, ivr_active: true, mode: mode})
 
-      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "expired", "CallDuration" => "16"})
+      VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "expired", "CallDuration" => "16", "CallSid" => "b1eca8c0-9b77-4273-848f-c821b3dbbabf"})
 
       assert 1 == %{survey_id: survey.id} |> RetryStat.stats() |> RetryStat.count(%{attempt: 1, ivr_active: true, mode: mode}),
              "respondent should remain active when contact expired"
@@ -516,7 +528,9 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       refute respondent.stats.total_call_time
-      assert respondent.stats.total_call_time_seconds == 16
+      refute respondent.stats.total_call_time_seconds
+      assert respondent.stats.call_durations
+      assert respondent.stats.call_durations["b1eca8c0-9b77-4273-848f-c821b3dbbabf"] == 16
 
       VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "expired", "CallDuration" => "16"})
     end

--- a/test/lib/runtime/verboice_channel_test.exs
+++ b/test/lib/runtime/verboice_channel_test.exs
@@ -256,28 +256,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
-
-      assert enqueueing.survey_id == survey.id
-      assert enqueueing.action_data == "Enqueueing call"
-      assert enqueueing.action_type == "contact"
-      assert enqueueing.disposition == "queued"
-
-      assert call_failed.survey_id == survey.id
-      assert call_failed.action_data == "(42)"
-      assert call_failed.action_type == "contact"
-      assert call_failed.disposition == "queued"
-
-      assert disposition_changed_to_failed.survey_id == survey.id
-      assert disposition_changed_to_failed.action_data == "Failed"
-      assert disposition_changed_to_failed.action_type == "disposition changed"
-      assert disposition_changed_to_failed.disposition == "queued"
-
-      respondent = Repo.get(Respondent, respondent.id)
-      refute respondent.stats.total_call_time
-      refute respondent.stats.total_call_time_seconds
-      assert respondent.stats.call_durations
-      assert respondent.stats.call_durations["some-id"] == 11
+      respondent |> assert_respondent_state("some-id", 11, "(42)")
 
       :ok = broker |> GenServer.stop
     end
@@ -308,28 +287,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
-
-      assert enqueueing.survey_id == survey.id
-      assert enqueueing.action_data == "Enqueueing call"
-      assert enqueueing.action_type == "contact"
-      assert enqueueing.disposition == "queued"
-
-      assert call_failed.survey_id == survey.id
-      assert call_failed.action_data == "some random reason"
-      assert call_failed.action_type == "contact"
-      assert call_failed.disposition == "queued"
-
-      assert disposition_changed_to_failed.survey_id == survey.id
-      assert disposition_changed_to_failed.action_data == "Failed"
-      assert disposition_changed_to_failed.action_type == "disposition changed"
-      assert disposition_changed_to_failed.disposition == "queued"
-
-      respondent = Repo.get(Respondent, respondent.id)
-      refute respondent.stats.total_call_time
-      refute respondent.stats.total_call_time_seconds
-      assert respondent.stats.call_durations
-      assert respondent.stats.call_durations["id with spaces"] == 12
+      respondent |> assert_respondent_state("id with spaces", 12, "some random reason")
 
       :ok = broker |> GenServer.stop
     end
@@ -360,28 +318,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
-
-      assert enqueueing.survey_id == survey.id
-      assert enqueueing.action_data == "Enqueueing call"
-      assert enqueueing.action_type == "contact"
-      assert enqueueing.disposition == "queued"
-
-      assert call_failed.survey_id == survey.id
-      assert call_failed.action_data == "failed"
-      assert call_failed.action_type == "contact"
-      assert enqueueing.disposition == "queued"
-
-      assert disposition_changed_to_failed.survey_id == survey.id
-      assert disposition_changed_to_failed.action_data == "Failed"
-      assert disposition_changed_to_failed.action_type == "disposition changed"
-      assert disposition_changed_to_failed.disposition == "queued"
-
-      respondent = Repo.get(Respondent, respondent.id)
-      refute respondent.stats.total_call_time
-      refute respondent.stats.total_call_time_seconds
-      assert respondent.stats.call_durations
-      assert respondent.stats.call_durations["12345"] == 13
+      respondent |> assert_respondent_state("12345", 13, "failed")
 
       :ok = broker |> GenServer.stop
     end
@@ -412,28 +349,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
-
-      assert enqueueing.survey_id == survey.id
-      assert enqueueing.action_data == "Enqueueing call"
-      assert enqueueing.action_type == "contact"
-      assert enqueueing.disposition == "queued"
-
-      assert call_failed.survey_id == survey.id
-      assert call_failed.action_data == "no-answer: another reason (foo)"
-      assert call_failed.action_type == "contact"
-      assert call_failed.disposition == "queued"
-
-      assert disposition_changed_to_failed.survey_id == survey.id
-      assert disposition_changed_to_failed.action_data == "Failed"
-      assert disposition_changed_to_failed.action_type == "disposition changed"
-      assert disposition_changed_to_failed.disposition == "queued"
-
-      respondent = Repo.get(Respondent, respondent.id)
-      refute respondent.stats.total_call_time
-      refute respondent.stats.total_call_time_seconds
-      assert respondent.stats.call_durations
-      assert respondent.stats.call_durations["1515"] == 14
+      respondent |> assert_respondent_state("1515", 14, "no-answer: another reason (foo)")
 
       :ok = broker |> GenServer.stop
     end
@@ -464,28 +380,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
-
-      assert enqueueing.survey_id == survey.id
-      assert enqueueing.action_data == "Enqueueing call"
-      assert enqueueing.action_type == "contact"
-      assert enqueueing.disposition == "queued"
-
-      assert call_failed.survey_id == survey.id
-      assert call_failed.action_data == "busy: yet another reason (bar)"
-      assert call_failed.action_type == "contact"
-      assert call_failed.disposition == "queued"
-
-      assert disposition_changed_to_failed.survey_id == survey.id
-      assert disposition_changed_to_failed.action_data == "Failed"
-      assert disposition_changed_to_failed.action_type == "disposition changed"
-      assert disposition_changed_to_failed.disposition == "queued"
-
-      respondent = Repo.get(Respondent, respondent.id)
-      refute respondent.stats.total_call_time
-      refute respondent.stats.total_call_time_seconds
-      assert respondent.stats.call_durations
-      assert respondent.stats.call_durations["1"] == 15
+      respondent |> assert_respondent_state("1", 15, "busy: yet another reason (bar)")
 
       :ok = broker |> GenServer.stop
     end
@@ -557,5 +452,31 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
     # :status should be :up when not receiving status information
     assert VerboiceChannel.check_status(%{}) == :up
+  end
+
+  defp assert_respondent_state(respondent, call_id, expected_call_duration, call_fail_reason) do
+    assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+
+    assert enqueueing.survey_id == respondent.survey_id
+    assert enqueueing.action_data == "Enqueueing call"
+    assert enqueueing.action_type == "contact"
+    assert enqueueing.disposition == "queued"
+
+    assert call_failed.survey_id == respondent.survey_id
+    assert call_failed.action_data == call_fail_reason
+    assert call_failed.action_type == "contact"
+    assert call_failed.disposition == "queued"
+
+    assert disposition_changed_to_failed.survey_id == respondent.survey_id
+    assert disposition_changed_to_failed.action_data == "Failed"
+    assert disposition_changed_to_failed.action_type == "disposition changed"
+    assert disposition_changed_to_failed.disposition == "queued"
+
+    respondent = Repo.get(Respondent, respondent.id)
+    refute respondent.stats.total_call_time
+    refute respondent.stats.total_call_time_seconds
+    assert respondent.stats.call_durations
+    assert respondent.stats.call_durations[call_id] == expected_call_duration
+    assert Ask.Stats.total_call_time_seconds(respondent.stats) == expected_call_duration
   end
 end


### PR DESCRIPTION
Surveda receives call durations on Verboice status callbacks.

Surveda was keeping the latest call duration received as the total call durations for the respondent, which was wrong. Now we keep record of each of the calls involved in a respondent's survey, so
we can then sum them up.

Surveda can receive multiple status callbacks for a single call, so it would be difficult to sum that in a single variable.

Fixes #1452