### PR TITLE
Add canonical phone number

### DIFF
--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -410,7 +410,7 @@ defmodule Ask.Runtime.Broker do
   end
 
   def mask_phone_number(%Respondent{} = respondent, {:reply, response}) do
-    pii = respondent.sanitized_phone_number |> String.slice(-6..-1)
+    pii = respondent.canonical_phone_number |> String.slice(-6..-1)
     # pii can be empty if the sanitized_phone_number has less than 5 digits,
     # that could be mostly to the case of a randomly generated phone number form a test
     # String.contains? returns true for empty strings
@@ -434,7 +434,7 @@ defmodule Ask.Runtime.Broker do
   end
 
   defp contains_phone_number(response, pii) do
-    String.contains?(Respondent.sanitize_phone_number(response), pii)
+    String.contains?(Respondent.canonicalize_phone_number(response), pii)
   end
 
   defp phone_number_matcher(pii) do

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -150,12 +150,12 @@ defmodule Ask.Runtime.Session do
   end
 
   defp apply_patterns_if_match(patterns, respondent) do
-    sanitized_number_as_list = Respondent.sanitize_phone_number(respondent.phone_number) |> String.graphemes
-    matching_patterns = ChannelPatterns.matching_patterns(patterns, sanitized_number_as_list)
+    canonical_number_as_list = respondent.canonical_phone_number |> String.graphemes
+    matching_patterns = ChannelPatterns.matching_patterns(patterns, canonical_number_as_list)
     case matching_patterns do
       [] -> respondent
       [p | _] ->
-        sanitized_phone_number = ChannelPatterns.apply_pattern(p, sanitized_number_as_list)
+        sanitized_phone_number = ChannelPatterns.apply_pattern(p, canonical_number_as_list)
         {:ok, updated_respondent} = respondent |> Respondent.changeset(%{sanitized_phone_number: sanitized_phone_number}) |> Repo.update
         updated_respondent
     end

--- a/priv/repo/migrations/20200211130308_add_respondents_canonical_phone_number.exs
+++ b/priv/repo/migrations/20200211130308_add_respondents_canonical_phone_number.exs
@@ -1,0 +1,9 @@
+defmodule Ask.Repo.Migrations.AddRespondentsCanonicalPhoneNumber do
+  use Ecto.Migration
+
+  def change do
+    alter table(:respondents) do
+      add :canonical_phone_number, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20200211131441_set_default_respondents_canonical_phone_number.exs
+++ b/priv/repo/migrations/20200211131441_set_default_respondents_canonical_phone_number.exs
@@ -1,0 +1,12 @@
+defmodule Ask.Repo.Migrations.SetDefaultRespondentsCanonicalPhoneNumber do
+  use Ecto.Migration
+
+  def up do
+    execute "UPDATE respondents SET canonical_phone_number = sanitized_phone_number"
+
+  end
+
+  def down do
+    execute "UPDATE respondents SET canonical_phone_number = NULL"
+  end
+end

--- a/test/lib/runtime/broker_test.exs
+++ b/test/lib/runtime/broker_test.exs
@@ -3838,7 +3838,8 @@ defmodule Ask.BrokerTest do
     [survey, group, _, _, _] = create_running_survey_with_channel_and_respondent()
 
     phone_number = "1-734-555-1212"
-    respondent = insert(:respondent, survey: survey, respondent_group: group, phone_number: phone_number, sanitized_phone_number: Ask.Respondent.sanitize_phone_number(phone_number))
+    canonical_phone_number = Ask.Respondent.canonicalize_phone_number(phone_number)
+    respondent = insert(:respondent, survey: survey, respondent_group: group, phone_number: phone_number, sanitized_phone_number: canonical_phone_number, canonical_phone_number: canonical_phone_number)
 
     {:ok, logger} = SurveyLogger.start_link
     {:ok, broker} = Broker.start_link
@@ -3897,7 +3898,8 @@ defmodule Ask.BrokerTest do
 
   test "respondent phone number is masked if it's part of a response" do
     phone_number = "1-734-555-1212"
