### PR TITLE
Providers' callback configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Once you have GUISSO enabled on Surveda, you can connect a Verboice instance tha
 config :ask, Verboice,
   base_url: "http://web.verboice.lvh.me", # or the URL for your Verboice instance
   channel_ui: true,
+  base_callback_url: "http://abcd123.ngrok.io", # specify the base URL to use on channel callbacks if it's not the same as the host
   guisso: [
     base_url: "http://web.guisso.lvh.me", # or the URL for your GUISSO
     client_id: "<Surveda's client id>",

--- a/lib/ask/runtime/channel.ex
+++ b/lib/ask/runtime/channel.ex
@@ -20,13 +20,13 @@ end
 
 defmodule Ask.Runtime.ChannelHelper do
 
-  def provider_callback_url(provider, path), do: provider_callback_endpoint(provider) <> path
+  def provider_callback_url(_provider, nil, path), do: application_endpoint() <> path
+  def provider_callback_url(provider, channel_base_url, path), do: provider_callback_endpoint(provider, channel_base_url) <> path
 
-  defp provider_callback_endpoint(provider) do
-    case Ask.Config.provider_config(provider) do
+  defp provider_callback_endpoint(provider, channel_base_url) do
+    case Ask.Config.provider_config(provider, channel_base_url) do
       nil -> application_endpoint()
-      [] -> application_endpoint()
-      configs -> hd(configs)[:base_callback_url] || application_endpoint()
+      config -> config[:base_callback_url] || application_endpoint()
     end
   end
 

--- a/lib/ask/runtime/channel.ex
+++ b/lib/ask/runtime/channel.ex
@@ -1,5 +1,5 @@
 defprotocol Ask.Runtime.Channel do
-  def prepare(channel, callback_url)
+  def prepare(channel)
   def setup(channel, respondent, token, not_before, not_after)
   def has_delivery_confirmation?(channel)
   def ask(channel, respondent, token, prompts)
@@ -16,4 +16,19 @@ defmodule Ask.Runtime.ChannelProvider do
   @callback sync_channels(user_id :: integer, base_url :: String.t) :: :ok
   @callback create_channel(user :: Ask.User.t, base_url :: String.t, api_channel :: map) :: Ask.Channel
   @callback callback(conn :: Plug.Conn.t, params :: map()) :: Plug.Conn.t
+end
+
+defmodule Ask.Runtime.ChannelHelper do
+
+  def provider_callback_url(provider, path), do: provider_callback_endpoint(provider) <> path
+
+  defp provider_callback_endpoint(provider) do
+    case Ask.Config.provider_config(provider) do
+      nil -> application_endpoint()
+      [] -> application_endpoint()
+      configs -> hd(configs)[:base_callback_url] || application_endpoint()
+    end
+  end
+
+  def application_endpoint(), do: Ask.Endpoint.url
 end

--- a/lib/ask/runtime/nuntium_channel.ex
+++ b/lib/ask/runtime/nuntium_channel.ex
@@ -240,7 +240,8 @@ defmodule Ask.Runtime.NuntiumChannel do
   def check_status(_any_other), do: {:down, []}
 
   defimpl Ask.Runtime.Channel, for: Ask.Runtime.NuntiumChannel do
-    def prepare(channel, callback_url) do
+    def prepare(channel) do
+      callback_url = Ask.Runtime.ChannelHelper.provider_callback_url(Nuntium, Ask.Router.Helpers.callback_path(Ask.Endpoint, :callback, "nuntium"))
       # Update the Nuntium app to setup the callback URL
       client = Nuntium.Client.new(channel.base_url, channel.oauth_token)
 
@@ -251,7 +252,7 @@ defmodule Ask.Runtime.NuntiumChannel do
         },
         delivery_ack: %{
           method: "get",
-          url: Ask.Router.Helpers.callback_url(Ask.Endpoint, :callback, "nuntium", ["status"], [])
+          url: Ask.Runtime.ChannelHelper.provider_callback_url(Nuntium, Ask.Router.Helpers.callback_path(Ask.Endpoint, :callback, "nuntium", ["status"], []))
         }
       }
 

--- a/lib/ask/runtime/nuntium_channel.ex
+++ b/lib/ask/runtime/nuntium_channel.ex
@@ -239,9 +239,11 @@ defmodule Ask.Runtime.NuntiumChannel do
   def check_status(%{ "enabled" => true }), do: :up
   def check_status(_any_other), do: {:down, []}
 
+  def nuntium_callback(channel, path), do: Ask.Runtime.ChannelHelper.provider_callback_url(Nuntium, channel.base_url, path)
+
   defimpl Ask.Runtime.Channel, for: Ask.Runtime.NuntiumChannel do
     def prepare(channel) do
-      callback_url = Ask.Runtime.ChannelHelper.provider_callback_url(Nuntium, Ask.Router.Helpers.callback_path(Ask.Endpoint, :callback, "nuntium"))
+      callback_url = NuntiumChannel.nuntium_callback(channel, Ask.Router.Helpers.callback_path(Ask.Endpoint, :callback, "nuntium"))
       # Update the Nuntium app to setup the callback URL
       client = Nuntium.Client.new(channel.base_url, channel.oauth_token)
 
