### PR TITLE
Treat Partial and Interim partial as Completed in Survey metrics

### DIFF
--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -459,7 +459,7 @@ defmodule Ask.SurveyControllerTest do
         "success_rate" => 0.667,
         "completion_rate" => 1.0,
         "estimated_success_rate" => 0.667
-      } = testing_survey(%{user: user, cutoff: 2, respondents: respondents})
+      } = testing_survey(%{user: user, respondents: respondents, attrs: %{cutoff: 2}})
         |> get_stats(conn)
     end
 
@@ -476,18 +476,18 @@ defmodule Ask.SurveyControllerTest do
 
     test "estimated success rate is calculated using linear interpolation", %{conn: conn, user: user} do
       respondents = Enum.map(1..3, fn _ -> %{disposition: "failed"} end) ++ [%{disposition: "completed"}]
-      %{"estimated_success_rate" => 0.85} = testing_survey(%{user: user, cutoff: 5, respondents: respondents})
+      %{"estimated_success_rate" => 0.85} = testing_survey(%{user: user, respondents: respondents, attrs: %{cutoff: 5}})
         |> get_stats(conn)
     end
 
     test "additional respondents are never less than zero", %{conn: conn, user: user} do
       respondents = Enum.map(1..2, fn _ -> %{disposition: "queued"} end)
-      %{"additional_respondents" => 0} = testing_survey(%{user: user, cutoff: 1, respondents: respondents})
+      %{"additional_respondents" => 0} = testing_survey(%{user: user, respondents: respondents, attrs: %{cutoff: 1}})
         |> get_stats(conn)
     end
 
     test "expose correctly respondents in final dispositions", %{conn: conn, user: user} do
-      final_dispositions = Respondent.final_dispositions()
+      final_dispositions = Respondent.metrics_final_dispositions()
       respondents = Enum.map(final_dispositions, fn disposition -> %{disposition: disposition} end)
       %{"exhausted" => exhausted, "available" => 0} = testing_survey(%{user: user, respondents: respondents})
         |> get_stats(conn)
@@ -495,7 +495,7 @@ defmodule Ask.SurveyControllerTest do
     end
 
     test "expose correctly respondents in non final dispositions", %{conn: conn, user: user} do
-      non_final_dispositions = Respondent.non_final_dispositions()
+      non_final_dispositions = Respondent.metrics_non_final_dispositions()
       respondents = Enum.map(non_final_dispositions, fn disposition -> %{disposition: disposition} end)
       %{"exhausted" => 0, "available" => available} = testing_survey(%{user: user, respondents: respondents})
         |> get_stats(conn)
@@ -509,44 +509,146 @@ defmodule Ask.SurveyControllerTest do
     end
 
     test "needed to complete equals target with no respondents", %{conn: conn, user: user} do
-      %{"needed_to_complete" => 5} = testing_survey(%{user: user, respondents: [], cutoff: 5})
+      %{"needed_to_complete" => 5} = testing_survey(%{user: user, respondents: [], attrs: %{cutoff: 5}})
         |> get_stats(conn)
     end
 
     test "additional_completes equals target - completed respondents", %{conn: conn, user: user} do
       respondents = Enum.map(["completed", "completed", "queued"], fn disposition -> %{disposition: disposition} end)
-      %{"additional_completes" => 3} = testing_survey(%{user: user, respondents: respondents, cutoff: 5})
+      %{"additional_completes" => 3} = testing_survey(%{user: user, respondents: respondents, attrs: %{cutoff: 5}})
         |> get_stats(conn)
     end
 
     test "needed to complete duplicates additional to complete when estimated success rate is 50%", %{conn: conn, user: user} do
       respondents = Enum.map(1..99, fn _ -> %{disposition: "completed"} end) ++ Enum.map(1..99, fn _ -> %{disposition: "failed"} end)
-      %{"additional_completes" => 1, "needed_to_complete" => 2} = testing_survey(%{user: user, respondents: respondents, cutoff: 100})
+      %{"additional_completes" => 1, "needed_to_complete" => 2} = testing_survey(%{user: user, respondents: respondents, attrs: %{cutoff: 100}})
         |> get_stats(conn)
     end
 
     test "needed to complete equals additional_completes when estimated success rate is 100%", %{conn: conn, user: user} do
       respondents = [%{disposition: "completed"}]
-      %{"additional_completes" => 1, "needed_to_complete" => 1} = testing_survey(%{user: user, respondents: respondents, cutoff: 2})
+      %{"additional_completes" => 1, "needed_to_complete" => 1} = testing_survey(%{user: user, respondents: respondents, attrs: %{cutoff: 2}})
         |> get_stats(conn)
     end
 
     test "additional respondents equals needed to complete - respondents in non final dispositions", %{conn: conn, user: user} do
