### PR TITLE
Survey target doesn't define histogram Y scale

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint": "eslint --ext .jsx,.js web/static/js/ test/js"
   },
   "dependencies": {
-    "@instedd/surveda-d3-components": "1.0.15",
+    "@instedd/surveda-d3-components": "1.0.18",
     "babel-preset-stage-0": "^6.5.0",
     "d3": "^3.5.17",
     "date-fns": "^1.27.2",

--- a/web/static/js/components/surveys/SurveyRetriesPanel.jsx
+++ b/web/static/js/components/surveys/SurveyRetriesPanel.jsx
@@ -10,8 +10,7 @@ class SurveyRetriesPanel extends Component {
     dispatch: PropTypes.func.isRequired,
     projectId: PropTypes.string.isRequired,
     surveyId: PropTypes.string.isRequired,
-    t: PropTypes.func.isRequired,
-    target: PropTypes.number.isRequired
+    t: PropTypes.func.isRequired
   }
 
   componentWillMount() {
@@ -52,7 +51,7 @@ class SurveyRetriesPanel extends Component {
   }
 
   render() {
-    const { retriesHistograms, target, t } = this.props
+    const { retriesHistograms, t } = this.props
 
     const getHistogram = h => {
       const flow = this.flowForRetriesHistogram(h.flow)
@@ -81,8 +80,6 @@ class SurveyRetriesPanel extends Component {
       if (!retriesHistograms) return t('Loading...')
       return retriesHistograms.map(h => getHistogram(h)).map(h => <RetriesHistogram
         key={h.flow.map(({type}) => type).join('-')}
-        // Used in the y-axis height calculation
-        quota={target}
         // Every attempt in the mode sequence, including the delay between them
         flow={h.flow}
         // Every set of active respondents grouped and ordered by hour

--- a/web/static/js/components/surveys/SurveyShow.jsx
+++ b/web/static/js/components/surveys/SurveyShow.jsx
@@ -286,7 +286,7 @@ class SurveyShow extends Component<any, State> {
               </div>
               <Stats data={stats} />
               <Forecasts data={forecasts} ceil={100} forecast={survey.state == 'running'} />
-              { this.showHistograms() ? <SurveyRetriesPanel projectId={projectId} surveyId={surveyId} target={target} /> : null }
+              { this.showHistograms() ? <SurveyRetriesPanel projectId={projectId} surveyId={surveyId} /> : null }
               <div className='row' style={{ 'display': 'flex', 'alignItems': 'center', 'marginTop': '20px' }}>
                 <div style={{ 'width': '50%' }}>
                   <div className='header'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@instedd/surveda-d3-components@1.0.15":
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/@instedd/surveda-d3-components/-/surveda-d3-components-1.0.15.tgz#0fc967bc021aa3c25e696094686229d8948bda76"
+"@instedd/surveda-d3-components@1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@instedd/surveda-d3-components/-/surveda-d3-components-1.0.18.tgz#70006f4c30beb7133d1848957800908aa5a397fb"
   dependencies:
     d3 "^4.0.0"
     react-tooltip "^3.11.1"


### PR DESCRIPTION
Instead, rely on the current component behavior: the max column size defines the scale

For #1614, partially fixes it