### PR TITLE
IVR attempts count

### DIFF
--- a/lib/ask/ecto_types/stats.ex
+++ b/lib/ask/ecto_types/stats.ex
@@ -114,12 +114,19 @@ defmodule Ask.Stats do
   def attempts(%Stats{attempts: %{"ivr" => total}}, :ivr), do: total - 1
   def attempts(%Stats{attempts: _}, :ivr), do: 0
 
+  def attempts(%Stats{attempts: %{"ivr" => _total}, last_call_started: true}, :current_ivr), do: 0
+  def attempts(%Stats{attempts: %{"ivr" => _total}}, :current_ivr), do: 1
+  def attempts(_, :current_ivr), do: 0
+
   def attempts(%Stats{attempts: nil}, :mobileweb), do: 0
   def attempts(%Stats{attempts: %{"mobileweb" => total}}, :mobileweb), do: total
   def attempts(%Stats{attempts: _}, :mobileweb), do: 0
 
   def attempts(%Stats{} = stats, :all),
     do: attempts(stats, :sms) + attempts(stats, :ivr) + attempts(stats, :mobileweb)
+
+  def attempts(%Stats{} = stats, :full),
+    do: attempts(stats, :all) + attempts(stats, :current_ivr)
 
   def add_attempt(stats, mode) do
     stats = add_attempt_internal(stats, mode)

--- a/lib/ask/ecto_types/stats.ex
+++ b/lib/ask/ecto_types/stats.ex
@@ -110,7 +110,8 @@ defmodule Ask.Stats do
   def attempts(%Stats{attempts: _}, :sms), do: 0
 
   def attempts(%Stats{attempts: nil}, :ivr), do: 0
-  def attempts(%Stats{attempts: %{"ivr" => total}}, :ivr), do: total
+  def attempts(%Stats{attempts: %{"ivr" => total}, last_call_started: true}, :ivr), do: total
+  def attempts(%Stats{attempts: %{"ivr" => total}}, :ivr), do: total - 1
   def attempts(%Stats{attempts: _}, :ivr), do: 0
 
   def attempts(%Stats{attempts: nil}, :mobileweb), do: 0

--- a/lib/ask/runtime/retries_histogram.ex
+++ b/lib/ask/runtime/retries_histogram.ex
@@ -93,7 +93,7 @@ defmodule Ask.Runtime.RetriesHistogram do
 
   defp retry_stat_group(%Respondent{stats: stats, mode: mode, survey_id: survey_id}, ivr_active?, timeout) do
     retry_time = Respondent.next_timeout_lowerbound(timeout, SystemTime.time.now) |> RetryStat.retry_time
-    %{attempt: stats |> Stats.attempts(:all), mode: mode, retry_time: retry_time, ivr_active: ivr_active?, survey_id: survey_id}
+    %{attempt: stats |> Stats.attempts(:full), mode: mode, retry_time: retry_time, ivr_active: ivr_active?, survey_id: survey_id}
   end
 
   defp reallocate_respondent(%Session{} = session, %Respondent{retry_stat_id: retry_stat_id} = respondent, ivr_active?, timeout) do

--- a/test/controllers/respondent_controller_test.exs
+++ b/test/controllers/respondent_controller_test.exs
@@ -775,7 +775,7 @@ defmodule Ask.RespondentControllerTest do
       questionnaire = insert(:questionnaire, name: "test", project: project, steps: @dummy_steps)
       survey = insert(:survey, project: project, cutoff: 4, questionnaires: [questionnaire], state: "ready", schedule: completed_schedule(), mode: [["sms", "ivr"], ["mobileweb"], ["sms", "mobileweb"]])
       group_1 = insert(:respondent_group)
-      respondent_1 = insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group_1, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}})
+      respondent_1 = insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group_1, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}, last_call_started: true})
       insert(:response, respondent: respondent_1, field_name: "Smokes", value: "Yes")
       insert(:response, respondent: respondent_1, field_name: "Exercises", value: "No")
       insert(:response, respondent: respondent_1, field_name: "Perfect Number", value: "100")

--- a/test/controllers/respondent_controller_test.exs
+++ b/test/controllers/respondent_controller_test.exs
@@ -12,7 +12,7 @@ defmodule Ask.RespondentControllerTest do
     "total_call_time_seconds" => nil,
     "total_received_sms" => 0,
     "total_sent_sms" => 0,
-    "last_call_started" => false,
+    "pending_call" => false,
     "call_durations" => %{}
   }
 