-      non_final_dispositions = Respondent.non_final_dispositions()
+      non_final_dispositions = Respondent.metrics_non_final_dispositions()
       respondents = [%{disposition: "completed"}] ++ Enum.map(non_final_dispositions, fn disposition -> %{disposition: disposition} end)
-      %{"needed_to_complete" => 100, "additional_respondents" => additional_respondents} = testing_survey(%{user: user, respondents: respondents, cutoff: 101})
+      %{"needed_to_complete" => 100, "additional_respondents" => additional_respondents} = testing_survey(%{user: user, respondents: respondents, attrs: %{cutoff: 101}})
         |> get_stats(conn)
       assert additional_respondents == 100 - Enum.count(non_final_dispositions)
     end
 
     test "additional respondents depends on needed to complete (it doesn't depend on additional_completes)", %{conn: conn, user: user} do
-      non_final_dispositions = Respondent.non_final_dispositions()
+      non_final_dispositions = Respondent.metrics_non_final_dispositions()
       respondents = Enum.map(1..100, fn _ -> %{disposition: "completed"} end) ++ Enum.map(1..100, fn _ -> %{disposition: "failed"} end) ++ Enum.map(non_final_dispositions, fn disposition -> %{disposition: disposition} end)
-      %{"needed_to_complete" => 18, "additional_completes" => 10, "additional_respondents" => additional_respondents} = testing_survey(%{user: user, respondents: respondents, cutoff: 110})
+      %{"needed_to_complete" => 18, "additional_completes" => 10, "additional_respondents" => additional_respondents} = testing_survey(%{user: user, respondents: respondents, attrs: %{cutoff: 110}})
         |> get_stats(conn)
       assert additional_respondents == 18 - Enum.count(non_final_dispositions)
     end
+  end
 
+  describe "count_partial_results stats" do
+    setup %{conn: conn, user: user} do
+      survey = count_partial_results_test_survey(%{
+        count_partial_results: false,
+        disposition: "completed",
+        user: user
+      })
+      completed_test_case_stats = get_stats(survey, conn)
+
+      {:ok, conn: conn, user: user, completed_test_case_stats: completed_test_case_stats}
+    end
+
+    test "treats completed as expected",
+      %{completed_test_case_stats: completed_test_case_stats} do
+
+      %{
+        "initial_success_rate" => initial_success_rate,
+        "completion_rate" => completion_rate,
+        "success_rate" => success_rate,
+        "estimated_success_rate" => estimated_success_rate,
+        "needed_to_complete" => needed_to_complete,
+        "available" => available,
+        "additional_respondents" => additional_respondents
+      } = completed_test_case_stats
+
+      assert initial_success_rate == 1
+      assert completion_rate == 0.333
+      assert success_rate == 0.5
+      assert estimated_success_rate == 0.833
+      assert needed_to_complete == 2
+      assert available == 1
+      assert additional_respondents == 1
+    end
+
+    test "treats partial as completed when count_partial_results",
+      %{conn: conn, user: user, completed_test_case_stats: completed_test_case_stats} do
+      survey = count_partial_results_test_survey(%{
+        count_partial_results: true,
+        disposition: "partial",
+        user: user
+      })
+
+      stats = get_stats(survey, conn)
+
+      assert stats == completed_test_case_stats
+    end
+
+    test "treats interim partial as completed when count_partial_results",
+      %{conn: conn, user: user, completed_test_case_stats: completed_test_case_stats} do
+      survey = count_partial_results_test_survey(%{
+        count_partial_results: true,
+        disposition: "interim partial",
+        user: user
+      })
+
+      stats = get_stats(survey, conn)
+
+      assert stats == completed_test_case_stats
+    end
+
+    test "doesn't treat partial as completed when not count_partial_results",
+      %{conn: conn, user: user, completed_test_case_stats: completed_test_case_stats} do
+      survey = count_partial_results_test_survey(%{
+        count_partial_results: false,
+        disposition: "partial",
+        user: user
+      })
+
+      stats = get_stats(survey, conn)
+
+      refute stats == completed_test_case_stats
+    end
+
+    test "doesn't treat interim partial as completed when not count_partial_results",
+      %{conn: conn, user: user, completed_test_case_stats: completed_test_case_stats} do
+      survey = count_partial_results_test_survey(%{
+        count_partial_results: false,
+        disposition: "interim partial",
+        user: user
+      })
+
+      stats = get_stats(survey, conn)
+
+      refute stats == completed_test_case_stats
+    end
+  end
+
+  defp count_partial_results_test_survey(%{
+      count_partial_results: count_partial_results,
+      disposition: disposition,
+      user: user
+    }) do
+    respondents = Enum.map(
+      [disposition, "failed", "started"],
+      fn disposition -> %{disposition: disposition} end
+    )
+    testing_survey(%{
+      user: user,
+      respondents: respondents,
+      attrs: %{count_partial_results: count_partial_results}
+    })
   end
 
   defp get_stats(%{survey: survey, project: project}, conn) do
