### PR TITLE
Limit survey simulation endpoints

### DIFF
--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -577,7 +577,7 @@ defmodule Ask.SurveyControllerTest do
   describe "stop simulation" do
     setup %{conn: conn, user: user} do
       create_running_survey = fn simulation ->
-        [survey, _group, _test_channel, _respondent, _phone_number] =
+        [survey | _tail] =
           create_running_survey_with_channel_and_respondent_with_options(
             user: user,
             simulation: simulation
@@ -617,7 +617,7 @@ defmodule Ask.SurveyControllerTest do
   describe "simulation status" do
     setup %{conn: conn, user: user} do
       create_running_survey = fn simulation ->
-        [survey, _group, _test_channel, _respondent, _phone_number] =
+        [survey | _tail] =
           create_running_survey_with_channel_and_respondent_with_options(
             user: user,
             simulation: simulation
@@ -705,7 +705,7 @@ defmodule Ask.SurveyControllerTest do
       create_running_survey: create_running_survey,
       get_simulation_initial_state: get_simulation_initial_state
     } do
-      [mode, simulation] = ["sms", false]
+      {mode, simulation} = {"sms", false}
       %{survey: survey} = create_running_survey.(mode, simulation)
 
       assert_error_sent(:not_found, fn ->
@@ -717,7 +717,7 @@ defmodule Ask.SurveyControllerTest do
       create_running_survey: create_running_survey,
       get_simulation_initial_state: get_simulation_initial_state
     } do
-      [mode, simulation] = ["sms", true]
+      {mode, simulation} = {"sms", true}
       %{survey: survey} = create_running_survey.(mode, simulation)
 
       conn = get_simulation_initial_state.(survey, mode)
@@ -729,7 +729,7 @@ defmodule Ask.SurveyControllerTest do
       create_running_survey: create_running_survey,
       get_simulation_initial_state: get_simulation_initial_state
     } do
-      [mode, simulation] = ["ivr", true]
+      {mode, simulation} = {"ivr", true}
       %{survey: survey} = create_running_survey.(mode, simulation)
 
       conn = get_simulation_initial_state.(survey, mode)
@@ -741,7 +741,7 @@ defmodule Ask.SurveyControllerTest do
       create_running_survey: create_running_survey,
       get_simulation_initial_state: get_simulation_initial_state
     } do
-      [mode, simulation] = ["mobileweb", true]
+      {mode, simulation} = {"mobileweb", true}
       %{survey: survey} = create_running_survey.(mode, simulation)
 
       conn = get_simulation_initial_state.(survey, mode)
@@ -756,7 +756,7 @@ defmodule Ask.SurveyControllerTest do
       poll_survey: poll_survey,
       get_simulation_initial_state: get_simulation_initial_state
     } do
-      [mode, simulation] = ["mobileweb", true]
+      {mode, simulation} = {"mobileweb", true}
       %{survey: survey, respondent_id: respondent_id} = create_running_survey.(mode, simulation)
       poll_survey.()
 

--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -578,7 +578,11 @@ defmodule Ask.SurveyControllerTest do
     setup %{conn: conn, user: user} do
       create_running_survey = fn simulation ->
         [survey, _group, _test_channel, _respondent, _phone_number] =
-          create_running_survey_with_channel_and_respondent_with_options(user: user, simulation: simulation)
+          create_running_survey_with_channel_and_respondent_with_options(
+            user: user,
+            simulation: simulation
+          )
+
         %{survey: survey}
       end
 
@@ -594,10 +598,7 @@ defmodule Ask.SurveyControllerTest do
         )
       end
 