@@ -771,7 +771,7 @@ defmodule Ask.RespondentControllerTest do
       questionnaire = insert(:questionnaire, name: "test", project: project, steps: @dummy_steps)
       survey = insert(:survey, project: project, cutoff: 4, questionnaires: [questionnaire], state: "ready", schedule: completed_schedule(), mode: [["sms", "ivr"], ["mobileweb"], ["sms", "mobileweb"]])
       group = insert(:respondent_group)
-      insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}, last_call_started: false})
+      insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}, pending_call: true})
 
       conn = get conn, project_survey_respondent_path(conn, :index, project.id, survey.id)
       data = json_response(conn, 200)["data"]
@@ -779,7 +779,7 @@ defmodule Ask.RespondentControllerTest do
       respondent = hd(data["respondents"])
       assert respondent["stats"]["attempts"]["sms"] == 1
       assert respondent["stats"]["attempts"]["mobileweb"] == 2
-      assert respondent["stats"]["attempts"]["ivr"] == 2, "should be 2 since last_call_started = false and ivr: 3"
+      assert respondent["stats"]["attempts"]["ivr"] == 2, "should be 2 since pending_call = true and ivr: 3"
     end
 
     test "index respondents with started last call", %{conn: conn, user: user} do
@@ -787,7 +787,7 @@ defmodule Ask.RespondentControllerTest do
       questionnaire = insert(:questionnaire, name: "test", project: project, steps: @dummy_steps)
       survey = insert(:survey, project: project, cutoff: 4, questionnaires: [questionnaire], state: "ready", schedule: completed_schedule(), mode: [["sms", "ivr"], ["mobileweb"], ["sms", "mobileweb"]])
       group = insert(:respondent_group)
-      insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}, last_call_started: true})
+      insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}, pending_call: false})
 
       conn = get conn, project_survey_respondent_path(conn, :index, project.id, survey.id)
       data = json_response(conn, 200)["data"]
@@ -795,7 +795,7 @@ defmodule Ask.RespondentControllerTest do
       respondent = hd(data["respondents"])
       assert respondent["stats"]["attempts"]["sms"] == 1
       assert respondent["stats"]["attempts"]["mobileweb"] == 2
-      assert respondent["stats"]["attempts"]["ivr"] == 3, "should be 3 since last_call_started = true and ivr: 3"
+      assert respondent["stats"]["attempts"]["ivr"] == 3, "should be 3 since pending_call = false and ivr: 3"
     end
 
   end
@@ -808,7 +808,7 @@ defmodule Ask.RespondentControllerTest do
       questionnaire = insert(:questionnaire, name: "test", project: project, steps: @dummy_steps)
       survey = insert(:survey, project: project, cutoff: 4, questionnaires: [questionnaire], state: "ready", schedule: completed_schedule(), mode: [["sms", "ivr"], ["mobileweb"], ["sms", "mobileweb"]])
       group_1 = insert(:respondent_group)
-      respondent_1 = insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group_1, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}, last_call_started: true})
+      respondent_1 = insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group_1, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}, pending_call: false})
       insert(:response, respondent: respondent_1, field_name: "Smokes", value: "Yes")
       insert(:response, respondent: respondent_1, field_name: "Exercises", value: "No")
       insert(:response, respondent: respondent_1, field_name: "Perfect Number", value: "100")
@@ -860,7 +860,7 @@ defmodule Ask.RespondentControllerTest do
       questionnaire = insert(:questionnaire, name: "test", project: project, steps: @dummy_steps)
       survey = insert(:survey, project: project, cutoff: 4, questionnaires: [questionnaire], state: "ready", schedule: completed_schedule(), mode: [["sms", "ivr"], ["mobileweb"], ["sms", "mobileweb"]])
       group = insert(:respondent_group)
-      respondent = insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}, last_call_started: false})
+      respondent = insert(:respondent, survey: survey, hashed_number: "1asd12451eds", disposition: "partial", effective_modes: ["sms", "ivr"], respondent_group: group, stats: %Stats{total_received_sms: 4, total_sent_sms: 3, total_call_time_seconds: 12, call_durations: %{"call-3" => 45}, attempts: %{sms: 1, mobileweb: 2, ivr: 3}, pending_call: true})
       insert(:response, respondent: respondent, field_name: "Smokes", value: "Yes")
       insert(:response, respondent: respondent, field_name: "Exercises", value: "No")
       insert(:response, respondent: respondent, field_name: "Perfect Number", value: "100")

--- a/test/lib/ecto_types/stats_test.exs
+++ b/test/lib/ecto_types/stats_test.exs
@@ -4,11 +4,11 @@ defmodule Ask.StatsTest do
 
   describe "dump:" do
     test "should dump empty" do
