### PR TITLE
Handle properly showing the user name in activity log when it's missing

### DIFF
--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -422,6 +422,7 @@ defmodule Ask.ProjectControllerTest do
       conn = get conn, project_activities_path(conn, :activities, project.id)
       assert json_response(conn, 200)["data"]["activities"] == [
         %{"user_name" => user.name,
+          "user_email" => user.email,
           "action" => "create_invite",
           "entity_type" => "project",
           "id" => create_invite_id,
@@ -434,6 +435,7 @@ defmodule Ask.ProjectControllerTest do
           }
         },
         %{"user_name" => user.name,
+          "user_email" => user.email,
           "action" => "enable_public_link",
           "entity_type" => "survey",
           "id" => enable_link_id,
@@ -512,6 +514,7 @@ defmodule Ask.ProjectControllerTest do
       conn = get conn, project_activities_path(conn, :activities, project.id)
       assert json_response(conn, 200)["data"]["activities"] == [
         %{"user_name" => user.name,
+          "user_email" => user.email,
           "action" => "create_invite",
           "entity_type" => "project",
           "id" => create_invite_log.id,

--- a/web/static/js/components/activity/ActivityIndex.jsx
+++ b/web/static/js/components/activity/ActivityIndex.jsx
@@ -48,14 +48,11 @@ class ActivityIndex extends Component {
       onPreviousPage={() => this.previousPage()}
       onNextPage={() => this.nextPage()} />
 
-    const userContent = (userName, remoteIp) => {
-      if (userName) {
-        return userName
-      } else if (remoteIp == '0.0.0.0') {
-        return t('Background process')
-      } else {
-        return remoteIp
-      }
+    const userContent = (userName, userEmail, remoteIp) => {
+      if (userName) return userName
+      if (userEmail) return userEmail
+      if (remoteIp == '0.0.0.0') return t('Background process')
+      return remoteIp
     }
 
     return (<div>
@@ -71,7 +68,7 @@ class ActivityIndex extends Component {
           {activities.map(activity => {
             return (
               <tr key={activity.id}>
-                <td>{userContent(activity.userName, activity.remoteIp)}</td>
+                <td>{userContent(activity.userName, activity.userEmail, activity.remoteIp)}</td>
                 <td>
                   <ActivityDescription activity={activity} />
                 </td>

--- a/web/views/project_view.ex
+++ b/web/views/project_view.ex
@@ -42,8 +42,20 @@ defmodule Ask.ProjectView do
     %{data: %{activities: render_many(activities, Ask.ProjectView, "activity.json", as: :activity)}, meta: %{count: activities_count}}
   end
 
+  def render("activity.json", %{activity: %{user: %{name: name, email: email}} = activity}) do
+    render_basic("activity.json", %{activity: activity})
+    |> Map.merge(%{
+      user_name: name,
+      user_email: email
+    })
+  end
+
   def render("activity.json", %{activity: activity}) do
-    %{user_name: (if activity.user, do: activity.user.name, else: nil),
+    render_basic("activity.json", %{activity: activity})
+  end
+
+  defp render_basic("activity.json", %{activity: activity}) do
+    %{
       remote_ip: activity.remote_ip,
       action: activity.action,
       entity_type: activity.entity_type,


### PR DESCRIPTION
🐛 The bug

We aren't handling properly showing the user name (that's not a required field) in the activity log when it's missing.
When the user name is missing, we're showing the IP of the activity log despite showing the user email is a much more logical decision. 

🚧 The fix

When the username is missing, show the user email, that's a required field

Fix #1688