### PR TITLE
Make RetriesHistogram use safer

### DIFF
--- a/lib/ask/logger.ex
+++ b/lib/ask/logger.ex
@@ -7,6 +7,12 @@ defmodule Ask.Logger do
     end
   end
 
+  def error(ex, msg) do
+    if should_log() do
+      Logger.error "#{msg}: #{inspect ex} #{inspect System.stacktrace}"
+    end
+  end
+
   def warn(msg) do
     if should_log() do
       Logger.warn msg

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -165,7 +165,7 @@ defmodule Ask.Runtime.Broker do
               IO.inspect System.stacktrace()
               raise e
             end
-            Logger.error "Error occurred while polling survey (id: #{survey.id}): #{inspect e} #{inspect System.stacktrace}"
+            Logger.error(e, "Error occurred while polling survey (id: #{survey.id})")
             Sentry.capture_exception(e, [
               stacktrace: System.stacktrace(),
               extra: %{survey_id: survey.id}])
@@ -378,7 +378,7 @@ defmodule Ask.Runtime.Broker do
           #   raise e
           # end
           respondent = Repo.get(Respondent, session.respondent.id)
-          Logger.error "Error occurred while processing sync step (survey_id: #{respondent.survey_id}, respondent_id: #{respondent.id}): #{inspect e} #{inspect System.stacktrace}"
+          Logger.error(e, "Error occurred while processing sync step (survey_id: #{respondent.survey_id}, respondent_id: #{respondent.id})")
           Sentry.capture_exception(e, [
             stacktrace: System.stacktrace(),
             extra: %{survey_id: respondent.survey_id, respondent_id: respondent.id}])

--- a/lib/ask/runtime/retries_histogram.ex
+++ b/lib/ask/runtime/retries_histogram.ex
@@ -2,12 +2,6 @@ defmodule Ask.Runtime.RetriesHistogram do
   alias Ask.{RetryStat, Stats, SystemTime, Logger, Respondent, Repo}
   alias Ask.Runtime.Session
 
-  defp update_respondent(%Respondent{} = respondent, retry_stat_id),
-    do:
-      respondent
-      |> Respondent.changeset(%{retry_stat_id: retry_stat_id})
-      |> Repo.update!
-
   def add_new_respondent(respondent, session, timeout) do
     try do
       %Respondent{} = respondent
@@ -20,12 +14,36 @@ defmodule Ask.Runtime.RetriesHistogram do
     end
   end
 
-  defp ivr?(%Session{current_mode: %Ask.Runtime.IVRMode{}}), do: true
-  defp ivr?(_session), do: false
+  def respondent_no_longer_active(respondent) do # only makes sense for verboice
+    # transition from ivr active to normal retryStat
+    try do
+      %Respondent{} = respondent
+      %Session{} = session = Session.load(respondent.session)
+      session = reallocate_respondent(session, respondent, false, Session.current_timeout(session))
+      session.respondent
+    rescue
+      _ -> Logger.error("Error deactivating ivr respondent in RetriesHistogram")
+      respondent
+    end
+  end
 
-  defp retry_stat_group(%Respondent{stats: stats, mode: mode, survey_id: survey_id}, ivr_active?, timeout) do
-    retry_time = Respondent.next_timeout_lowerbound(timeout, SystemTime.time.now) |> RetryStat.retry_time
-    %{attempt: stats |> Stats.attempts(:all), mode: mode, retry_time: retry_time, ivr_active: ivr_active?, survey_id: survey_id}
+  def retry(session) do
+    try do
+      %Session{respondent: %Respondent{} = respondent} = session
+      reallocate_respondent(session, respondent, ivr?(session), Session.current_timeout(session))
+    rescue
+      _ -> Logger.error("Error handling retry in RetriesHistogram")
+      session
+    end
+  end
+
+  def next_step(respondent, session, next_action) do
+    try do
+      do_next_step(respondent, session, next_action)
+    rescue
+      _ -> Logger.error("Error handling next_step in RetriesHistogram")
+     session
+    end
   end
 
   def remove_respondent(respondent) do
@@ -34,56 +52,51 @@ defmodule Ask.Runtime.RetriesHistogram do
       RetryStat.subtract(retry_stat_id)
       update_respondent(respondent, nil)
     rescue
-      _ -> Logger.error("Error removing respondent from histogram")
+      e -> Logger.error("Error removing the respondent in RetriesHistogram: " <> e.message)
       respondent
     end
   end
 