-      {:ok,
-        create_running_survey: create_running_survey,
-        stop_simulation: stop_simulation
-      }
+      {:ok, create_running_survey: create_running_survey, stop_simulation: stop_simulation}
     end
 
     test "limits endpoint for survey simulations only", %{
@@ -607,18 +608,21 @@ defmodule Ask.SurveyControllerTest do
       simulation = false
       %{survey: survey} = create_running_survey.(simulation)
 
-      assert_error_sent :not_found, fn ->
+      assert_error_sent(:not_found, fn ->
         stop_simulation.(survey)
-      end
+      end)
     end
-
   end
 
   describe "simulation status" do
     setup %{conn: conn, user: user} do
       create_running_survey = fn simulation ->
         [survey, _group, _test_channel, _respondent, _phone_number] =
-          create_running_survey_with_channel_and_respondent_with_options(user: user, simulation: simulation)
+          create_running_survey_with_channel_and_respondent_with_options(
+            user: user,
+            simulation: simulation
+          )
+
         %{survey: survey}
       end
 
@@ -635,9 +639,7 @@ defmodule Ask.SurveyControllerTest do
       end
 
       {:ok,
-        create_running_survey: create_running_survey,
-        get_simulation_status: get_simulation_status
-      }
+       create_running_survey: create_running_survey, get_simulation_status: get_simulation_status}
     end
 
     test "limits endpoint for survey simulations only", %{
@@ -647,18 +649,22 @@ defmodule Ask.SurveyControllerTest do
       simulation = false
       %{survey: survey} = create_running_survey.(simulation)
 
-      assert_error_sent :not_found, fn ->
+      assert_error_sent(:not_found, fn ->
         get_simulation_status.(survey)
-      end
+      end)
     end
-
   end
 
   describe "simulation initial state" do
     setup %{conn: conn, user: user} do
-      create_running_survey = fn (mode, simulation) ->
+      create_running_survey = fn mode, simulation ->
         [survey, _group, _test_channel, respondent, _phone_number] =
-          create_running_survey_with_channel_and_respondent_with_options(user: user, mode: mode, simulation: simulation)
+          create_running_survey_with_channel_and_respondent_with_options(
+            user: user,
+            mode: mode,
+            simulation: simulation
+          )
+
         %{survey: survey, respondent_id: respondent.id}
       end
 
@@ -692,8 +698,7 @@ defmodule Ask.SurveyControllerTest do
        create_running_survey: create_running_survey,
        get_simulation_initial_state: get_simulation_initial_state,
        poll_survey: poll_survey,
-       mobile_contact_messages: mobile_contact_messages
-      }
+       mobile_contact_messages: mobile_contact_messages}
     end
 
     test "limits endpoint for survey simulations only", %{
@@ -703,9 +708,9 @@ defmodule Ask.SurveyControllerTest do
       [mode, simulation] = ["sms", false]
       %{survey: survey} = create_running_survey.(mode, simulation)
 
-      assert_error_sent :not_found, fn ->
+      assert_error_sent(:not_found, fn ->
         get_simulation_initial_state.(survey, mode)
-      end
+      end)
     end
 
     test "SMS return an empty map", %{

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -40,6 +40,7 @@ defmodule Ask.TestHelpers do
         schedule = Keyword.get(options, :schedule, Ask.Schedule.always())
         fallback_delay = Keyword.get(options, :fallback_delay, "10m")
         user = Keyword.get(options, :user, nil)
+        simulation = Keyword.get(options, :simulation, false)
 
         project = if (user), do: create_project_for_user(user), else: nil
         test_channel = Ask.TestChannel.new(false, mode == "sms")
@@ -51,7 +52,7 @@ defmodule Ask.TestHelpers do
 
         channel = insert(:channel, settings: test_channel |> Ask.TestChannel.settings, type: channel_type)
         quiz = insert(:questionnaire, steps: steps, quota_completed_steps: nil)
-        survey = %{schedule: schedule, state: "running", questionnaires: [quiz], mode: [[mode]], fallback_delay: fallback_delay}
+        survey = %{schedule: schedule, state: "running", questionnaires: [quiz], mode: [[mode]], fallback_delay: fallback_delay, simulation: simulation}
         survey = if (project), do: Map.put(survey, :project, project), else: survey
         survey = insert(:survey, survey)
         group = insert(:respondent_group, survey: survey, respondents_count: 1) |> Ask.Repo.preload(:channels)

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -738,17 +738,19 @@ defmodule Ask.SurveyController do
     end
   end
 
-  def simulation_initial_state(conn, %{"project_id" => project_id, "survey_id" => survey_id, "mode" => "mobileweb"}) do
-    project = conn
-    |> load_project(project_id)
-
-    survey = project
+  def simulation_initial_state(conn, %{"project_id" => project_id, "survey_id" => survey_id, "mode" => mode}) do
+    survey = load_project(conn, project_id)
     |> assoc(:surveys)
-    |> Repo.get!(survey_id, simulation: true)
+    |> where([s], s.simulation)
+    |> Repo.get!(survey_id)
 
+    render_initial_state(conn, survey.id, mode)
+  end
+
+  defp render_initial_state(conn, survey_id, "mobileweb" = _mode) do
     # The simulation has only one respondent
     respondent = Repo.one!(from r in Respondent,
-      where: r.survey_id == ^survey.id)
+    where: r.survey_id == ^survey_id)
 
     response = if (respondent.session) do
       session = Session.load_respondent_session(respondent, true)
@@ -766,11 +768,7 @@ defmodule Ask.SurveyController do
     response
   end
 
-  def simulation_initial_state(conn, %{"project_id" => project_id, "survey_id" => survey_id}) do
-    load_project(conn, project_id)
-    |> assoc(:surveys)
-    |> Repo.get!(survey_id, simulation: true)
-
+  defp render_initial_state(conn, _survey_id, _mode) do
     json(conn, %{"data" => %{}})
   end
 

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -406,12 +406,11 @@ defmodule Ask.SurveyController do
   end
 
   def simulation_status(conn, %{"project_id" => project_id, "survey_id" => survey_id}) do
-    project = conn
+    survey = conn
     |> load_project(project_id)
-
-    survey = project
     |> assoc(:surveys)
-    |> Repo.get!(survey_id, simulation: true)
+    |> where([s], s.simulation)
+    |> Repo.get!(survey_id)
 
     # The simulation has only one respondent
     respondent = Repo.one!(from r in Respondent,
@@ -464,7 +463,8 @@ defmodule Ask.SurveyController do
 
     survey = project
     |> assoc(:surveys)
-    |> Repo.get!(survey_id, simulation: true)
+    |> where([s], s.simulation)
+    |> Repo.get!(survey_id)
 
     questionnaire = survey
     |> assoc(:questionnaires)


### PR DESCRIPTION
Before #1787, any survey simulation API endpoint wasn't limiting the actions to survey simulations only.

In #1787 we tried to add this restriction: real surveys can't be stopped, or any other action shouldn't apply to them from the simulation endpoints.

But the solution didn't work. Also, we didn't test it.

So, in this PR, we made these restrictions work and added the corresponding tests.

Fix #1791 