### PR TITLE
Add caption to timezones dropdown

### DIFF
--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -422,6 +422,7 @@
   "The system only accepts CSV files": "",
   "This will finalize the survey execution": "",
   "Thu": "",
+  "Time at selected timezone: {{time}}": "",
   "Timezone": "",
   "Title": "",
   "Title must not be blank": "",

--- a/web/static/js/components/timezones/TimezoneAutocomplete.jsx
+++ b/web/static/js/components/timezones/TimezoneAutocomplete.jsx
@@ -66,8 +66,14 @@ class TimezoneAutocomplete extends Component {
     dispatch(actions.setTimezone(timezone.id))
   }
 
+  getTimeForTimezone(timezone, locale) {
+    var date = new Date(Date.now())
+    return date.toLocaleString(locale, {timeZone: timezone, hour12: false, hour: '2-digit', minute: '2-digit',  weekday: 'long'});
+  }
+
   render() {
-    const { timezones, t, readOnly } = this.props
+    const { timezones, t, readOnly, i18n } = this.props
+    const currentLanguage = i18n.language
 
     if (!timezones || !timezones.items) {
       return (
@@ -89,6 +95,7 @@ class TimezoneAutocomplete extends Component {
             className='timezone-dropdown'
             ref='autocomplete'
           />
+          <span className='small-text-bellow'>{t('Time at selected timezone: {{time}}', {time: this.getTimeForTimezone(this.props.selectedTz, currentLanguage)})}</span>
         </div>
       )
     }

--- a/web/static/js/components/timezones/TimezoneAutocomplete.jsx
+++ b/web/static/js/components/timezones/TimezoneAutocomplete.jsx
@@ -68,7 +68,7 @@ class TimezoneAutocomplete extends Component {
   }
 
   getTimeForTimezone(timezone, locale) {
-    var date = new Date(Date.now())
+    var date = new Date()
     return date.toLocaleString(locale, {timeZone: timezone, hour12: false, hour: '2-digit', minute: '2-digit', weekday: 'long'})
   }
 

--- a/web/static/js/components/timezones/TimezoneAutocomplete.jsx
+++ b/web/static/js/components/timezones/TimezoneAutocomplete.jsx
@@ -13,7 +13,8 @@ class TimezoneAutocomplete extends Component {
     dispatch: PropTypes.func.isRequired,
     selectedTz: PropTypes.string,
     timezones: PropTypes.object,
-    readOnly: PropTypes.bool
+    readOnly: PropTypes.bool,
+    i18n: PropTypes.object
   }
 
   constructor(props) {
@@ -68,7 +69,7 @@ class TimezoneAutocomplete extends Component {
 
   getTimeForTimezone(timezone, locale) {
     var date = new Date(Date.now())
-    return date.toLocaleString(locale, {timeZone: timezone, hour12: false, hour: '2-digit', minute: '2-digit',  weekday: 'long'});
+    return date.toLocaleString(locale, {timeZone: timezone, hour12: false, hour: '2-digit', minute: '2-digit', weekday: 'long'})
   }
 
   render() {


### PR DESCRIPTION
In survey schedule step, add current time for selected timezone.
This is the frontend feature in #1604 

<img width="739" alt="Screen Shot 2020-02-06 at 11 43 24" src="https://user-images.githubusercontent.com/43004687/73947264-f2fb2280-48d5-11ea-99da-f60ee038757a.png">
<img width="721" alt="Screen Shot 2020-02-06 at 11 43 38" src="https://user-images.githubusercontent.com/43004687/73947276-f55d7c80-48d5-11ea-9071-25145d4e46ff.png">