-  defp reallocate_respondent(session, respondent, ivr_active?, timeout) do
-    try do
-      %Respondent{retry_stat_id: retry_stat_id} = respondent
-      %Session{} = session
-      {:ok, retry_stat} = RetryStat.transition(
-        retry_stat_id,
-        retry_stat_group(respondent, ivr_active?, timeout)
-      )
-      %Session{ session | respondent: update_respondent(respondent, retry_stat.id)}
-    rescue
-      _ ->
-        Logger.error("Error reallocating respondent")
-        session
-    end
+  defp update_respondent(%Respondent{} = respondent, retry_stat_id),
+    do:
+      respondent
+      |> Respondent.changeset(%{retry_stat_id: retry_stat_id})
+      |> Repo.update!
+
+  defp ivr?(%Session{current_mode: %Ask.Runtime.IVRMode{}}), do: true
+  defp ivr?(%Session{current_mode: _}), do: false
+
+  defp retry_stat_group(%Respondent{stats: stats, mode: mode, survey_id: survey_id}, ivr_active?, timeout) do
+    retry_time = Respondent.next_timeout_lowerbound(timeout, SystemTime.time.now) |> RetryStat.retry_time
+    %{attempt: stats |> Stats.attempts(:all), mode: mode, retry_time: retry_time, ivr_active: ivr_active?, survey_id: survey_id}
   end
 
-  def next_step(respondent, %Session{current_mode: %Ask.Runtime.SMSMode{}} = session, {:reply, _reply}) do
+  defp reallocate_respondent(%Session{} = session, %Respondent{retry_stat_id: retry_stat_id} = respondent, ivr_active?, timeout) do
+    {:ok, retry_stat} = RetryStat.transition(
+      retry_stat_id,
+      retry_stat_group(respondent, ivr_active?, timeout)
+    )
+    %Session{ session | respondent: update_respondent(respondent, retry_stat.id)}
+  end
+
+  defp do_next_step(%Respondent{} = respondent, %Session{current_mode: %Ask.Runtime.SMSMode{}} = session, {:reply, _reply}) do
     # sms -> transition to active RetryStat
     if respondent.retry_stat_id, do:
       reallocate_respondent(session, respondent, false, Session.current_timeout(session))
   end
 
-  def next_step(_respondent, _session, {:reply, _reply}) do
+  defp do_next_step(_respondent, _session, {:reply, _reply}) do
     # ivr -> do nothing, respondent is on call
     # mobile-web -> do nothing
   end
 
-  def next_step(respondent, _session, {:end, _reply}) do
+  defp do_next_step(%Respondent{} = respondent, _session, {:end, _reply}) do
     # remove respondent from histogram
     remove_respondent(respondent)
   end
 
-  def next_step(respondent, _session, :end) do
+  defp do_next_step(%Respondent{} = respondent, _session, :end) do
     # remove respondent from histogram
     remove_respondent(respondent)
-  end
-
-  def respondent_no_longer_active(%{session: session} = respondent) do # only makes sense for verboice
-    # transition from ivr active to normal retryStat
-    session = Session.load(session)
-    session = reallocate_respondent(session, respondent, false, Session.current_timeout(session))
-    session.respondent
-  end
-
-  def retry(%{respondent: respondent} = session) do
-    reallocate_respondent(session, respondent, ivr?(session), Session.current_timeout(session))
   end
 end

--- a/lib/ask/runtime/retries_histogram.ex
+++ b/lib/ask/runtime/retries_histogram.ex
@@ -67,7 +67,7 @@ defmodule Ask.Runtime.RetriesHistogram do
     try do
       callback.()
     rescue
-      _ -> Logger.error(error_message)
+      e -> Logger.error(e, error_message)
       rescue_result
     end
   end

--- a/web/controllers/respondent_controller.ex
+++ b/web/controllers/respondent_controller.ex
@@ -62,7 +62,7 @@ defmodule Ask.RespondentController do
     stats(conn, survey, survey.quota_vars)
   rescue
     e ->
-      Logger.error "Error occurred while processing respondent stats (survey_id: #{survey_id}): #{inspect e} #{inspect System.stacktrace}"
+      Logger.error(e, "Error occurred while processing respondent stats (survey_id: #{survey_id})")
       Sentry.capture_exception(e, [
         stacktrace: System.stacktrace(),
         extra: %{survey_id: survey_id}])


### PR DESCRIPTION
- Public functions doesn't enforce structs in params
 - Structs are enforced inside the try/rescue blocks
 - Private functions enforce structs in params
 - Try/rescue blocks execution is placed in an extracted method
 - Include exception in error logs

For #1594 