-      assert {:ok, "{\"total_sent_sms\":0,\"total_received_sms\":0,\"total_call_time_seconds\":null,\"total_call_time\":null,\"call_durations\":{},\"attempts\":null}"} == Stats.dump(%Stats{})
+      assert {:ok, "{\"total_sent_sms\":0,\"total_received_sms\":0,\"total_call_time_seconds\":null,\"total_call_time\":null,\"last_call_started\":false,\"call_durations\":{},\"attempts\":null}"} == Stats.dump(%Stats{})
     end
 
     test "should dump full" do
-      assert {:ok, "{\"total_sent_sms\":3,\"total_received_sms\":2,\"total_call_time_seconds\":60,\"total_call_time\":1,\"call_durations\":{\"12345\":30},\"attempts\":{\"sms\":5,\"mobileweb\":7,\"ivr\":6}}"} == Stats.dump(%Stats{total_received_sms: 2, total_sent_sms: 3, total_call_time_seconds: 60, total_call_time: 1, attempts: %{sms: 5, ivr: 6, mobileweb: 7}, call_durations: %{"12345" => 30}})
+      assert {:ok, "{\"total_sent_sms\":3,\"total_received_sms\":2,\"total_call_time_seconds\":60,\"total_call_time\":1,\"last_call_started\":true,\"call_durations\":{\"12345\":30},\"attempts\":{\"sms\":5,\"mobileweb\":7,\"ivr\":6}}"} == Stats.dump(%Stats{total_received_sms: 2, total_sent_sms: 3, total_call_time_seconds: 60, total_call_time: 1, attempts: %{sms: 5, ivr: 6, mobileweb: 7}, last_call_started: true, call_durations: %{"12345" => 30}})
     end
   end
 

--- a/test/lib/ecto_types/stats_test.exs
+++ b/test/lib/ecto_types/stats_test.exs
@@ -273,5 +273,4 @@ defmodule Ask.StatsTest do
       assert Stats.total_call_time(stats) == "1m 30s"
     end
   end
-
 end

--- a/test/lib/ecto_types/stats_test.exs
+++ b/test/lib/ecto_types/stats_test.exs
@@ -4,11 +4,11 @@ defmodule Ask.StatsTest do
 
   describe "dump:" do
     test "should dump empty" do
-      assert {:ok, "{\"total_sent_sms\":0,\"total_received_sms\":0,\"total_call_time_seconds\":null,\"total_call_time\":null,\"last_call_started\":false,\"call_durations\":{},\"attempts\":null}"} == Stats.dump(%Stats{})
+      assert {:ok, "{\"total_sent_sms\":0,\"total_received_sms\":0,\"total_call_time_seconds\":null,\"total_call_time\":null,\"pending_call\":false,\"call_durations\":{},\"attempts\":null}"} == Stats.dump(%Stats{})
     end
 
     test "should dump full" do
-      assert {:ok, "{\"total_sent_sms\":3,\"total_received_sms\":2,\"total_call_time_seconds\":60,\"total_call_time\":1,\"last_call_started\":true,\"call_durations\":{\"12345\":30},\"attempts\":{\"sms\":5,\"mobileweb\":7,\"ivr\":6}}"} == Stats.dump(%Stats{total_received_sms: 2, total_sent_sms: 3, total_call_time_seconds: 60, total_call_time: 1, attempts: %{sms: 5, ivr: 6, mobileweb: 7}, last_call_started: true, call_durations: %{"12345" => 30}})
+      assert {:ok, "{\"total_sent_sms\":3,\"total_received_sms\":2,\"total_call_time_seconds\":60,\"total_call_time\":1,\"pending_call\":true,\"call_durations\":{\"12345\":30},\"attempts\":{\"sms\":5,\"mobileweb\":7,\"ivr\":6}}"} == Stats.dump(%Stats{total_received_sms: 2, total_sent_sms: 3, total_call_time_seconds: 60, total_call_time: 1, attempts: %{sms: 5, ivr: 6, mobileweb: 7}, pending_call: true, call_durations: %{"12345" => 30}})
     end
   end
 

--- a/test/lib/ecto_types/stats_test.exs
+++ b/test/lib/ecto_types/stats_test.exs
@@ -57,10 +57,19 @@ defmodule Ask.StatsTest do
       assert 0 == stats |> Stats.attempts(:all)
 
       stats = stats |> Stats.add_attempt(:ivr)
+      assert 1 == stats.attempts["ivr"]
+      assert 0 == stats |> Stats.attempts(:ivr)
+      assert 0 == stats |> Stats.attempts(:all)
+
+      stats = stats |> Stats.with_last_call_attempted
+      assert 1 == stats.attempts["ivr"]
       assert 1 == stats |> Stats.attempts(:ivr)
       assert 1 == stats |> Stats.attempts(:all)
 
