### PR TITLE
Simulator improvements

### DIFF
--- a/lib/ask/runtime/questionnaire_simulator.ex
+++ b/lib/ask/runtime/questionnaire_simulator.ex
@@ -43,7 +43,7 @@ defmodule Ask.Runtime.QuestionnaireSimulator do
       started_at: Timex.now
     }
 
-    respondent = %Respondent{
+    new_respondent = %Respondent{
       id: Ecto.UUID.generate(),
       survey_id: survey.id,
       survey: survey,
@@ -55,15 +55,21 @@ defmodule Ask.Runtime.QuestionnaireSimulator do
       sanitized_phone_number: ""
     }
 
-    {:ok, session, _reply, _timeout} = session_started = Session.start(questionnaire, respondent, %Ask.Runtime.SimulatorChannel{}, @sms_mode, Ask.Schedule.always(), [], nil, nil, [], nil, false, false)
+    # Simulating what Broker does when starting a respondent: Session.start and then Survey.handle_session_step
+    session_started = Session.start(questionnaire, new_respondent, %Ask.Runtime.SimulatorChannel{}, @sms_mode, Ask.Schedule.always(), [], nil, nil, [], nil, false, false)
     {:reply, reply, respondent} = Runtime.Survey.handle_session_step(session_started, SystemTime.time.now, false)
 
-    reply_messages = reply_to_messages(reply)
-    messages = AOMessage.create_all(reply_messages)
-    updated_respondent = %Respondent{respondent | session: session}
+    # Must nest respondent in respondent.session since this is the one updated
+    # If not respondent data would be loss for simulation
+    respondent_for_confirmation = %{respondent | session: %{respondent.session | respondent: respondent}}
+
+    # Simulating Nuntium confirmation on message delivery
+    %{respondent: respondent} = Runtime.Survey.delivery_confirm(respondent_for_confirmation, "", @sms_mode, false)
+
+    messages = reply |> reply_to_messages |> AOMessage.create_all
     submitted_steps = SubmittedStep.build_from(reply, questionnaire)
 
-    QuestionnaireSimulatorStore.add_respondent_simulation(respondent.id, %Ask.QuestionnaireSimulation{questionnaire: questionnaire, respondent: updated_respondent, messages: messages, submissions: submitted_steps})
+    QuestionnaireSimulatorStore.add_respondent_simulation(respondent.id, %Ask.QuestionnaireSimulation{questionnaire: questionnaire, respondent: respondent, messages: messages, submissions: submitted_steps})
     |> QuestionnaireSimulationStep.build(Status.active)
   end
 

--- a/lib/ask/runtime/questionnaire_simulator.ex
+++ b/lib/ask/runtime/questionnaire_simulator.ex
@@ -137,10 +137,10 @@ defmodule Ask.Simulation.SubmittedStep do
   def build_from(reply, questionnaire) do
     responses = Reply.stores(reply)
                 |> Enum.map(fn {step_name, value} ->
-                  referred_step = questionnaire |> Questionnaire.all_steps |> Enum.filter(fn step -> step["store"] == step_name end)
-                  # hd function is used since there is a restriction that two steps cannot have the same store variable name
-                  id = referred_step |> Enum.map(fn step -> step["id"] end) |> hd
-                  title = referred_step |> Enum.map(fn step -> step["title"] end) |> hd
+                  # find function is used since there is a restriction that two steps cannot have the same store variable name
+                  %{"title" => title, "id" => id} = questionnaire
+                                                    |> Questionnaire.all_steps
+                                                    |> Enum.find(fn step -> step["store"] == step_name end)
                   %{step: title, response: value, id: id}
     end)
 

--- a/lib/ask/runtime/reply.ex
+++ b/lib/ask/runtime/reply.ex
@@ -16,6 +16,10 @@ defmodule Ask.Runtime.Reply do
     steps
   end
 
+  def steps(_) do
+    []
+  end
+
   def stores(%Reply{stores: stores}) do
     stores
   end

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -112,7 +112,7 @@ defmodule Ask.Runtime.Session do
     end
     respondent = session.respondent
     step_answer = Flow.step(session.flow, current_mode |> SessionMode.visitor, response, SessionMode.mode(current_mode), respondent.disposition)
-                  |> relevant_interim_partial_step(respondent)
+                  |> relevant_interim_partial_step(respondent, persist)
     reply = case step_answer do
       {:end, _, reply} -> reply
       {:ok, _flow, reply} -> reply
@@ -347,9 +347,9 @@ defmodule Ask.Runtime.Session do
   # If the respondent has answered at least `min_relevant_steps` relevant steps
   # and the reply doesn't defines already a disposition
   # then, 'interim partial' disposition is returned in reply
-  defp relevant_interim_partial_step({:ok, flow, %{disposition: nil} = reply} = step_answer, %{disposition: "started"} = respondent) do
+  defp relevant_interim_partial_step({:ok, flow, %{disposition: nil} = reply} = step_answer, %{disposition: "started"} = respondent, persist) do
     new_step_answer = if Flow.interim_partial_by_relevant_steps?(flow) do # Filtered here to avoid fetching the responses unnecessarily
-      valid_relevant_responses = all_responses(respondent.id, reply) |> Enum.count(&Flow.relevant_response?(flow, &1))
+      valid_relevant_responses = all_responses(respondent, reply, persist) |> Enum.count(&Flow.relevant_response?(flow, &1))
       if valid_relevant_responses >= Flow.min_relevant_steps(flow) do
         {:ok, flow, %{reply | disposition: "interim partial"}}
       end
@@ -358,11 +358,11 @@ defmodule Ask.Runtime.Session do
     new_step_answer || step_answer
   end
 
-  defp relevant_interim_partial_step(step_answer, _respondent), do: step_answer
+  defp relevant_interim_partial_step(step_answer, _respondent, _persist), do: step_answer
 
-  defp all_responses(respondent_id, reply) do
-    current_responses = Reply.stores(reply) |> Enum.map(fn {field_name, value} -> %Ask.Response{field_name: field_name, value: value} end)
-    stored_responses = from(r in Ask.Response, where: r.respondent_id == ^respondent_id) |> Repo.all
+  defp all_responses(respondent, reply, persist) do
+    current_responses = Ask.Response.build_from_reply(reply)
+    stored_responses = if persist, do: from(r in Ask.Response, where: r.respondent_id == ^respondent.id) |> Repo.all, else: respondent.responses
     current_responses ++ stored_responses
   end
 
@@ -588,7 +588,8 @@ defmodule Ask.Runtime.Session do
       store_response(respondent, reply)
       try_to_assign_bucket(respondent, session)
     else
-      respondent
+      updated_responses = respondent.responses ++ Ask.Response.build_from_reply(reply)
+      %{respondent | responses: updated_responses}
     end
   end
 

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -209,9 +209,9 @@ defmodule Ask.Runtime.Session do
     {:ok, session, base_timeout + current_timeout(session)}
   end
 
-  def delivery_confirm(session, title, current_mode) do
-    log_confirmation(title, session.respondent.disposition, current_mode.channel, session.flow.mode, session.respondent)
-    update_respondent_disposition(session, "contacted", current_mode)
+  def delivery_confirm(session, title, current_mode, persist) do
+    if persist, do: log_confirmation(title, session.respondent.disposition, current_mode.channel, session.flow.mode, session.respondent)
+    update_respondent_disposition(session, "contacted", current_mode, persist)
   end
 
   def cancel(session) do

--- a/lib/ask/runtime/survey.ex
+++ b/lib/ask/runtime/survey.ex
@@ -187,15 +187,15 @@ defmodule Ask.Runtime.Survey do
     delivery_confirm(respondent, title, nil)
   end
 
-  def delivery_confirm(respondent, title, mode) do
+  def delivery_confirm(respondent, title, mode, persist \\ true) do
     unless respondent.session == nil do
-      session = respondent.session |> Session.load
+      session = Session.load_respondent_session(respondent, persist)
       session_mode =
         case session_mode(respondent, session, mode) do
           :invalid_mode -> session.current_mode
           mode -> mode
         end
-      Session.delivery_confirm(session, title, session_mode)
+      Session.delivery_confirm(session, title, session_mode, persist)
     end
   end
 

--- a/lib/ask/runtime/survey.ex
+++ b/lib/ask/runtime/survey.ex
@@ -130,7 +130,7 @@ defmodule Ask.Runtime.Survey do
   def handle_session_step({:stopped, reply, respondent}, _, persist) do
     updated_respondent = respondent_updates(:stopped, respondent, Reply.disposition(reply), persist)
     updated_respondent = if(disposition_changed?(respondent, updated_respondent)) do
-      disposition_changed(updated_respondent, respondent.session |> Session.load, respondent.disposition, persist)
+      disposition_changed(updated_respondent, Session.load_respondent_session(respondent, persist), respondent.disposition, persist)
     else
       updated_respondent
     end

--- a/lib/ask/runtime/survey.ex
+++ b/lib/ask/runtime/survey.ex
@@ -143,13 +143,13 @@ defmodule Ask.Runtime.Survey do
   end
 
   def failed_session(respondent, persist) do
-    session = respondent.session |> Session.load
+    session = Session.load_respondent_session(respondent, persist)
     mode = session.current_mode |> SessionMode.mode
     old_disposition = respondent.disposition
     new_disposition = Flow.failed_disposition_from(respondent.disposition)
 
     updated_respondent = respondent_updates(:failed, respondent, persist)
-    Session.log_disposition_changed(updated_respondent, session.current_mode.channel, mode, old_disposition, new_disposition)
+    Session.log_disposition_changed(updated_respondent, session.current_mode.channel, mode, old_disposition, new_disposition, persist)
     disposition_changed(updated_respondent, session, old_disposition, persist)
   end
 

--- a/test/lib/runtime/questionnaire_simulator_test.exs
+++ b/test/lib/runtime/questionnaire_simulator_test.exs
@@ -27,7 +27,7 @@ defmodule QuestionnaireSimulatorTest do
     test "with partial flag", %{project: project} do
       quiz = questionnaire_with_steps(SimulatorQuestionnaireSteps.with_interim_partial_flag)
       %{respondent_id: respondent_id, disposition: disposition, messages_history: messages, simulation_status: status} = QuestionnaireSimulator.start_simulation(project, quiz)
-      assert "queued" == disposition
+      assert "contacted" == disposition
       assert  "Do you smoke? Reply 1 for YES, 2 for NO" == List.last(messages).body
       assert Ask.Simulation.Status.active == status
 
@@ -123,7 +123,7 @@ defmodule QuestionnaireSimulatorTest do
 
   defp assert_dummy_steps(project, quiz) do
     %{respondent_id: respondent_id, disposition: disposition, messages_history: messages, simulation_status: status} = QuestionnaireSimulator.start_simulation(project, quiz)
-    assert "queued" == disposition
+    assert "contacted" == disposition
     assert "Do you smoke? Reply 1 for YES, 2 for NO" == List.last(messages).body
     assert Ask.Simulation.Status.active == status
 

--- a/test/support/dummy_steps.ex
+++ b/test/support/dummy_steps.ex
@@ -1074,3 +1074,167 @@ defmodule Ask.DummySteps do
     end
   end
 end
+
+defmodule Ask.QuestionnaireRelevantSteps do
+  use Ask.DummySteps
+  import Ask.StepBuilder
+
+  def all_relevant_steps(), do: @dummy_steps |> Enum.map(fn step -> Map.put(step, "relevant", true) end)
+
+  def odd_relevant_steps(), do: @dummy_steps |> Enum.map_every(2, fn step -> Map.put(step, "relevant", true) end) # Only the odd steps are relevant
+
+  def odd_relevant_with_numeric_refusal(), do: [
+        multiple_choice_step(
+          id: Ecto.UUID.generate,
+          title: "Do you smoke?",
+          prompt: prompt(
+            sms: sms_prompt("Do you smoke? Reply 1 for YES, 2 for NO"),
+            ivr: tts_prompt("Do you smoke? Press 8 for YES, 9 for NO")
+          ),
+          store: "Smokes",
+          choices: [
+            choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["8"])),
+            choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["9"]))
+          ],
+          relevant: true
+        ),
+        multiple_choice_step(
+          id: Ecto.UUID.generate,
+          title: "Do you exercise",
+          prompt: prompt(
+            sms: sms_prompt("Do you exercise? Reply 1 for YES, 2 for NO"),
+            ivr: tts_prompt("Do you exercise? Press 1 for YES, 2 for NO")
+          ),
+          store: "Exercises",
+          choices: [
+            choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["1"])),
+            choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["2"]))
+          ]
+        ),
+        numeric_step(
+          id: Ecto.UUID.generate,
+          title: "Which is the second perfect number?",
+          prompt: prompt(
+            sms: sms_prompt("Which is the second perfect number??"),
+            ivr: tts_prompt("Which is the second perfect number")
+          ),
+          store: "Perfect Number",
+          skip_logic: default_numeric_skip_logic(),
+          alphabetical_answers: false,
+          refusal: %{
+            "enabled" => true,
+            "responses" => %{
+              "sms" => %{
+                "en" => ["#", "0"],
+                "skip_logic" => nil
+              },
+              "ivr" => %{
+                "en" => ["#", "0"],
+                "skip_logic" => nil
+              }
+            }
+          },
+          relevant: true
+        ),
+        numeric_step(
+          id: Ecto.UUID.generate,
+          title: "What's the number of this question?",
+          prompt: prompt(
+            sms: sms_prompt("What's the number of this question??"),
+            ivr: tts_prompt("What's the number of this question")
+          ),
+          store: "Question",
+          skip_logic: default_numeric_skip_logic(),
+          alphabetical_answers: false,
+          refusal: nil
+        )
+      ]
+
+  def odd_relevant_with_multiple_choice_refusal(), do: [
+    multiple_choice_step(
+     id: Ecto.UUID.generate,
+     title: "Do you smoke?",
+     prompt: prompt(
+       sms: sms_prompt("Do you smoke? Reply 1 for YES, 2 for NO"),
+       ivr: tts_prompt("Do you smoke? Press 8 for YES, 9 for NO")
+     ),
+     store: "Smokes",
+     choices: [
+       choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["8"])),
+       choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["9"])),
+       choice(value: "Skip", responses: responses(sms: ["skip", "S", "#"], ivr: ["#"]))
+     ],
+     relevant: true
+    ),
+    multiple_choice_step(
+     id: Ecto.UUID.generate,
+     title: "Do you exercise",
+     prompt: prompt(
+       sms: sms_prompt("Do you exercise? Reply 1 for YES, 2 for NO"),
+       ivr: tts_prompt("Do you exercise? Press 1 for YES, 2 for NO")
+     ),
+     store: "Exercises",
+     choices: [
+       choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["1"])),
+       choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["2"]))
+     ]
+    ),
+    numeric_step(
+     id: Ecto.UUID.generate,
+     title: "Which is the second perfect number?",
+     prompt: prompt(
+       sms: sms_prompt("Which is the second perfect number??"),
+       ivr: tts_prompt("Which is the second perfect number")
+     ),
+     store: "Perfect Number",
+     skip_logic: default_numeric_skip_logic(),
+     alphabetical_answers: false,
+     refusal: nil,
+     relevant: true
+    ),
+    numeric_step(
+     id: Ecto.UUID.generate,
+     title: "What's the number of this question?",
+     prompt: prompt(
+       sms: sms_prompt("What's the number of this question??"),
+       ivr: tts_prompt("What's the number of this question")
+     ),
+     store: "Question",
+     skip_logic: default_numeric_skip_logic(),
+     alphabetical_answers: false,
+     refusal: nil
+    )
+  ]
+
+  def relevant_steps_in_multiple_sections(), do: [
+    section(id: "section 1", title: "First section", randomize: false, steps: [
+      multiple_choice_step(
+      id: Ecto.UUID.generate,
+      title: "Do you sleep well?",
+      prompt: prompt(
+        sms: sms_prompt("Do you sleep well? Reply 1 for YES, 2 for NO"),
+        ivr: tts_prompt("Do you sleep well? Press 8 for YES, 9 for NO")
+      ),
+      store: "Sleep",
+      choices: [
+        choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["8"])),
+        choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["9"]))
+      ],
+      relevant: true
+    ),
+    numeric_step(
+     id: Ecto.UUID.generate,
+     title: "How many hours do you sleep?",
+     prompt: prompt(
+       sms: sms_prompt("How many hours do you sleep??"),
+       ivr: tts_prompt("How many hours do you sleep")
+     ),
+     store: "SleepHours",
+     skip_logic: default_numeric_skip_logic(),
+     alphabetical_answers: false,
+     refusal: nil
+    )
+    ]),
+    section(id: "section 2", title: "Second section", randomize: false, steps: all_relevant_steps()),
+  ]
+end

