### PR TITLE
Show no surveys message when the project is empty

### DIFF
--- a/web/static/js/actions/folder.js
+++ b/web/static/js/actions/folder.js
@@ -105,7 +105,18 @@ export const fetchFolders = (projectId: number) => (dispatch: Function) => {
 
   return api.fetchFolders(projectId)
     .then(response => {
-      dispatch(fetchedFolders(projectId, response.entities.folders))
+      /*
+        When there are no folders:
+          - the API response is {"data": []}
+          - `response` here is {entities: {}, result: []}
+        When there are folders:
+          - the API response is {"data": [{"project_id": 15, "name": "Foo", "id": 6}]}
+          - `response` here is {entities: {folders: {6: {…}}}, result: [6]}
+
+        When there are no folders `response.entities.folders` is undefined.
+        This is why in this case it's defaulted to an empty array.
+      */
+      dispatch(fetchedFolders(projectId, response.entities.folders || []))
     })
 }
 

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -209,7 +209,7 @@ const mapStateToProps = (state, ownProps) => {
     totalCount,
     loadingSurveys: state.surveys.fetching,
     loadingFolders: state.folder.loadingFetch,
-    folders: state.folder.folders && Object.values(state.folder.folders)
+    folders: (state.folder.folders && Object.values(state.folder.folders)) || []
   }
 }
 

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -209,7 +209,7 @@ const mapStateToProps = (state, ownProps) => {
     totalCount,
     loadingSurveys: state.surveys.fetching,
     loadingFolders: state.folder.loadingFetch,
-    folders: (state.folder.folders && Object.values(state.folder.folders)) || []
+    folders: state.folder.folders && Object.values(state.folder.folders)
   }
 }
 


### PR DESCRIPTION
This is how it looks:

![Empty project](https://user-images.githubusercontent.com/39921597/93828401-9ae51680-fc41-11ea-925d-fdd5c185282e.png)

Fix #1780