-      stats = stats |> Stats.add_attempt(:ivr)
+      stats = stats
+              |> Stats.add_attempt(:ivr)
+              |> Stats.with_last_call_attempted
+      assert 2 == stats.attempts["ivr"]
       assert 2 == stats |> Stats.attempts(:ivr)
       assert 2 == stats |> Stats.attempts(:all)
 
@@ -100,18 +109,22 @@ defmodule Ask.StatsTest do
       assert 1 == stats |> Stats.attempts(:all)
 
       stats = stats |> Stats.add_attempt(:ivr)
-      assert 1 == stats |> Stats.attempts(:ivr)
-      assert 2 == stats |> Stats.attempts(:all)
+      assert 0 == stats |> Stats.attempts(:ivr)
+      assert 1 == stats |> Stats.attempts(:all)
 
       stats = stats |> Stats.add_attempt(:mobileweb)
       assert 1 == stats |> Stats.attempts(:mobileweb)
-      assert 3 == stats |> Stats.attempts(:all)
+      assert 2 == stats |> Stats.attempts(:all)
 
       stats = stats |> Stats.add_attempt(:sms)
       assert 2 == stats |> Stats.attempts(:sms)
+      assert 3 == stats |> Stats.attempts(:all)
+
+      stats = stats |> Stats.with_last_call_attempted
+      assert 1 == stats |> Stats.attempts(:ivr)
       assert 4 == stats |> Stats.attempts(:all)
 
-      stats = stats |> Stats.add_attempt(:ivr)
+      stats = stats |> Stats.add_attempt(:ivr) |> Stats.with_last_call_attempted
       assert 2 == stats |> Stats.attempts(:ivr)
       assert 5 == stats |> Stats.attempts(:all)
 
@@ -119,7 +132,7 @@ defmodule Ask.StatsTest do
       assert 2 == stats |> Stats.attempts(:mobileweb)
       assert 6 == stats |> Stats.attempts(:all)
 
-      stats = stats |> Stats.add_attempt(:ivr)
+      stats = stats |> Stats.add_attempt(:ivr) |> Stats.with_last_call_attempted
       assert 3 == stats |> Stats.attempts(:ivr)
       assert 7 == stats |> Stats.attempts(:all)
 

--- a/test/lib/ecto_types/stats_test.exs
+++ b/test/lib/ecto_types/stats_test.exs
@@ -156,6 +156,36 @@ defmodule Ask.StatsTest do
       assert 1 == stats |> Stats.attempts(:sms)
       assert 2 == stats |> Stats.attempts(:all)
     end
+
+    test "full counts non-started ivr calls" do
+      stats = %Stats{}
+
+      assert 0 == stats |> Stats.attempts(:ivr)
+      assert 0 == stats |> Stats.attempts(:all)
+      assert 0 == stats |> Stats.attempts(:full)
+
+      stats = stats |> Stats.add_attempt(:sms)
+      assert 1 == stats |> Stats.attempts(:sms)
+      assert 0 == stats |> Stats.attempts(:ivr)
+      assert 1 == stats |> Stats.attempts(:all)
+      assert 1 == stats |> Stats.attempts(:full)
+      
+      stats = stats |> Stats.add_attempt(:mobileweb)
+      assert 1 == stats |> Stats.attempts(:mobileweb)
+      assert 0 == stats |> Stats.attempts(:ivr)
+      assert 2 == stats |> Stats.attempts(:all)
+      assert 2 == stats |> Stats.attempts(:full)
+
+      stats = stats |> Stats.add_attempt(:ivr)
+      assert 0 == stats |> Stats.attempts(:ivr)
+      assert 2 == stats |> Stats.attempts(:all)
+      assert 3 == stats |> Stats.attempts(:full)
+      
+      stats = stats |> Stats.with_last_call_attempted
+      assert 1 == stats |> Stats.attempts(:ivr)
+      assert 3 == stats |> Stats.attempts(:all)
+      assert 3 == stats |> Stats.attempts(:full)
+    end
   end
 
   describe "sms count:" do

--- a/test/lib/runtime/session_test.exs
+++ b/test/lib/runtime/session_test.exs
@@ -213,7 +213,6 @@ defmodule Ask.SessionTest do
     refute_receive _
 
     assert session.channel_state == 0
-    assert 1 == respondent.stats |> Stats.attempts(:ivr)
   end
 
   test "retry question", %{quiz: quiz, respondent: respondent, test_channel: test_channel, channel: channel} do