--- a/web/models/response.ex
+++ b/web/models/response.ex
@@ -17,4 +17,13 @@ defmodule Ask.Response do
     |> cast(params, [:field_name, :value])
     |> validate_required([:field_name, :value])
   end
+
+  @doc """
+  Builds a list of responses based on reply.stores
+  """
+  def build_from_reply(reply) do
+    reply
+    |> Ask.Runtime.Reply.stores
+    |> Enum.map(fn {field_name, value} -> %Ask.Response{field_name: field_name, value: value} end)
+  end
 end


### PR DESCRIPTION
##  Respondents start simulation with `"contacted"` disposition
In real surveys, respondent transitions from `"queued"` to `"contacted"` when nuntium sends the delivery_confirmation through the status callback
Added a call to `delivery_confirm` in `QuestionnaireSimulator.start_simulation` to simulate this behavior

## Interim-partial-by-relevant-steps feature works in simulation
The `Ask.Respondent` struct has a field called `responses`. This is a consequence of defining `has_many :responses, Ask.Response` in its schema.

Used the `persist` parameter to determine if getting the responses from db o directly from `respondent.responses`. When storing responses, if `persist: false`, the responses are kept under this field


## Stop messages work in simulation
Implemented missing pattern `Reply.steps(_)`
Implemented `QuestionnaireSimulator.sync_respondent` for this feature (and probably others too) to work properly with only in-memory respondent

_____

for #1672 