### PR TITLE
Let the user select every field of the survey

### DIFF
--- a/test/controllers/respondent_controller_test.exs
+++ b/test/controllers/respondent_controller_test.exs
@@ -269,8 +269,17 @@ defmodule Ask.RespondentControllerTest do
 
       body = json_response(conn, 200)
       fields = body["meta"]["fields"]
-      assert fields
-      assert Enum.at(fields, 4)["key"] == "Smokes"
+
+      assert_field_at(fields, "fixed", "phone_number", 0)
+      assert_field_at(fields, "fixed", "disposition", 1)
+      assert_field_at(fields, "fixed", "date", 2)
+      assert_field_at(fields, "mode", "sms", 3)
+
+      # The response fields are ordered alphabetically
+      assert_field_at(fields, "response", "Exercises", 4)
+      assert_field_at(fields, "response", "Perfect Number", 5)
+      assert_field_at(fields, "response", "Question", 6)
+      assert_field_at(fields, "response", "Smokes", 7)
     end
 
     test "fetches responses on index", %{conn: conn, user: user} do
@@ -2861,5 +2870,10 @@ defmodule Ask.RespondentControllerTest do
     else
       assert actual == expected
     end
+  end
+
+  defp assert_field_at(fields, type, key, index) do
+    assert Enum.at(fields, index)["type"] == type
+    assert Enum.at(fields, index)["key"] == key
   end
 end

--- a/test/controllers/respondent_controller_test.exs
+++ b/test/controllers/respondent_controller_test.exs
@@ -254,14 +254,23 @@ defmodule Ask.RespondentControllerTest do
 
     test "includes meta with fields in the index response", %{conn: conn, user: user} do
       project = create_project_for_user(user)
-      survey = insert(:survey, project: project)
+
+      questionnaire =
+        insert(
+          :questionnaire,
+          name: "test",
+          project: project,
+          steps: @dummy_steps
+        )
+
+      survey = insert(:survey, project: project, questionnaires: [questionnaire])
 
       conn = get conn, project_survey_respondent_path(conn, :index, project.id, survey.id)
 
       body = json_response(conn, 200)
       fields = body["meta"]["fields"]
       assert fields
-      assert Enum.at(fields, 0)["type"] == "fixed"
+      assert Enum.at(fields, 4)["key"] == "Smokes"
     end
 
     test "fetches responses on index", %{conn: conn, user: user} do

--- a/web/controllers/respondent_controller.ex
+++ b/web/controllers/respondent_controller.ex
@@ -85,10 +85,13 @@ defmodule Ask.RespondentController do
       |> Enum.uniq()
       |> map_fields_with_type(field_type)
 
-  defp index_fields_for_render("response" = field_type, questionnaires),
-    do:
-      all_questionnaires_fields(questionnaires)
-      |> map_fields_with_type(field_type)
+  defp index_fields_for_render("response" = field_type, questionnaires) do
+    order_alphabetically = &(String.downcase(&1) < String.downcase(&2))
+
+    all_questionnaires_fields(questionnaires)
+    |> Enum.sort(&order_alphabetically.(&1, &2))
+    |> map_fields_with_type(field_type)
+  end
 
   defp index_fields_for_render("variant" = _field_type, [] = _survey_comparisons), do: []
 


### PR DESCRIPTION
By computing the fields using the Survey's questionnaires
Instead of the responses of the first request respondents

Fix #1764