@@ -236,12 +235,10 @@ defmodule Ask.SessionTest do
     test_channel = TestChannel.new
     channel = build(:channel, settings: test_channel |> TestChannel.settings)
     {:ok, session = %Session{token: token, respondent: respondent}, _, 5} = handle_session_started(Session.start(quiz, respondent, channel, "ivr", Schedule.always(), [5]), quiz.id, ["ivr"])
-    assert 1 == respondent.stats |> Stats.attempts(:ivr)
     assert_receive [:setup, ^test_channel, respondent_received, ^token]
     assert respondent_received.id == respondent.id
 
     assert {:ok, %Session{token: token2, respondent: respondent}, _, 5} = Session.timeout(session)
-    assert 2 == respondent.stats |> Stats.attempts(:ivr)
     assert token2 != token
     assert_receive [:setup, ^test_channel, respondent_received, ^token2]
     assert respondent_received.id == respondent.id
@@ -393,8 +390,6 @@ defmodule Ask.SessionTest do
     {:ok, result = %Session{token: token, respondent: respondent}, _, 5} = Session.timeout(session_after_second_retry)
     assert_receive [:setup, ^fallback_runtime_channel, respondent_received, ^token]
     assert respondent.id == respondent_received.id
-
-    assert 1 == respondent_received.stats |> Stats.attempts(:ivr)
 
     assert result.current_mode == expected_session.current_mode
     assert result.fallback_mode == expected_session.fallback_mode
@@ -571,12 +566,10 @@ defmodule Ask.SessionTest do
     channel = build(:channel, settings: test_channel |> TestChannel.settings)
 
     assert {:ok, session = %Session{token: token, respondent: respondent}, _, 5} = Session.start(quiz, respondent, channel, "ivr", Schedule.always(), [5])
-    assert 1 == respondent.stats |> Stats.attempts(:ivr)
 
     assert_receive [:setup, ^test_channel, ^respondent, ^token]
 
     assert {:ok, %Session{token: token, respondent: respondent}, %Reply{}, 5} = Session.timeout(session)
-    assert 1 == respondent.stats |> Stats.attempts(:ivr)
     assert_receive [:setup, ^test_channel, ^respondent, ^token]
   end
 
@@ -602,12 +595,9 @@ defmodule Ask.SessionTest do
     fallback_retries = [5]
 
     {:ok, session = %Session{token: token, respondent: respondent}, _, 120} = Session.start(quiz, respondent, channel, "ivr", Schedule.always(), [], fallback_channel, "ivr", fallback_retries)
-    assert 1 == respondent.stats |> Stats.attempts(:ivr)
     assert_receive [:setup, ^test_channel, ^respondent, ^token]
 
-
     assert {:ok, %Session{token: token, respondent: respondent} , %Reply{}, 120} = Session.timeout(session)
-    assert 1 == respondent.stats |> Stats.attempts(:ivr)
     assert_receive [:setup, ^test_channel, ^respondent, ^token]
   end
 

--- a/web/models/respondent.ex
+++ b/web/models/respondent.ex
@@ -129,7 +129,7 @@ defmodule Ask.Respondent do
 
   def add_mode_attempt!(respondent, mode), do: respondent |> changeset(%{stats: Stats.add_attempt(respondent.stats, mode)}) |> Repo.update!
 
-  def call_attempted(%{stats: %{last_call_started: true} } = respondent), do: respondent
+  def call_attempted(%{stats: %{pending_call: false} } = respondent), do: respondent
   def call_attempted(%{stats: stats} = respondent), do: respondent |> changeset(%{stats: Stats.with_last_call_attempted(stats)}) |> Repo.update!
 
   @doc """

--- a/web/models/respondent.ex
+++ b/web/models/respondent.ex
@@ -129,6 +129,9 @@ defmodule Ask.Respondent do
 
   def add_mode_attempt!(respondent, mode), do: respondent |> changeset(%{stats: Stats.add_attempt(respondent.stats, mode)}) |> Repo.update!
 
+  def call_attempted(%{stats: %{last_call_started: true} } = respondent), do: respondent
+  def call_attempted(%{stats: stats} = respondent), do: respondent |> changeset(%{stats: Stats.with_last_call_attempted(stats)}) |> Repo.update!
+
   @doc """
   Computes the date-time on which the respondent should be retried or stalled given the timeout and time-window availability
   """


### PR DESCRIPTION
Keep track of whether the last call sent to Verboice has actually been tried or not to omit it from the IVR attempts count if necessary.

Any contact from Verboice (except expiring the call) counts towards activity on the attempt.

Fixes #1589