### PR TITLE
QuestionnaireSimulator supports sections

### DIFF
--- a/lib/ask/runtime/flow.ex
+++ b/lib/ask/runtime/flow.ex
@@ -518,7 +518,7 @@ defmodule Ask.Runtime.Flow do
     quiz_step["relevant"] && not_ignored.(response.value)
   end
 
-  def ignored_values_from_relevant_steps(questionnaire) do
+  defp ignored_values_from_relevant_steps(questionnaire) do
     not_empty = fn str -> str != "" end
     (questionnaire.partial_relevant_config["ignored_values"] || "")
     |> String.split(",")

--- a/lib/ask/runtime/session_mode.ex
+++ b/lib/ask/runtime/session_mode.ex
@@ -11,7 +11,6 @@ defmodule Ask.Runtime.SessionModeProvider do
   defp mode_provider("sms"), do: SMSMode
   defp mode_provider("ivr"), do: IVRMode
   defp mode_provider("mobileweb"), do: MobileWebMode
-  defp mode_provider("sms_simulator"), do: SMSSimulatorMode
 
   def new(nil, _channel, _retries), do: nil
 

--- a/lib/ask/runtime/session_mode.ex
+++ b/lib/ask/runtime/session_mode.ex
@@ -14,7 +14,7 @@ defmodule Ask.Runtime.SessionModeProvider do
 
   def new(nil, _channel, _retries), do: nil
 
-  def new(_mode, %Ask.Runtime.SimulatorChannel{} = channel, retries) do
+  def new("sms", %Ask.Runtime.SimulatorChannel{} = channel, retries) do
     SMSSimulatorMode.new(channel, retries)
   end
 

--- a/lib/ask/runtime/session_mode.ex
+++ b/lib/ask/runtime/session_mode.ex
@@ -14,6 +14,11 @@ defmodule Ask.Runtime.SessionModeProvider do
   defp mode_provider("sms_simulator"), do: SMSSimulatorMode
 
   def new(nil, _channel, _retries), do: nil
+
+  def new(_mode, %Ask.Runtime.SimulatorChannel{} = channel, retries) do
+    SMSSimulatorMode.new(channel, retries)
+  end
+
   def new(mode, channel, retries) when not is_nil(channel) and is_list(retries) do
     mode_provider(mode).new(channel, retries)
   end
@@ -45,22 +50,22 @@ defmodule Ask.Runtime.SMSSimulatorMode do
 
   defstruct [:channel, :retries]
 
-  def new(channel, _retries), do: %SMSSimulatorMode{channel: channel, retries: []}
+  def new(channel, retries), do: %SMSSimulatorMode{channel: channel, retries: retries}
   def load(_mode_dump), do: %SMSSimulatorMode{}
 
   defimpl Ask.Runtime.SessionMode, for: Ask.Runtime.SMSSimulatorMode do
     def dump(%SMSSimulatorMode{}) do
       %{
-        mode: "sms_simulator",
+        mode: "sms",
       }
     end
 
     def visitor(_) do
-      TextVisitor.new("sms_simulator")
+      TextVisitor.new("sms")
     end
 
     def mode(_) do
-      "sms_simulator"
+      "sms"
     end
   end
 end


### PR DESCRIPTION
 * Refactor the codebase so `QuestionnaireSimulator` works with `"sms"` mode instead of `"sms_simulator"`. 
With this changes, the simulator uses the questionnaire as-it-is without adapting it, this means that no longer has the limitation of not working with questionnaires with sections

* Do not dump session if `persist = false`

for #1672