### PR TITLE
Add link to wiki disposition flow chart

### DIFF
--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -489,6 +489,7 @@
   "Variable name:": "",
   "Version: {{version}}": "",
   "View advanced search syntax": "",
+  "View disposition flow chart": "",
   "Voice channels": "",
   "Voice message": "",
   "Voice prompt must not be blank": "",

--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -58,6 +58,11 @@
   margin: .5rem 0 2rem;
 }
 
+.disposition-flow-chart-link {
+  font-size: 0.8rem;
+  margin-top: 0.5rem;
+}
+
 .question.left {
   width: 90%;
   .question-icon-label {

--- a/web/static/js/components/surveys/SurveyShow.jsx
+++ b/web/static/js/components/surveys/SurveyShow.jsx
@@ -417,7 +417,17 @@ class SurveyShow extends Component<any, State> {
     return (
       <div className='card overflow'>
         <div className='card-table-title'>
-          {t('Dispositions')}
+          <div>
+            {t('Dispositions')}
+          </div>
+          <div className='disposition-flow-chart-link'>
+            <a
+              href='https://github.com/instedd/surveda/wiki/Disposition-flow-chart'
+              target='_blank'
+            >
+              {t('View disposition flow chart')}
+            </a>
+          </div>
         </div>
         <div className='card-table'>
           <table>


### PR DESCRIPTION
In the survey overview

This is how it looks:

![Dispositions on survey overview](https://user-images.githubusercontent.com/39921597/92288008-d6fa4680-eee1-11ea-92ab-b8a5d353d6d1.png)

Fix #1765