-    respondent = insert(:respondent, phone_number: phone_number, sanitized_phone_number: Ask.Respondent.sanitize_phone_number(phone_number))
+    canonical_phone_number = Ask.Respondent.canonicalize_phone_number(phone_number)
+    respondent = insert(:respondent, phone_number: phone_number, sanitized_phone_number: canonical_phone_number, canonical_phone_number: canonical_phone_number)
 
     [
       {"1-734-5##-####", "1-734-555-1212"},

--- a/test/lib/runtime/channel_patterns.exs
+++ b/test/lib/runtime/channel_patterns.exs
@@ -3,7 +3,7 @@ defmodule Ask.ChannelPatternsTest do
   alias Ask.Runtime.ChannelPatterns
 
   test "matches sanitized phone number against input patterns" do
-    sanitized_phone_number = ["1", "2", "3", "4"]
+    canonical_phone_number = ["1", "2", "3", "4"]
     patterns = [
       %{"input" => "1XXX", "output" => "1XXX"}, #matches
       %{"input" => "X2XX", "output" => "1XXX"}, #matches
@@ -21,7 +21,7 @@ defmodule Ask.ChannelPatternsTest do
       %{"input" => "X1234", "output" => "1XXX"} #doesn't match
     ]
 
-    assert (ChannelPatterns.matching_patterns(patterns, sanitized_phone_number) == [
+    assert (ChannelPatterns.matching_patterns(patterns, canonical_phone_number) == [
       %{"input" => "1XXX", "output" => "1XXX"}, #matches
       %{"input" => "X2XX", "output" => "1XXX"}, #matches
       %{"input" => "XX3X", "output" => "1XXX"}, #matches
@@ -33,24 +33,24 @@ defmodule Ask.ChannelPatternsTest do
   end
 
   test "matching against empty patterns returns empty list" do
-    sanitized_phone_number = ["1", "2", "3", "4"]
-    assert ChannelPatterns.matching_patterns([], sanitized_phone_number) == []
+    canonical_phone_number = ["1", "2", "3", "4"]
+    assert ChannelPatterns.matching_patterns([], canonical_phone_number) == []
   end
 
   test "applies output pattern to sanitized phone number" do
-    sanitized_phone_number = ["1", "2", "3", "4"]
+    canonical_phone_number = ["1", "2", "3", "4"]
     patterns = [
       %{"input" => "XXXX", "output" => "555XXXX"},
       %{"input" => "XXXX", "output" => "XXXX555"},
       %{"input" => "XXXX", "output" => "7X9X5X3X0"}
     ]
 
-    expected_sanitized_phone_numbers = [
+    expected_canonical_phone_numbers = [
       "5551234",
       "1234555",
       "719253340"
     ]
 
-    assert (patterns |> Enum.map(&(ChannelPatterns.apply_pattern(&1, sanitized_phone_number)))) == expected_sanitized_phone_numbers
+    assert (patterns |> Enum.map(&(ChannelPatterns.apply_pattern(&1, canonical_phone_number)))) == expected_canonical_phone_numbers
   end
 end

--- a/test/lib/runtime/nuntium_channel_test.exs
+++ b/test/lib/runtime/nuntium_channel_test.exs
@@ -9,7 +9,7 @@ defmodule Ask.Runtime.NuntiumChannelTest do
 
   setup %{conn: conn} do
     GenServer.start_link(BrokerStub, [], name: BrokerStub.server_ref)
-    respondent = insert(:respondent, phone_number: "123 456", sanitized_phone_number: "123456", state: "active", session: %{"current_mode" => %{"mode" => "sms"}})
+    respondent = insert(:respondent, phone_number: "123 456", sanitized_phone_number: "123456", canonical_phone_number: "123456", state: "active", session: %{"current_mode" => %{"mode" => "sms"}})
     {:ok, conn: conn, respondent: respondent}
   end
 
@@ -64,7 +64,7 @@ defmodule Ask.Runtime.NuntiumChannelTest do
   end
 
   test "callback with stalled respondent", %{conn: conn} do
-    respondent = insert(:respondent, phone_number: "123 457", sanitized_phone_number: "123457", state: "stalled", session: %{"current_mode" => %{"mode" => "sms"}})
+    respondent = insert(:respondent, phone_number: "123 457", sanitized_phone_number: "123457", canonical_phone_number: "123457", state: "stalled", session: %{"current_mode" => %{"mode" => "sms"}})
     respondent_id = respondent.id
     GenServer.cast(BrokerStub.server_ref, {:expects, fn
       {:sync_step, %Respondent{id: ^respondent_id}, {:reply, "yes"}, "sms"} ->

--- a/test/lib/runtime/session_test.exs
+++ b/test/lib/runtime/session_test.exs
@@ -91,7 +91,9 @@ defmodule Ask.SessionTest do
     ]
     test_channel = TestChannel.new
     channel = insert(:channel, settings: test_channel |> TestChannel.settings, patterns: patterns)
-    respondent = insert(:respondent, phone_number: "12 34", sanitized_phone_number: "1234")
+    phone_number = "12 34"
+    canonical_phone_number = Respondent.canonicalize_phone_number(phone_number)
+    respondent = insert(:respondent, phone_number: phone_number, sanitized_phone_number: canonical_phone_number, canonical_phone_number: canonical_phone_number)
 
     {:ok, %{respondent: respondent}, _, _} = Session.start(quiz, respondent, channel, "sms", Schedule.always())
 
@@ -102,12 +104,14 @@ defmodule Ask.SessionTest do
   test "sanitized_phone_number remains the same when starting and channel has no patterns", %{quiz: quiz} do
     test_channel = TestChannel.new
     channel = insert(:channel, settings: test_channel |> TestChannel.settings, patterns: [])
-    respondent = insert(:respondent, phone_number: "12 34", sanitized_phone_number: "1234")
+    phone_number = "12 34"
+    canonical_phone_number = Respondent.canonicalize_phone_number(phone_number)
+    respondent = insert(:respondent, phone_number: phone_number, sanitized_phone_number: canonical_phone_number, canonical_phone_number: canonical_phone_number)
 
     {:ok, %{respondent: respondent}, _, _} = Session.start(quiz, respondent, channel, "sms", Schedule.always())
 
-    assert respondent.sanitized_phone_number == "1234"
-    assert (Respondent |> Repo.get(respondent.id)).sanitized_phone_number == "1234"
+    assert respondent.sanitized_phone_number == canonical_phone_number
+    assert (Respondent |> Repo.get(respondent.id)).sanitized_phone_number == canonical_phone_number
   end
 
   test "sanitized_phone_number remains the same when starting and no pattern matches", %{quiz: quiz} do
@@ -118,12 +122,14 @@ defmodule Ask.SessionTest do
     ]
     test_channel = TestChannel.new
     channel = insert(:channel, settings: test_channel |> TestChannel.settings, patterns: patterns)
-    respondent = insert(:respondent, phone_number: "12 34", sanitized_phone_number: "1234")
+    phone_number = "12 34"
+    canonical_phone_number = Respondent.canonicalize_phone_number(phone_number)
+    respondent = insert(:respondent, phone_number: phone_number, sanitized_phone_number: canonical_phone_number, canonical_phone_number: canonical_phone_number)
 
     {:ok, %{respondent: respondent}, _, _} = Session.start(quiz, respondent, channel, "sms", Schedule.always())
 
-    assert respondent.sanitized_phone_number == "1234"
-    assert (Respondent |> Repo.get(respondent.id)).sanitized_phone_number == "1234"
+    assert respondent.sanitized_phone_number == canonical_phone_number
+    assert (Respondent |> Repo.get(respondent.id)).sanitized_phone_number == canonical_phone_number
   end
 
   test "reloading the page should not consume retries in mobileweb mode", %{respondent: respondent, test_channel: test_channel, channel: channel} do
@@ -486,7 +492,9 @@ defmodule Ask.SessionTest do
   end
 
   test "applies first pattern that matches when swtiching to fallback", %{quiz: quiz, channel: channel} do
-    respondent = insert(:respondent, phone_number: "12 34", sanitized_phone_number: "1234")
+    phone_number = "12 34"
+    canonical_phone_number = Respondent.canonicalize_phone_number(phone_number)
+    respondent = insert(:respondent, phone_number: "12 34", sanitized_phone_number: canonical_phone_number, canonical_phone_number: canonical_phone_number)
     patterns = [
       %{"input" => "22XXXX", "output" => "5XXXX"},
       %{"input" => "XXXX", "output" => "4XXXX"},

--- a/test/models/respondent_test.exs
+++ b/test/models/respondent_test.exs
@@ -18,8 +18,8 @@ defmodule Ask.RespondentTest do
     refute changeset.valid?
   end
 
-  test "sanitize phone number" do
-    num = Respondent.sanitize_phone_number("+ (549) 11 1234 5627")
+  test "canonicalize phone number" do
+    num = Respondent.canonicalize_phone_number("+ (549) 11 1234 5627")
     assert num == "5491112345627"
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -167,11 +167,13 @@ defmodule Ask.Factory do
   def respondent_factory do
     phone_number = "#{Integer.to_string(:rand.uniform(100))} #{Integer.to_string(:rand.uniform(100))} #{Integer.to_string(:rand.uniform(100))}"
     respondent_group = build(:respondent_group)
+    canonical_phone_number = Ask.Respondent.canonicalize_phone_number(phone_number)
     %Ask.Respondent{
       respondent_group: respondent_group,
       survey: (respondent_group |> Ask.Repo.preload(:survey)).survey,
       phone_number: phone_number,
-      sanitized_phone_number: Ask.Respondent.sanitize_phone_number(phone_number)
+      sanitized_phone_number: canonical_phone_number,
+      canonical_phone_number: canonical_phone_number
     }
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -48,7 +48,7 @@ defmodule Ask.TestHelpers do
         Ask.RespondentGroupChannel.changeset(%Ask.RespondentGroupChannel{}, %{respondent_group_id: group.id, channel_id: channel.id, mode: mode}) |> Ask.Repo.insert
 
         respondent = insert(:respondent, survey: survey, respondent_group: group)
-        phone_number = respondent.sanitized_phone_number
+        phone_number = respondent.canonical_phone_number
 
         [survey, group, test_channel, respondent, phone_number]
       end

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -396,6 +396,7 @@ defmodule Ask.SurveyController do
       respondent_group_id: respondent_group.id,
       phone_number: phone_number,
       sanitized_phone_number: phone_number,
+      canonical_phone_number: phone_number,
       hashed_number: phone_number}
     |> Ecto.Changeset.change
     |> Repo.insert!

--- a/web/models/respondent.ex
+++ b/web/models/respondent.ex
@@ -72,7 +72,7 @@ defmodule Ask.Respondent do
     |> Ecto.Changeset.optimistic_lock(:lock_version)
   end
 
-  def sanitize_phone_number(text) do
+  def canonicalize_phone_number(text) do
     ~r/[^\d]/ |> Regex.replace(text, "")
   end
 

--- a/web/models/respondent.ex
+++ b/web/models/respondent.ex
@@ -4,8 +4,9 @@ defmodule Ask.Respondent do
   alias Ask.{Stats, Repo, Respondent, Survey}
 
   schema "respondents" do
-    field :phone_number, :string
-    field :sanitized_phone_number, :string
+    field :phone_number, :string # phone_number as-it-is in the respondents_list
+    field :sanitized_phone_number, :string # phone_number with the channel's patterns applied `channel.apply_patterns(canonical_phone_number)`
+    field :canonical_phone_number, :string # phone_number with the basic prunes/validations applied
     field :hashed_number, :string
     field :section_order, JSON
 
@@ -64,7 +65,7 @@ defmodule Ask.Respondent do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:phone_number, :sanitized_phone_number, :state, :session, :quota_bucket_id, :completed_at, :timeout_at, :questionnaire_id, :mode, :disposition, :mobile_web_cookie_code, :language, :effective_modes, :stats, :section_order, :retry_stat_id])
+    |> cast(params, [:phone_number, :sanitized_phone_number, :canonical_phone_number, :state, :session, :quota_bucket_id, :completed_at, :timeout_at, :questionnaire_id, :mode, :disposition, :mobile_web_cookie_code, :language, :effective_modes, :stats, :section_order, :retry_stat_id])
     |> validate_required([:phone_number, :state])
     |> validate_inclusion(:disposition, ["registered", "queued", "contacted", "failed", "unresponsive", "started", "ineligible", "rejected", "breakoff", "refused", "partial", "interim partial", "completed"])
     |> validate_inclusion(:state, ["pending", "active", "completed", "failed", "stalled", "rejected", "cancelled"])


### PR DESCRIPTION
Add `canonical_phone_number` to respondents' table
When a new respondent_list file is added, respondents are compared by this new field instead of `sanitized_phone_number` (that changes depending on the channel) to determine whether the respondent has already been added to the survey

fixes #1639 