### PR TITLE
Avoid showing onboarding to fresh users when quex is not empty

### DIFF
--- a/web/static/js/components/questionnaires/QuestionnaireEditor.jsx
+++ b/web/static/js/components/questionnaires/QuestionnaireEditor.jsx
@@ -280,7 +280,7 @@ class QuestionnaireEditor extends Component<any, State> {
   }
 
   render() {
-    const { questionnaire,  questionnaireHasSections, errors, project, readOnly, userSettings, errorsByPath, selectedSteps, selectedQuotaCompletedSteps, uploadId, uploadError, uploadProgress, userLevel, t } = this.props
+    const { questionnaire, questionnaireHasSections, errors, project, readOnly, userSettings, errorsByPath, selectedSteps, selectedQuotaCompletedSteps, uploadId, uploadError, uploadProgress, userLevel, t } = this.props
 
     if (questionnaire == null || project == null || userSettings.settings == null) {
       return <div>Loading...</div>
@@ -295,7 +295,7 @@ class QuestionnaireEditor extends Component<any, State> {
     const settings = userSettings.settings
     // emptyQuestionnaire is to show onboarding to fresh users with write level in new or empty questionnaires. As questionnaires are created with an empty step, all this conditions are necessary to check if it is actually empty
     const emptyChoices = questionnaire.steps[0].choices && questionnaire.steps[0].choices.length == 0
-    const emptyQuestionnaire = !questionnaireHasSections && !questionnaire.name && questionnaire.steps.length == 1 && questionnaire.steps[0].title == "" && emptyChoices
+    const emptyQuestionnaire = !questionnaireHasSections && !questionnaire.name && questionnaire.steps.length == 1 && questionnaire.steps[0].title == '' && emptyChoices
     const skipOnboarding = !emptyQuestionnaire || (settings.onboarding && settings.onboarding.questionnaire) || userLevel == 'reader'
     const hasQuotaCompletedSteps = !!questionnaire.quotaCompletedSteps
     const partialRelevantEnabled = questionnaire.partialRelevantConfig && questionnaire.partialRelevantConfig.enabled

--- a/web/static/js/components/questionnaires/QuestionnaireEditor.jsx
+++ b/web/static/js/components/questionnaires/QuestionnaireEditor.jsx
@@ -280,7 +280,7 @@ class QuestionnaireEditor extends Component<any, State> {
   }
 
   render() {
-    const { questionnaire, errors, project, readOnly, userSettings, errorsByPath, selectedSteps, selectedQuotaCompletedSteps, uploadId, uploadError, uploadProgress, userLevel, t } = this.props
+    const { questionnaire,  questionnaireHasSections, errors, project, readOnly, userSettings, errorsByPath, selectedSteps, selectedQuotaCompletedSteps, uploadId, uploadError, uploadProgress, userLevel, t } = this.props
 
     if (questionnaire == null || project == null || userSettings.settings == null) {
       return <div>Loading...</div>
@@ -293,7 +293,10 @@ class QuestionnaireEditor extends Component<any, State> {
     }
 
     const settings = userSettings.settings
-    const skipOnboarding = (settings.onboarding && settings.onboarding.questionnaire) || userLevel == 'reader'
+    // emptyQuestionnaire is to show onboarding to fresh users with write level in new or empty questionnaires. As questionnaires are created with an empty step, all this conditions are necessary to check if it is actually empty
+    const emptyChoices = questionnaire.steps[0].choices && questionnaire.steps[0].choices.length == 0
+    const emptyQuestionnaire = !questionnaireHasSections && !questionnaire.name && questionnaire.steps.length == 1 && questionnaire.steps[0].title == "" && emptyChoices
+    const skipOnboarding = !emptyQuestionnaire || (settings.onboarding && settings.onboarding.questionnaire) || userLevel == 'reader'
     const hasQuotaCompletedSteps = !!questionnaire.quotaCompletedSteps
     const partialRelevantEnabled = questionnaire.partialRelevantConfig && questionnaire.partialRelevantConfig.enabled
     const partialRelevantMinRelevantSteps = partialRelevantEnabled && questionnaire.partialRelevantConfig.minRelevantSteps

--- a/web/static/js/components/questionnaires/QuestionnaireEditor.jsx
+++ b/web/static/js/components/questionnaires/QuestionnaireEditor.jsx
@@ -294,8 +294,8 @@ class QuestionnaireEditor extends Component<any, State> {
 
     const settings = userSettings.settings
     // emptyQuestionnaire is to show onboarding to fresh users with write level in new or empty questionnaires. As questionnaires are created with an empty step, all this conditions are necessary to check if it is actually empty
-    const emptyChoices = questionnaire.steps[0].choices && questionnaire.steps[0].choices.length == 0
-    const emptyQuestionnaire = !questionnaireHasSections && !questionnaire.name && questionnaire.steps.length == 1 && questionnaire.steps[0].title == '' && emptyChoices
+    const emptyChoices = questionnaire.steps.length == 0 || (questionnaire.steps[0].choices && questionnaire.steps[0].choices.length == 0)
+    const emptyQuestionnaire = !questionnaireHasSections && !questionnaire.name && (questionnaire.steps.length == 0 || (questionnaire.steps[0].title == '' && emptyChoices))
     const skipOnboarding = !emptyQuestionnaire || (settings.onboarding && settings.onboarding.questionnaire) || userLevel == 'reader'
     const hasQuotaCompletedSteps = !!questionnaire.quotaCompletedSteps
     const partialRelevantEnabled = questionnaire.partialRelevantConfig && questionnaire.partialRelevantConfig.enabled


### PR DESCRIPTION
Quex are created with an empty step, so to check if this was the case it checks many things. This is not the perfect solution, but for now it kinda works. This should be reviewed later on.

Fixes #1690 