### PR TITLE
Fix questionnaire's audios export

### DIFF
--- a/test/controllers/audio_controller_test.exs
+++ b/test/controllers/audio_controller_test.exs
@@ -84,7 +84,7 @@ defmodule Ask.AudioControllerTest do
       file = %Plug.Upload{path: "test/fixtures/invalid_audio.csv", filename: "test1.csv"}
       conn = post conn, audio_path(conn, :create), file: file
 
-      assert Enum.at(json_response(conn, 422)["errors"]["filename"], 0) == "Invalid file type. Allowed types are MPEG and WAV."
+      assert Enum.at(json_response(conn, 422)["errors"]["filename"], 0) == "Invalid file type. Allowed types are MP3 and WAV."
     end
 
   end

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -169,10 +169,6 @@ defmodule Ask.QuestionnaireController do
     end
   end
 
-  defp exported_audio_file_name(uuid) do
-    uuid <> ".#{Audio.stored_audio_extension()}"
-  end
-
   def export_zip(conn, %{"project_id" => project_id, "questionnaire_id" => id}) do
     project = conn
     |> load_project(project_id)
@@ -206,7 +202,7 @@ defmodule Ask.QuestionnaireController do
     end)
     audio_entries = Stream.map(audio_resource, fn audio ->
       #Zstream needs to recieve audio.data as enumerable in order to work, otherwise it throws Protocol.undefined error.
-      Zstream.entry("audios/" <> exported_audio_file_name(audio.uuid), [audio.data])
+      Zstream.entry("audios/" <> Audio.exported_audio_file_name(audio.uuid), [audio.data])
     end)
 
     manifest = %{
@@ -274,11 +270,11 @@ defmodule Ask.QuestionnaireController do
     {:ok, manifest} = Poison.decode(json)
 
     audio_files = manifest |> Map.get("audio_files")
-    audio_files |> Enum.each(fn %{"uuid" => uuid, "filename" => filename, "source" => source, "duration" => duration} ->
+    audio_files |> Enum.each(fn %{"uuid" => uuid, "original_filename" => original_filename, "source" => source, "duration" => duration} ->
       # Only create audio if it doesn't exist already
       unless Audio |> Repo.get_by(uuid: uuid) do
-        data = files |> Map.get("audios/#{uuid}")
-        %Audio{uuid: uuid, data: data, filename: filename, source: source, duration: duration} |> Repo.insert!
+        data = files |> Map.get("audios/#{Audio.exported_audio_file_name(uuid)}")
+        %Audio{uuid: uuid, data: data, filename: original_filename, source: source, duration: duration} |> Repo.insert!
       end
     end)
 

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -191,7 +191,9 @@ defmodule Ask.QuestionnaireController do
       end,
       fn _ -> [] end
     )
-    # Link the audio file to its corresponding step
+
+    # The audio file import is based on this list
+    # If it's empty, nothing will be imported
     audio_files = Stream.map(audio_resource, fn audio ->
       %{
         "uuid" => audio.uuid,
@@ -199,6 +201,7 @@ defmodule Ask.QuestionnaireController do
         "source" => audio.source
       }
     end)
+
     audio_entries = Stream.map(audio_resource, fn audio ->
       #Zstream needs to recieve audio.data as enumerable in order to work, otherwise it throws Protocol.undefined error.
       Zstream.entry("audios/" <> Audio.exported_audio_file_name(audio.uuid), [audio.data])

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -196,8 +196,7 @@ defmodule Ask.QuestionnaireController do
       %{
         "uuid" => audio.uuid,
         "original_filename" => audio.filename,
-        "source" => audio.source,
-        "duration" => audio.duration
+        "source" => audio.source
       }
     end)
     audio_entries = Stream.map(audio_resource, fn audio ->
@@ -270,11 +269,11 @@ defmodule Ask.QuestionnaireController do
     {:ok, manifest} = Poison.decode(json)
 
     audio_files = manifest |> Map.get("audio_files")
-    audio_files |> Enum.each(fn %{"uuid" => uuid, "original_filename" => original_filename, "source" => source, "duration" => duration} ->
+    audio_files |> Enum.each(fn %{"uuid" => uuid, "original_filename" => original_filename, "source" => source} ->
       # Only create audio if it doesn't exist already
       unless Audio |> Repo.get_by(uuid: uuid) do
         data = files |> Map.get("audios/#{Audio.exported_audio_file_name(uuid)}")
-        %Audio{uuid: uuid, data: data, filename: original_filename, source: source, duration: duration} |> Repo.insert!
+        %Audio{uuid: uuid, data: data, filename: original_filename, source: source} |> Repo.insert!
       end
     end)
 

--- a/web/models/audio.ex
+++ b/web/models/audio.ex
@@ -16,7 +16,7 @@ defmodule Ask.Audio do
   end
 
   @stored_audio_extension "mp3"
-  def stored_audio_extension(), do: @stored_audio_extension
+  def exported_audio_file_name(uuid), do: uuid <> ".#{@stored_audio_extension()}"
 
   @doc """
   Builds a changeset based on the `struct` and `params`.

--- a/web/models/audio.ex
+++ b/web/models/audio.ex
@@ -15,6 +15,9 @@ defmodule Ask.Audio do
     timestamps()
   end
 
+  @stored_audio_extension "mp3"
+  def stored_audio_extension(), do: @stored_audio_extension
+
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
@@ -38,14 +41,15 @@ defmodule Ask.Audio do
 
   def params_from_converted_upload(upload) do
     case Path.extname(upload.filename) do
-      ".wav" -> case Sox.convert("wav", upload.path, "mp3") do
+      ".wav" -> case Sox.convert("wav", upload.path, @stored_audio_extension) do
                   {:ok, data} ->
-                    %{"uuid" => Ecto.UUID.generate, "data" => data, "filename" => "#{Path.basename(upload.filename, ".wav")}.mp3"}
+                    %{"uuid" => Ecto.UUID.generate, "data" => data, "filename" => "#{Path.basename(upload.filename, ".wav")}.#{@stored_audio_extension}"}
                   {:error, error} ->
                     Logger.warn("Error converting file #{upload.path}: #{error}")
                     params_from_upload(upload)
                 end
-      _ -> params_from_upload(upload)
+      ".#{@stored_audio_extension}"
+        -> params_from_upload(upload)
     end
   end
 
@@ -62,7 +66,7 @@ defmodule Ask.Audio do
     if valid_type do
       []
     else
-      [filename: "Invalid file type. Allowed types are MPEG and WAV."]
+      [filename: "Invalid file type. Allowed types are MP3 and WAV."]
     end
   end
 

--- a/web/models/audio.ex
+++ b/web/models/audio.ex
@@ -10,6 +10,7 @@ defmodule Ask.Audio do
     field :data, :binary
     field :filename, :string
     field :source, :string, default: "upload"
+    # :duration is unused. We should remove it from the model (and DB)
     field :duration, :integer, default: 0 # seconds
 
     timestamps()


### PR DESCRIPTION
🐛 The bugs 

1.  The `audio_files` property is the list which the audio file import used to iterate, check if the audio file exists and upload if it doesn't. It's not being filled now, and when it's empty no audio file is imported.
2. The `original_file name` (instead of the `uuid`) was being used for naming the audio files. This field isn't unique, so when exporting more than one file with the original name duplicated, they were being overridden. Also, the questionnaire import relies on the file name is the audio `uuid`, so inserting in the DB link it automatically to its corresponding step.

💥 The consequences

1. The audio file export is broken. The audio files aren't being imported, and can't be imported, because the questionnaire's audio file export is broken.

🚧 The fixes

1. Go back to [the original design](https://github.com/instedd/surveda/issues/545#issuecomment-272258190) of the questionnaire export regarding audio files. The only difference with this design is that the `.mp3` was added at the end of the file since this is the only audio type that's being stored in the DB for a very long time.

❗ The considerations

With the current design, audio files are being shared between questionnaires (and projects).
They don't _belong_ to the questionnaire nor the project.
I don't know if this is a problem because the user can't erase (nor change) them from the DB.  

🏃 The technical debt

It was manually tested because there are no tests regarding questionnaire export/import.

Fix #1708 