### PR TITLE
Unify respondent locks identifiers

### DIFF
--- a/web/models/respondent.ex
+++ b/web/models/respondent.ex
@@ -150,7 +150,12 @@ defmodule Ask.Respondent do
   Avoid nesting locks to prevent deadlocks
   """
   def with_lock(respondent_id, operation, respondent_modifier \\ fn x -> x end) do
-    Mutex.under(Ask.Mutex, respondent_id, fn ->
+    # `respondent_id` can be either an Integer or its String representation depending on
+    # the caller. Since we need a unified key to access the Mutex, we here convert it to
+    # a string - even if it's in a non-politically-correct way
+    mutex_key = "#{respondent_id}"
+    
+    Mutex.under(Ask.Mutex, mutex_key, fn ->
       respondent = Respondent
                    |> Repo.get(respondent_id)
                    |> respondent_modifier.()


### PR DESCRIPTION
Depending on the caller of the `Respondent.with_lock` function, the respondent_id paremeter was either an Integer or String, so the lock wasn't useful when Broker and Channels callbacks were competing.

We now unify them as strings so they compite for the same lock.

We still enqueue Verboice calls 5 seconds in the future to avoid the callbacks to timeout (see #1623).

Fixes #1737

Co-authored-by: Ana Pérez Ghiglia (@anaPerezGhiglia)