### PR TITLE
Deprecated timezones

### DIFF
--- a/test/controllers/timezone_controller_test.exs
+++ b/test/controllers/timezone_controller_test.exs
@@ -9,9 +9,33 @@ defmodule Ask.TimezoneControllerTest do
     {:ok, conn: conn, user: user}
   end
 
-  test "returns Timex timezones", %{conn: conn} do
-    conn = get conn, timezone_path(conn, :timezones)
-    assert json_response(conn, 200)["timezones"] == Timex.timezones
-  end
+  describe "the timezones map" do
+    test "should link each deprecated timezone with its canonical timezone", %{conn: conn} do
+      conn = get conn, timezone_path(conn, :timezones)
+      timezones = json_response(conn, 200)["timezones"]
 
+      Tzdata.zone_alias_list()
+      |> Enum.each(fn deprecated_tz ->
+        assert timezones[deprecated_tz] == Tzdata.links()[deprecated_tz]
+      end)
+    end
+
+    test "should link each canonical timezone with itself", %{conn: conn} do
+      conn = get conn, timezone_path(conn, :timezones)
+      timezones = json_response(conn, 200)["timezones"]
+
+      Tzdata.canonical_zone_list()
+      |> Enum.each(fn canonical_tz ->
+        assert timezones[canonical_tz] == canonical_tz
+      end)
+    end
+
+    test "should contain all the timezones defined in Timex.timezones", %{conn: conn} do
+      conn = get conn, timezone_path(conn, :timezones)
+      timezones = json_response(conn, 200)["timezones"]
+
+      assert map_size(timezones) == length(Timex.timezones())
+      Timex.timezones() |> Enum.each(fn tz -> assert Map.has_key?(timezones, tz) end)
+    end
+  end
 end

--- a/web/controllers/timezone_controller.ex
+++ b/web/controllers/timezone_controller.ex
@@ -2,7 +2,11 @@ defmodule Ask.TimezoneController do
   use Ask.Web, :api_controller
 
   def timezones(conn, _) do
-    timezones = Timex.timezones
+    canonical_links = Tzdata.canonical_zone_list() # only contains the valid (non-deprecated) timezones
+                      |> Enum.map(fn tz -> {tz, tz} end) |> Map.new
+    links = Tzdata.links() # only contains the deprecated timezones with its links to the 'new' timezones
+
+    timezones = Map.merge(canonical_links, links)
     render(conn, "index.json", timezones: timezones)
   end
 end

--- a/web/static/js/components/timezones/TimezoneAutocomplete.jsx
+++ b/web/static/js/components/timezones/TimezoneAutocomplete.jsx
@@ -57,7 +57,7 @@ class TimezoneAutocomplete extends Component {
   autocompleteGetData(value, callback) {
     const { timezones } = this.props
     const matches = (value, tz) => { return (tz.indexOf(value) !== -1 || tz.toLowerCase().indexOf(value) !== -1) }
-    const matchingOptions = timezones.items.filter((tz) => matches(formatTimezone(value.toLowerCase()), formatTimezone(tz)))
+    const matchingOptions = Object.keys(timezones.items).filter((tz) => matches(formatTimezone(value.toLowerCase()), formatTimezone(tz)))
     callback(value, this.buildTimezonesforAutoselect(matchingOptions))
   }
 
@@ -73,7 +73,7 @@ class TimezoneAutocomplete extends Component {
   }
 
   render() {
-    const { timezones, t, readOnly, i18n } = this.props
+    const { timezones, t, readOnly, i18n, selectedTz } = this.props
     const currentLanguage = i18n.language
 
     if (!timezones || !timezones.items) {
@@ -81,6 +81,8 @@ class TimezoneAutocomplete extends Component {
         <div>{t('Loading timezones...')}</div>
       )
     } else {
+      const canonicalTz = timezones.items[selectedTz]
+
       return (
         <div className='input-field timezone-selection'>
           <InputWithLabel value={this.state.timezone.text} label={t('Timezone')}>
@@ -96,7 +98,7 @@ class TimezoneAutocomplete extends Component {
             className='timezone-dropdown'
             ref='autocomplete'
           />
-          <span className='small-text-bellow'>{t('Time at selected timezone: {{time}}', {time: this.getTimeForTimezone(this.props.selectedTz, currentLanguage)})}</span>
+          <span className='small-text-bellow'>{t('Time at selected timezone: {{time}}', {time: this.getTimeForTimezone(canonicalTz, currentLanguage)})}</span>
         </div>
       )
     }

--- a/web/static/js/components/timezones/TimezoneAutocomplete.jsx
+++ b/web/static/js/components/timezones/TimezoneAutocomplete.jsx
@@ -82,7 +82,10 @@ class TimezoneAutocomplete extends Component {
       )
     } else {
       const canonicalTz = timezones.items[selectedTz]
-
+      let timeAtSelectedTz
+      try {
+        timeAtSelectedTz = this.getTimeForTimezone(canonicalTz, currentLanguage)
+      } catch (e) {}
       return (
         <div className='input-field timezone-selection'>
           <InputWithLabel value={this.state.timezone.text} label={t('Timezone')}>
@@ -98,7 +101,9 @@ class TimezoneAutocomplete extends Component {
             className='timezone-dropdown'
             ref='autocomplete'
           />
-          <span className='small-text-bellow'>{t('Time at selected timezone: {{time}}', {time: this.getTimeForTimezone(canonicalTz, currentLanguage)})}</span>
+          { timeAtSelectedTz &&
+            <span className='small-text-bellow'>{t('Time at selected timezone: {{time}}', {time: timeAtSelectedTz})}</span>
+          }
         </div>
       )
     }


### PR DESCRIPTION
## Backend
Change surveda api (http://app.surveda.lvh.me/api/v1/timezones) to return a map of timezones instead of a list of them. 

This map links each timezone with its canonical, even if the timezone itself is a canonical one

For example (taken from de endpoint above):
**deprecated** -> canonical:
    "US/Eastern": "America/New_York"


**canonical** -> canonical: 
    "America/Argentina/Buenos_Aires": "America/Argentina/Buenos_Aires"

## Frontend
The `TimezoneAutocomplete` was modified to use the canonical timezone for calculating the current time in the selected timezone 

The `survey.schedule` still uses the generic timezone (canonical or deprecated), since this is what user sees

<img src="https://user-images.githubusercontent.com/13237343/74571815-ff7a1d80-4f5c-11ea-97b6-b8cad143a3f0.png"  width="50%">
Fixes #1653