@@ -554,15 +656,16 @@ defmodule Ask.SurveyControllerTest do
     json_response(conn, 200)["data"]
   end
 
-  defp testing_survey(%{user: user, cutoff: cutoff, respondents: respondents}) do
+  defp testing_survey(%{user: user, respondents: respondents, attrs: attrs}) do
     project = create_project_for_user(user)
-    survey = if cutoff, do: insert(:survey, project: project, cutoff: cutoff), else: insert(:survey, project: project)
-    survey = Survey |> Repo.get(survey.id)
+    survey = insert(:survey, project: project)
+    survey = if (attrs), do: Survey.changeset(survey, attrs) |> Repo.update!, else: survey
     Enum.each(respondents, fn %{disposition: disposition} -> insert(:respondent, survey: survey, disposition: disposition) end)
     %{project: project, survey: survey}
   end
 
-  defp testing_survey(%{user: user, respondents: respondents}), do: testing_survey(%{user: user, respondents: respondents, cutoff: nil})
+  defp testing_survey(%{user: user, respondents: respondents}), do:
+    testing_survey(%{user: user, respondents: respondents, attrs: nil})
 
   test "retries histograms", %{conn: conn, user: user} do
     project = create_project_for_user(user)

--- a/web/controllers/respondent_controller.ex
+++ b/web/controllers/respondent_controller.ex
@@ -156,10 +156,7 @@ defmodule Ask.RespondentController do
       |> Enum.map(fn {_, c} -> c end)
       |> Enum.sum
 
-    dispositions_for_completion = case survey.count_partial_results do
-      true -> ["completed", "partial", "interim partial"]
-      _ -> ["completed"]
-    end
+    dispositions_for_completion = Respondent.completed_dispositions(survey.count_partial_results)
 
     completed_or_partial = total_respondents_by_disposition
       |> Enum.filter(fn {d, _} -> d in dispositions_for_completion end)

--- a/web/models/respondent.ex
+++ b/web/models/respondent.ex
@@ -117,13 +117,59 @@ defmodule Ask.Respondent do
     "mobile_web_code_#{respondent_id}"
   end
 
-  def final_dispositions do
-    ["failed", "unresponsive", "ineligible", "rejected", "breakoff", "refused", "partial", "completed"]
-  end
+  def completed_dispositions(_count_partial_results \\ false)
 
-  def non_final_dispositions do
-    ["registered", "queued", "contacted", "started", "interim partial"]
-  end
+  def completed_dispositions(false), do: ["completed"]
+
+  def completed_dispositions(true), do:
+    completed_dispositions() ++ ["partial", "interim partial"]
+
+  def final_dispositions(), do: [
+    "failed",
+    "unresponsive",
+    "ineligible",
+    "rejected","breakoff",
+    "refused",
+    "partial",
+    "completed"
+  ]
+
+  def non_final_dispositions(), do: [
+    "registered",
+    "queued",
+    "contacted",
+    "started",
+    "interim partial"
+  ]
+
+  # Interim partial was created to distinguish between the respondents that reached partial but
+  # still can reach a complete and those who cannot. In the context of the current cockpit, it
+  # doesn't make sense to maintain this distinction when Count partial as complete is selected.
+
+  @doc """
+  The dispositions listed here are considered final for metrics.
+  """
+  def metrics_final_dispositions(_count_partial_results \\ false)
+
+  def metrics_final_dispositions(false), do: final_dispositions()
+
+  @doc """
+  Interim partial isn't a final disposition but it's considered final for metrics
+  """
+  def metrics_final_dispositions(true), do: final_dispositions() ++ ["interim partial"]
+
+  @doc """
+  The dispositions listed here are considered non final for metrics.
+  """
+  def metrics_non_final_dispositions(count_partial_results \\ false)
+
+  def metrics_non_final_dispositions(false), do: non_final_dispositions()
+
+  @doc """
+  Interim partial is a non final disposition but it's considered final for metrics
+  """
+  def metrics_non_final_dispositions(true), do:
+    List.delete(non_final_dispositions(), "interim partial")
 
   def add_mode_attempt!(respondent, mode), do: respondent |> changeset(%{stats: Stats.add_attempt(respondent.stats, mode)}) |> Repo.update!
 


### PR DESCRIPTION
When "count partials as completed" is enabled, treat Partial and Interim Partial as Completed in the Survey metrics

Fix #1726