### PR TITLE
Cockpit: round using another decimal

### DIFF
--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -449,16 +449,16 @@ defmodule Ask.SurveyControllerTest do
 
     test "measures the completion rate when it isn't completed", %{conn: conn, user: user} do
       respondents = Enum.map(["completed", "queued", "started"], fn disposition -> %{disposition: disposition} end)
-      %{"completion_rate" => 0.33} = testing_survey(%{user: user, respondents: respondents})
+      %{"completion_rate" => 0.333} = testing_survey(%{user: user, respondents: respondents})
         |> get_stats(conn)
     end
 
     test "estimated success rate equals current when completed", %{conn: conn, user: user} do
       respondents = Enum.map(1..2, fn _ -> %{disposition: "completed"} end) ++ [%{disposition: "failed"}]
       %{
-        "success_rate" => 0.67,
+        "success_rate" => 0.667,
         "completion_rate" => 1.0,
-        "estimated_success_rate" => 0.67
+        "estimated_success_rate" => 0.667
       } = testing_survey(%{user: user, cutoff: 2, respondents: respondents})
         |> get_stats(conn)
     end

--- a/web/models/survey.ex
+++ b/web/models/survey.ex
@@ -428,14 +428,14 @@ defmodule Ask.Survey do
     available = not_exhausted_respondents(respondents_by_disposition)
     needed_to_complete = Kernel.trunc(Float.round(additional_completes / estimated_success_rate))
     additional_respondents = if needed_to_complete - available > 0, do: needed_to_complete - available, else: 0
-    success_rate = if exhausted > 0, do: Float.round(current_success_rate, 2), else: 0.0
+    success_rate = if exhausted > 0, do: Float.round(current_success_rate, 3), else: 0.0
 
     %{
       success_rate_data: %{
         success_rate: success_rate,
-        completion_rate: Float.round(completion_rate, 2),
-        initial_success_rate: Float.round(initial_success_rate, 2),
-        estimated_success_rate: Float.round(estimated_success_rate, 2)
+        completion_rate: Float.round(completion_rate, 3),
+        initial_success_rate: Float.round(initial_success_rate, 3),
+        estimated_success_rate: Float.round(estimated_success_rate, 3)
       },
       queue_size_data: %{
         exhausted: exhausted,


### PR DESCRIPTION
For numbers shown in 0.X% format in success rate

Before: 0.0028 -> 0.0%
Now: 0.0028 -> 0.3%

Fix #1645