### PR TITLE
Fix: expired Verboice calls aren't queued

### DIFF
--- a/lib/ask/runtime/verboice_channel.ex
+++ b/lib/ask/runtime/verboice_channel.ex
@@ -389,6 +389,7 @@ defmodule Ask.Runtime.VerboiceChannel do
         {:ok, %{"state" => "completed"}} -> false
         {:ok, %{"state" => "failed"}} -> false
         {:ok, %{"state" => "canceled"}} -> false
+        {:ok, %{"state" => "expired"}} -> false
         {:ok, %{"state" => _}} -> true
         _ -> false
       end


### PR DESCRIPTION
If the pre-existing Verboice call is expired, it isn't queued anymore since it won't be attempted in the future.

By changing this function, we enable the Session to queue a new call if the previous one was expired and we missed the expiration callback.

There are no other uses of this function except on [`Session#timeout/1`](https://github.com/instedd/surveda/blob/c3db61cfc6120cfba55c99dc328a5928012c2ba7/lib/ask/runtime/session.ex#L48) where we want to make the change of behaviour.

Fix #1732