### PR TITLE
Fix deprecated timezones

### DIFF
--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -312,6 +312,9 @@ path.respondentsData.referenceStrokeColor15 { stroke: var(--reference-color15); 
   @extend .black-text;
   padding: 0px;
 
+  .survey-status-container {
+    min-height: 24px;
+  }
   .survey-card-status {
     @extend .grey-text;
     display: flex;

--- a/web/static/js/actions/timezones.js
+++ b/web/static/js/actions/timezones.js
@@ -4,7 +4,7 @@ import * as api from '../api'
 
 export const fetchTimezones = () => (dispatch, getState) => {
   const state = getState()
-  if (state.timezones.fetching) {
+  if (state.timezones.fetching || state.timezones.items) {
     return
   }
   dispatch(startFetchingTimezones())

--- a/web/static/js/components/surveys/SurveyStatus.jsx
+++ b/web/static/js/components/surveys/SurveyStatus.jsx
@@ -1,9 +1,11 @@
 import React, { PureComponent, PropTypes } from 'react'
-import TimeAgo from 'react-timeago'
-import { Tooltip } from '../ui'
-import { formatTimezone } from '../timezones/util'
-import classNames from 'classnames/bind'
 import { translate, Trans } from 'react-i18next'
+import { connect } from 'react-redux'
+import { formatTimezone } from '../timezones/util'
+import { Tooltip } from '../ui'
+import {fetchTimezones} from '../../actions/timezones'
+import TimeAgo from 'react-timeago'
+import classNames from 'classnames/bind'
 import DownChannelsStatus from '../channels/DownChannelsStatus'
 import dateformat from 'dateformat'
 import map from 'lodash/map'
@@ -12,14 +14,21 @@ import min from 'lodash/min'
 class SurveyStatus extends PureComponent {
   static propTypes = {
     t: PropTypes.func,
+    dispatch: PropTypes.func.isRequired,
     survey: PropTypes.object.isRequired,
-    short: PropTypes.bool
+    short: PropTypes.bool,
+    timezones: PropTypes.object
   }
 
   constructor(props) {
     super(props)
     this.bindedFormatter = this.formatter.bind(this)
     this.bindedStartedFormatter = this.startedFormatter.bind(this)
+  }
+
+  componentDidMount() {
+    const { dispatch } = this.props
+    dispatch(fetchTimezones())
   }
 
   formatter(number, unit, suffix, date, defaultFormatter) {
@@ -69,9 +78,10 @@ class SurveyStatus extends PureComponent {
   }
 
   hourDescription(survey, date) {
+    const { timezones } = this.props
     let locale = Intl.DateTimeFormat().resolvedOptions().locale || 'en-US'
     let options = {
-      timeZone: survey.schedule.timezone,
+      timeZone: timezones.items[survey.schedule.timezone],
       hour12: true,
       hour: 'numeric'
     }
@@ -90,7 +100,7 @@ class SurveyStatus extends PureComponent {
   }
 
   render() {
-    const { survey, t } = this.props
+    const { survey, t, timezones } = this.props
 
     if (!survey) {
       return <p>{t('Loading...')}</p>
@@ -121,9 +131,11 @@ class SurveyStatus extends PureComponent {
           break
         } else {
           if (survey.nextScheduleTime) {
-            icon = 'access_time'
-            const date = new Date(survey.nextScheduleTime)
-            text = this.nextCallDescription(survey, date)
+            if (timezones && timezones.items) {
+              icon = 'access_time'
+              const date = new Date(survey.nextScheduleTime)
+              text = this.nextCallDescription(survey, date)
+            }
           } else {
             icon = 'play_arrow'
             text = <TimeAgo date={survey.startedAt} live={false} formatter={this.bindedStartedFormatter} />
@@ -201,4 +213,10 @@ class SurveyStatus extends PureComponent {
   }
 }
 
-export default translate()(SurveyStatus)
+const mapStateToProps = (state) => {
+  return {
+    timezones: state.timezones
+  }
+}
+
+export default translate()(connect(mapStateToProps)(SurveyStatus))

--- a/web/static/js/components/surveys/SurveyStatus.jsx
+++ b/web/static/js/components/surveys/SurveyStatus.jsx
@@ -206,7 +206,7 @@ class SurveyStatus extends PureComponent {
     }
 
     return (
-      <p className={classNames(color, 'truncate')}>
+      <p className={classNames(color, 'truncate', 'survey-status-container')}>
         {component}
       </p>
     )


### PR DESCRIPTION
convert `survey.schedule.timezone` in `SurveyStatus.hourDescription()` to canonical 

in chrome was braking the **project-surveys** page and the **survey-overview** UI since `date.toLocaleTimeString` does not support deprecated timezones

### fix side-effect:
`SurveyStatus` component takes a little longer to render (if timezones not loaded) since is waiting for the backend response (timezones api). 

### fix bonus-track:
add a validation to avoid fetching the timezones to the backend if timezones are already loaded in the `state`

fixes #1657 