@@ -252,7 +254,7 @@ defmodule Ask.Runtime.NuntiumChannel do
         },
         delivery_ack: %{
           method: "get",
-          url: Ask.Runtime.ChannelHelper.provider_callback_url(Nuntium, Ask.Router.Helpers.callback_path(Ask.Endpoint, :callback, "nuntium", ["status"], []))
+          url: NuntiumChannel.nuntium_callback(channel, Ask.Router.Helpers.callback_path(Ask.Endpoint, :callback, "nuntium", ["status"], []))
         }
       }
 

--- a/lib/ask/runtime/verboice_channel.ex
+++ b/lib/ask/runtime/verboice_channel.ex
@@ -303,17 +303,19 @@ defmodule Ask.Runtime.VerboiceChannel do
   end
 
   def callback_url(respondent) do
-    Ask.Router.Helpers.callback_url(Ask.Endpoint, :callback, "verboice", respondent: respondent.id)
+    verboice_callback(Ask.Router.Helpers.callback_path(Ask.Endpoint, :callback, "verboice", respondent: respondent.id))
   end
 
   def no_reply_callback_url(respondent) do
-    Ask.Router.Helpers.callback_url(Ask.Endpoint, :callback, "verboice", respondent: respondent.id, Digits: "timeout")
+    verboice_callback(Ask.Router.Helpers.callback_path(Ask.Endpoint, :callback, "verboice", respondent: respondent.id, Digits: "timeout"))
   end
 
   def status_callback_url(respondent, token) do
     respondent_id = respondent.id |> Integer.to_string
-    Ask.Router.Helpers.callback_url(Ask.Endpoint, :callback, "verboice", ["status", respondent_id, token], [])
+    verboice_callback(Ask.Router.Helpers.callback_path(Ask.Endpoint, :callback, "verboice", ["status", respondent_id, token], []))
   end
+
+  defp verboice_callback(path), do: Ask.Runtime.ChannelHelper.provider_callback_url(Verboice, path)
 
   def process_call_response(response) do
     case response do
@@ -340,7 +342,7 @@ defmodule Ask.Runtime.VerboiceChannel do
   defimpl Ask.Runtime.Channel, for: Ask.Runtime.VerboiceChannel do
     def has_delivery_confirmation?(_), do: false
     def ask(_, _, _, _), do: throw(:not_implemented)
-    def prepare(_, _), do: :ok
+    def prepare(_), do: :ok
 
     def setup(channel, respondent, token, not_before, not_after) do
       in_five_seconds = Timex.shift(not_before, seconds: 5)

--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -1487,8 +1487,7 @@ defmodule Ask.SurveyControllerTest do
     assert json_response(conn, 200)
     assert Repo.get(Survey, survey.id).state == "running"
 
-    received_at_uri = "#{Ask.Endpoint.url}/callbacks/test"
-    assert_received [:prepare, ^test_channel, ^received_at_uri]
+    assert_received [:prepare, ^test_channel]
   end
 
   test "sets started_at with proper datetime value when a survey is launched", %{conn: conn, user: user} do

--- a/test/lib/runtime/verboice_channel_test.exs
+++ b/test/lib/runtime/verboice_channel_test.exs
@@ -17,6 +17,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
   setup %{conn: conn} do
     GenServer.start_link(BrokerStub, [], name: BrokerStub.server_ref)
     ChannelStatusServer.start_link
+    Ask.Config.start_link()
     respondent = insert(:respondent, phone_number: "123", state: "active", session: %{"current_mode" => %{"mode" => "ivr"}})
     {
       :ok,

--- a/test/support/test_channel.ex
+++ b/test/support/test_channel.ex
@@ -80,8 +80,8 @@ defmodule Ask.TestChannel do
 end
 
 defimpl Ask.Runtime.Channel, for: Ask.TestChannel do
-  def prepare(channel, callback_url) do
-    send channel.pid, [:prepare, channel, callback_url]
+  def prepare(channel) do
+    send channel.pid, [:prepare, channel]
     :ok
   end
 

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -740,7 +740,7 @@ defmodule Ask.SurveyController do
   defp prepare_channels(_, []), do: :ok
   defp prepare_channels(conn, [channel | rest]) do
     runtime_channel = Ask.Channel.runtime_channel(channel)
-    case Ask.Runtime.Channel.prepare(runtime_channel, callback_url(conn, :callback, channel.provider)) do
+    case Ask.Runtime.Channel.prepare(runtime_channel) do
       {:ok, _} -> prepare_channels(conn, rest)
       error -> error
     end


### PR DESCRIPTION
add support for `callback_base_url` config for providers

Nuntium's log
<img width="785" alt="nuntium_callback" src="https://user-images.githubusercontent.com/13237343/74055632-1948bd00-49bf-11ea-85fc-fb005fe17bb5.png">

configuration:
``` elixir
config :ask, Nuntium,
  base_url: "http://nuntium-stg.instedd.org", #"http://web.nuntium.lvh.me", #"https://nuntium.instedd.org",
  channel_ui: true,
  base_callback_url: "https://fed53c45.ngrok.io",
  guisso: [
    base_url: guisso_stg_base_url, #"http://web.guisso.lvh.me", # or the URL for your GUISSO
    client_id: guisso_stg_surveda_client_id,
    client_secret: guisso_stg_surveda_secret_id,
    app_id: "nuntium-stg.instedd.org" #"web.nuntium.lvh.me" #"nuntium.instedd.org" # or your Nuntium APP ID in GUISSO
  ]
```

closes #1624 