### PR TITLE
Repeat panel survey (API)

### DIFF
--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -1,6 +1,11 @@
 defmodule Ask.Runtime.PanelSurvey do
-  def new_ocurrence(survey) do
-    %{
+  alias Ask.Survey
+  def new_ocurrence_changeset(survey) do
+    survey =
+      survey
+      |> Repo.preload([:project])
+
+    new_ocurrence = %{
       # basic settings
       project_id: survey.project_id,
       folder_id: survey.folder_id,
@@ -22,5 +27,12 @@ defmodule Ask.Runtime.PanelSurvey do
       quota_vars: survey.quota_vars,
       quotas: survey.quotas
     }
+
+    questionnaire_ids = Enum.map(survey.questionnaires, fn q -> q.id end)
+
+    survey.project
+    |> Ecto.build_assoc(:surveys)
+    |> Survey.changeset(new_ocurrence)
+    |> Survey.update_questionnaires(questionnaire_ids)
   end
 end

--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -1,8 +1,9 @@
 defmodule Ask.Runtime.PanelSurvey do
   import Ecto.Query
   alias Ask.{Survey, Repo, Respondent, RespondentGroupChannel}
+
   def new_ocurrence_changeset(survey) do
-    unless survey.latest_panel_survey, do: raise "Only the latest occurrence can be repeated"
+    unless survey.latest_panel_survey, do: raise("Only the latest occurrence can be repeated")
 
     survey =
       survey
@@ -41,39 +42,41 @@ defmodule Ask.Runtime.PanelSurvey do
 
   def copy_respondents(current_occurrence, new_occurrence) do
     current_occurrence =
-    current_occurrence
+      current_occurrence
       |> Repo.preload([:respondent_groups])
 
     # TODO: Improve the following respondent group creation logic.
     # For each existing group a new respondent group with the same name is created. Each
     # respondent group has a copy of every respondent (except refused) and channel association
-    respondent_group_ids = Enum.map(current_occurrence.respondent_groups, fn respondent_group ->
-      phone_numbers =
-      (
-        from r in Respondent,
-        where: r.respondent_group_id == ^respondent_group.id and r.disposition != "refused",
-        select: r.phone_number
-      )
-      |> Repo.all
+    respondent_group_ids =
+      Enum.map(current_occurrence.respondent_groups, fn respondent_group ->
+        phone_numbers =
+          from(r in Respondent,
+            where: r.respondent_group_id == ^respondent_group.id and r.disposition != "refused",
+            select: r.phone_number
+          )
+          |> Repo.all()
 
-      new_respondent_group = Ask.Runtime.RespondentGroup.create(respondent_group.name, phone_numbers, new_occurrence)
-      copy_respondent_group_channels(respondent_group, new_respondent_group)
-      new_respondent_group.id
-    end)
+        new_respondent_group =
+          Ask.Runtime.RespondentGroup.create(respondent_group.name, phone_numbers, new_occurrence)
+
+        copy_respondent_group_channels(respondent_group, new_respondent_group)
+        new_respondent_group.id
+      end)
 
     new_occurrence
     |> Repo.preload(:respondent_groups)
-    |> Survey.changeset
+    |> Survey.changeset()
     |> Survey.update_respondent_groups(respondent_group_ids)
-    |> Repo.update!
+    |> Repo.update!()
   end
 
   defp copy_respondent_group_channels(respondent_group, new_respondent_group) do
     respondent_group =
-    respondent_group
+      respondent_group
       |> Repo.preload(:respondent_group_channels)
 
-    Repo.transaction fn ->
+    Repo.transaction(fn ->
       Enum.each(
         respondent_group.respondent_group_channels,
         fn respondent_group_channel ->
@@ -85,9 +88,9 @@ defmodule Ask.Runtime.PanelSurvey do
               mode: respondent_group_channel.mode
             }
           )
-          |> Repo.insert!
+          |> Repo.insert!()
         end
       )
-    end
+    end)
   end
 end

--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -3,7 +3,9 @@ defmodule Ask.Runtime.PanelSurvey do
   alias Ask.{Survey, Repo, Respondent, RespondentGroupChannel}
 
   def new_ocurrence_changeset(survey) do
+    unless Survey.panel_survey?(survey), do: raise("Only panel surveys can be repeated")
     unless survey.latest_panel_survey, do: raise("Only the latest occurrence can be repeated")
+    unless Survey.succeeded?(survey), do: raise("Only succeeded surveys can be repeated")
 
     survey =
       survey

--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -3,9 +3,7 @@ defmodule Ask.Runtime.PanelSurvey do
   alias Ask.{Survey, Repo, Respondent, RespondentGroupChannel}
 
   def new_ocurrence_changeset(survey) do
-    unless Survey.panel_survey?(survey), do: raise("Only panel surveys can be repeated")
-    unless survey.latest_panel_survey, do: raise("Only the latest occurrence can be repeated")
-    unless Survey.succeeded?(survey), do: raise("Only succeeded surveys can be repeated")
+    unless Survey.repeatable?(survey), do: raise("Panel survey isn't repeatable")
 
     survey =
       survey

--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -1,0 +1,26 @@
+defmodule Ask.Runtime.PanelSurvey do
+  def new_ocurrence(survey) do
+    %{
+      # basic settings
+      project_id: survey.project_id,
+      folder_id: survey.folder_id,
+      name: survey.name,
+      description: survey.description,
+      mode: survey.mode,
+      state: "ready",
+      started_at: Timex.now(),
+      panel_survey_of: survey.panel_survey_of,
+      latest_panel_survey: true,
+      # advanced settings
+      cutoff: survey.cutoff,
+      count_partial_results: survey.count_partial_results,
+      schedule: survey.schedule,
+      sms_retry_configuration: survey.sms_retry_configuration,
+      ivr_retry_configuration: survey.ivr_retry_configuration,
+      mobileweb_retry_configuration: survey.mobileweb_retry_configuration,
+      fallback_delay: survey.fallback_delay,
+      quota_vars: survey.quota_vars,
+      quotas: survey.quotas
+    }
+  end
+end

--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -1,6 +1,9 @@
 defmodule Ask.Runtime.PanelSurvey do
-  alias Ask.Survey
+  import Ecto.Query
+  alias Ask.{Survey, Repo, Respondent, RespondentGroupChannel}
   def new_ocurrence_changeset(survey) do
+    unless survey.latest_panel_survey, do: raise "Only the latest occurrence can be repeated"
+
     survey =
       survey
       |> Repo.preload([:project])
@@ -34,5 +37,57 @@ defmodule Ask.Runtime.PanelSurvey do
     |> Ecto.build_assoc(:surveys)
     |> Survey.changeset(new_ocurrence)
     |> Survey.update_questionnaires(questionnaire_ids)
+  end
+
+  def copy_respondents(current_occurrence, new_occurrence) do
+    current_occurrence =
+    current_occurrence
+      |> Repo.preload([:respondent_groups])
+
+    # TODO: Improve the following respondent group creation logic.
+    # For each existing group a new respondent group with the same name is created. Each
+    # respondent group has a copy of every respondent (except refused) and channel association
+    respondent_group_ids = Enum.map(current_occurrence.respondent_groups, fn respondent_group ->
+      phone_numbers =
+      (
+        from r in Respondent,
+        where: r.respondent_group_id == ^respondent_group.id and r.disposition != "refused",
+        select: r.phone_number
+      )
+      |> Repo.all
+
+      new_respondent_group = Ask.Runtime.RespondentGroup.create(respondent_group.name, phone_numbers, new_occurrence)
+      copy_respondent_group_channels(respondent_group, new_respondent_group)
+      new_respondent_group.id
+    end)
+
+    new_occurrence
+    |> Repo.preload(:respondent_groups)
+    |> Survey.changeset
+    |> Survey.update_respondent_groups(respondent_group_ids)
+    |> Repo.update!
+  end
+
+  defp copy_respondent_group_channels(respondent_group, new_respondent_group) do
+    respondent_group =
+    respondent_group
+      |> Repo.preload(:respondent_group_channels)
+
+    Repo.transaction fn ->
+      Enum.each(
+        respondent_group.respondent_group_channels,
+        fn respondent_group_channel ->
+          RespondentGroupChannel.changeset(
+            %RespondentGroupChannel{},
+            %{
+              respondent_group_id: new_respondent_group.id,
+              channel_id: respondent_group_channel.channel_id,
+              mode: respondent_group_channel.mode
+            }
+          )
+          |> Repo.insert!
+        end
+      )
+    end
   end
 end

--- a/lib/ask/runtime/respondent_group.ex
+++ b/lib/ask/runtime/respondent_group.ex
@@ -1,0 +1,63 @@
+defmodule Ask.Runtime.RespondentGroup do
+  alias Ask.{Survey, Repo, Respondent, Stats, RespondentGroup}
+  alias Ecto.Changeset
+
+  def create(name, phone_numbers, survey) do
+    sample = phone_numbers |> Enum.take(5)
+    respondents_count = phone_numbers |> length
+
+    respondent_group =
+      %RespondentGroup{
+        name: name,
+        survey_id: survey.id,
+        sample: sample,
+        respondents_count: respondents_count
+      }
+      |> Repo.insert!()
+      |> Repo.preload(:respondent_group_channels)
+
+    insert_respondents(phone_numbers, respondent_group)
+
+    survey
+    |> Repo.preload([:questionnaires])
+    |> Repo.preload([:quota_buckets])
+    |> Repo.preload(respondent_groups: [respondent_group_channels: :channel])
+    |> Changeset.change()
+    |> Survey.update_state()
+    |> Repo.update!()
+
+    respondent_group
+  end
+
+  def insert_respondents(phone_numbers, respondent_group) do
+    respondent_group = Repo.preload(respondent_group, [survey: :project])
+
+    map_respondent = fn phone_number ->
+      canonical_number = Respondent.canonicalize_phone_number(phone_number)
+
+      %{
+        phone_number: phone_number,
+        sanitized_phone_number: canonical_number,
+        canonical_phone_number: canonical_number,
+        survey_id: respondent_group.survey_id,
+        respondent_group_id: respondent_group.id,
+        hashed_number: Respondent.hash_phone_number(phone_number, respondent_group.survey.project.salt),
+        disposition: "registered",
+        stats: %Stats{},
+        user_stopped: false,
+        inserted_at: Timex.now(),
+        updated_at: Timex.now()
+      }
+    end
+
+    insert_respondents = fn respondents ->
+      Repo.insert_all(Respondent, respondents)
+    end
+
+    Stream.map(phone_numbers, map_respondent)
+    # Insert all respondent in the sample in chunks of 1K
+    |> Stream.chunk_every(1_000)
+    |> Stream.each(insert_respondents)
+    |> Stream.run()
+  end
+end

--- a/lib/ask/runtime/respondent_group.ex
+++ b/lib/ask/runtime/respondent_group.ex
@@ -30,7 +30,7 @@ defmodule Ask.Runtime.RespondentGroup do
   end
 
   def insert_respondents(phone_numbers, respondent_group) do
-    respondent_group = Repo.preload(respondent_group, [survey: :project])
+    respondent_group = Repo.preload(respondent_group, survey: :project)
 
     map_respondent = fn phone_number ->
       canonical_number = Respondent.canonicalize_phone_number(phone_number)
@@ -41,7 +41,8 @@ defmodule Ask.Runtime.RespondentGroup do
         canonical_phone_number: canonical_number,
         survey_id: respondent_group.survey_id,
         respondent_group_id: respondent_group.id,
-        hashed_number: Respondent.hash_phone_number(phone_number, respondent_group.survey.project.salt),
+        hashed_number:
+          Respondent.hash_phone_number(phone_number, respondent_group.survey.project.salt),
         disposition: "registered",
         stats: %Stats{},
         user_stopped: false,

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -122,21 +122,12 @@ defmodule Ask.Runtime.SurveyAction do
       |> Repo.preload([:project])
       |> Repo.preload([:questionnaires])
 
-    new_ocurrence = PanelSurvey.new_ocurrence(survey)
-    questionnaire_ids = Enum.map(survey.questionnaires, fn q -> q.id end)
-
-    insert_changeset =
-      survey.project
-      |> Ecto.build_assoc(:surveys)
-      |> Survey.changeset(new_ocurrence)
-      |> Survey.update_questionnaires(questionnaire_ids)
-
     update_changeset = Survey.changeset(survey, %{latest_panel_survey: false})
 
     multi =
       Multi.new()
       |> Multi.update(:update, update_changeset)
-      |> Multi.insert(:insert, insert_changeset)
+      |> Multi.insert(:insert, PanelSurvey.new_ocurrence_changeset(survey))
       |> Repo.transaction()
 
     case multi do

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -1,0 +1,150 @@
+defmodule Ask.Runtime.SurveyAction do
+  alias Ask.{Survey, Logger, Repo, Questionnaire}
+  alias Ask.Runtime.PanelSurvey
+  alias Ecto.Multi
+
+  def start(survey, options \\ []) do
+    survey =
+      survey
+      |> Repo.preload([:project])
+      |> Repo.preload([:quota_buckets])
+      |> Repo.preload([:questionnaires])
+      |> Repo.preload(respondent_groups: :channels)
+
+    if survey.state == "ready" do
+      channels =
+        survey.respondent_groups
+        |> Enum.flat_map(& &1.channels)
+        |> Enum.uniq()
+
+      case prepare_channels(channels) do
+        :ok ->
+          repetition? = Keyword.get(options, :repetition?, false)
+          perform_start(survey, repetition?)
+
+        {:error, reason} ->
+          Logger.warn(
+            "Error when preparing channels for launching survey #{survey.id} (#{reason})"
+          )
+
+          {:error, %{survey: survey}}
+      end
+    else
+      Logger.warn("Error when launching survey #{survey.id}. State is not ready ")
+      {:error, %{survey: survey}}
+    end
+  end
+
+  def repeat(survey) do
+    if Survey.succeeded?(survey) and Survey.panel_survey?(survey) do
+      case create_panel_survey_occurrence(survey) do
+        {:ok, %{survey: new_occurrence}} ->
+          start(new_occurrence, repetition?: true)
+
+        result ->
+          result
+      end
+    else
+      Logger.warn(
+        "Survey #{survey.id} can't be repeated because it's not a panel survey or it didn's succeeded"
+      )
+
+      {:error, %{survey: survey}}
+    end
+  end
+
+  defp perform_start(survey, repetition?) do
+    changeset = Survey.changeset(survey, %{state: "running", started_at: Timex.now()})
+
+    case Repo.update(changeset) do
+      {:ok, _} ->
+        survey = if repetition?, do: survey, else: create_survey_questionnaires_snapshot(survey)
+
+        {:ok, %{survey: survey}}
+
+      {:error, _, changeset, _} ->
+        Logger.warn("Error when launching survey: #{inspect(changeset)}")
+        {:error, %{changeset: changeset}}
+    end
+  end
+
+  defp prepare_channels([]), do: :ok
+
+  defp prepare_channels([channel | rest]) do
+    runtime_channel = Ask.Channel.runtime_channel(channel)
+
+    case Ask.Runtime.Channel.prepare(runtime_channel) do
+      {:ok, _} -> prepare_channels(rest)
+      error -> error
+    end
+  end
+
+  defp create_survey_questionnaires_snapshot(survey) do
+    # Create copies of questionnaires
+    new_questionnaires =
+      Enum.map(survey.questionnaires, fn questionnaire ->
+        %{
+          questionnaire
+          | id: nil,
+            snapshot_of_questionnaire: questionnaire,
+            questionnaire_variables: [],
+            project: survey.project
+        }
+        |> Repo.preload(:translations)
+        |> Repo.insert!()
+        |> Questionnaire.recreate_variables!()
+      end)
+
+    # Update references in comparisons, if any
+    comparisons = survey.comparisons
+
+    comparisons =
+      if comparisons do
+        comparisons
+        |> Enum.map(fn comparison ->
+          questionnaire_id = Map.get(comparison, "questionnaire_id")
+          snapshot = Enum.find(new_questionnaires, fn q -> q.snapshot_of == questionnaire_id end)
+          Map.put(comparison, "questionnaire_id", snapshot.id)
+        end)
+      else
+        comparisons
+      end
+
+    survey
+    |> Survey.changeset(%{comparisons: comparisons})
+    |> Ecto.Changeset.put_assoc(:questionnaires, new_questionnaires)
+    |> Repo.update!()
+  end
+
+  defp create_panel_survey_occurrence(survey) do
+    survey =
+      survey
+      |> Repo.preload([:project])
+      |> Repo.preload([:questionnaires])
+
+    new_ocurrence = PanelSurvey.new_ocurrence(survey)
+    questionnaire_ids = Enum.map(survey.questionnaires, fn q -> q.id end)
+
+    insert_changeset =
+      survey.project
+      |> Ecto.build_assoc(:surveys)
+      |> Survey.changeset(new_ocurrence)
+      |> Survey.update_questionnaires(questionnaire_ids)
+
+    update_changeset = Survey.changeset(survey, %{latest_panel_survey: false})
+
+    multi =
+      Multi.new()
+      |> Multi.update(:update, update_changeset)
+      |> Multi.insert(:insert, insert_changeset)
+      |> Repo.transaction()
+
+    case multi do
+      {:ok, %{insert: survey}} ->
+        {:ok, %{survey: survey}}
+
+      {:error, _, changeset, _} ->
+        {:error, %{changeset: changeset}}
+    end
+  end
+end

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -133,8 +133,7 @@ defmodule Ask.Runtime.SurveyAction do
 
     case multi do
       {:ok, %{new_occurrence: new_occurrence}} ->
-        new_occurrence =
-          PanelSurvey.copy_respondents(survey, new_occurrence)
+        new_occurrence = PanelSurvey.copy_respondents(survey, new_occurrence)
 
         {:ok, %{survey: new_occurrence}}
 

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -36,7 +36,7 @@ defmodule Ask.Runtime.SurveyAction do
   end
 
   def repeat(survey) do
-    if Survey.succeeded?(survey) and Survey.panel_survey?(survey) and survey.latest_panel_survey do
+    if Survey.repeatable?(survey) do
       case create_panel_survey_occurrence(survey) do
         {:ok, %{survey: new_occurrence}} ->
           start(new_occurrence, repetition?: true)
@@ -46,7 +46,7 @@ defmodule Ask.Runtime.SurveyAction do
       end
     else
       Logger.warn(
-        "Survey #{survey.id} can't be repeated because it isn't a panel survey, it isn't the latest occurrence or it didn't succeeded"
+        "Survey #{survey.id} isn't repeatable"
       )
 
       {:error, %{survey: survey}}

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -36,7 +36,7 @@ defmodule Ask.Runtime.SurveyAction do
   end
 
   def repeat(survey) do
-    if Survey.succeeded?(survey) and Survey.panel_survey?(survey) do
+    if Survey.succeeded?(survey) and Survey.panel_survey?(survey) and survey.latest_panel_survey do
       case create_panel_survey_occurrence(survey) do
         {:ok, %{survey: new_occurrence}} ->
           start(new_occurrence, repetition?: true)
@@ -46,7 +46,7 @@ defmodule Ask.Runtime.SurveyAction do
       end
     else
       Logger.warn(
-        "Survey #{survey.id} can't be repeated because it's not a panel survey or it didn's succeeded"
+        "Survey #{survey.id} can't be repeated because it isn't a panel survey, it isn't the latest occurrence or it didn't succeeded"
       )
 
       {:error, %{survey: survey}}

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -348,7 +348,6 @@ defmodule Ask.SurveyController do
       render(conn, "show.json",
         survey:
           survey
-          |> Repo.preload(:questionnaires)
           |> Survey.with_links(user_level(survey.project_id, current_user(conn).id))
       )
 

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -18,6 +18,7 @@ defmodule Ask.SurveyController do
     dynamic =
       if params["state"] do
         if params["state"] == "completed" do
+          # Same as Survey.succeeded?(s)
           dynamic([s], s.state == "terminated" and s.exit_code == 0 and ^dynamic)
         else
           dynamic([s], s.state == ^params["state"] and ^dynamic)
@@ -264,13 +265,8 @@ defmodule Ask.SurveyController do
     end
   end
 
-  defp update_questionnaires(changeset, %{"questionnaire_ids" => questionnaires_params}) do
-    questionnaires_changeset = Enum.map(questionnaires_params, fn ch ->
-      Repo.get!(Questionnaire, ch) |> change
-    end)
-
-    changeset
-    |> put_assoc(:questionnaires, questionnaires_changeset)
+  defp update_questionnaires(changeset, %{"questionnaire_ids" => questionnaires_ids}) do
+    Survey.update_questionnaires(changeset, questionnaires_ids)
   end
 
   defp update_questionnaires(changeset, _) do
@@ -307,57 +303,54 @@ defmodule Ask.SurveyController do
     end
   end
 
-  def launch(conn, %{"survey_id" => id}) do
-    survey = Repo.get!(Survey, id)
-    |> Repo.preload([:project])
-    |> Repo.preload([:quota_buckets])
-    |> Repo.preload([:questionnaires])
-    |> Repo.preload(respondent_groups: :channels)
+  def launch(conn, %{"project_id" => project_id, "survey_id" => survey_id}) do
+    perform_action = fn survey -> Ask.Runtime.SurveyAction.start(survey) end
+    activity_log = fn survey -> ActivityLog.start(survey.project, conn, survey) end
+    launch_or_repeat(conn, project_id, survey_id, perform_action, activity_log)
+  end
 
-    if survey.state != "ready" do
-      Logger.warn "Error when launching survey #{id}. State is not ready "
+  def repeat(conn, %{"project_id" => project_id, "survey_id" => survey_id}) do
+    perform_action = fn survey -> Ask.Runtime.SurveyAction.repeat(survey) end
+    activity_log = fn survey -> ActivityLog.repeat(survey.project, conn, survey) end
+    launch_or_repeat(conn, project_id, survey_id, perform_action, activity_log)
+  end
+
+  defp launch_or_repeat(conn, project_id, survey_id, perform_action, activity_log) do
+    project =
       conn
+      |> load_project_for_change(project_id)
+
+    survey =
+      project
+      |> assoc(:surveys)
+      |> Repo.get!(survey_id)
+
+    case perform_action.(survey) do
+      {:ok, %{survey: survey}} ->
+        Project.touch!(survey.project)
+        activity_log.(survey) |> Repo.insert!()
+        render_survey(conn, survey)
+
+      {:error, %{survey: survey}} ->
+        conn
         |> put_status(:unprocessable_entity)
-        |> render("show.json", survey: survey |> Repo.preload(:questionnaires) |> Survey.with_links(user_level(survey.project_id, current_user(conn).id)))
-    else
-      project = conn
-      |> load_project_for_change(survey.project_id)
+        |> render_survey(survey)
 
-      channels = survey.respondent_groups
-      |> Enum.flat_map(&(&1.channels))
-      |> Enum.uniq
-
-      case prepare_channels(conn, channels) do
-        :ok ->
-          changeset = Survey.changeset(survey, %{"state": "running", "started_at": Timex.now})
-
-          multi = Multi.new
-          |> Multi.update(:survey, changeset)
-          |> Multi.insert(:log, ActivityLog.start(project, conn, survey))
-          |> Repo.transaction
-
-          case multi do
-            {:ok, _} ->
-              survey = create_survey_questionnaires_snapshot(survey)
-              |> Repo.preload(:questionnaires)
-              |> Survey.with_links(user_level(survey.project_id, current_user(conn).id))
-              project |> Project.touch!
-              render(conn, "show.json", survey: survey)
-            {:error, _, changeset, _} ->
-              Logger.warn "Error when launching survey: #{inspect changeset}"
-              conn
-              |> put_status(:unprocessable_entity)
-              |> render(Ask.ChangesetView, "error.json", changeset: changeset)
-          end
-
-        {:error, reason} ->
-          Logger.warn "Error when preparing channels for launching survey #{id} (#{reason})"
-          conn
-          |> put_status(:unprocessable_entity)
-          |> render("show.json", survey: survey |> Repo.preload(:questionnaires) |> Survey.with_links(user_level(survey.project_id, current_user(conn).id)))
-      end
+      {:error, %{changeset: changeset}} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Ask.ChangesetView, "error.json", changeset: changeset)
     end
   end
+
+  defp render_survey(conn, survey),
+    do:
+      render(conn, "show.json",
+        survey:
+          survey
+          |> Repo.preload(:questionnaires)
+          |> Survey.with_links(user_level(survey.project_id, current_user(conn).id))
+      )
 
   def simulate_questionanire(conn, %{"project_id" => project_id, "questionnaire_id" => questionnaire_id, "phone_number" => phone_number, "mode" => mode, "channel_id" => channel_id}) do
     project = conn
@@ -489,34 +482,6 @@ defmodule Ask.SurveyController do
         "questionnaire_id" => questionnaire.snapshot_of
       }
     })
-  end
-
-  defp create_survey_questionnaires_snapshot(survey) do
-    # Create copies of questionnaires
-    new_questionnaires = Enum.map(survey.questionnaires, fn questionnaire ->
-      %{questionnaire | id: nil, snapshot_of_questionnaire: questionnaire, questionnaire_variables: [], project: survey.project}
-      |> Repo.preload(:translations)
-      |> Repo.insert!
-      |> Questionnaire.recreate_variables!
-    end)
-
-    # Update references in comparisons, if any
-    comparisons = survey.comparisons
-    comparisons = if comparisons do
-      comparisons
-      |> Enum.map(fn comparison ->
-        questionnaire_id = Map.get(comparison, "questionnaire_id")
-        snapshot = Enum.find(new_questionnaires, fn q -> q.snapshot_of == questionnaire_id end)
-        Map.put(comparison, "questionnaire_id", snapshot.id)
-      end)
-    else
-      comparisons
-    end
-
-    survey
-    |> Survey.changeset(%{comparisons: comparisons})
-    |> Ecto.Changeset.put_assoc(:questionnaires, new_questionnaires)
-    |> Repo.update!
   end
 
   def config(conn, _params) do
@@ -780,15 +745,6 @@ defmodule Ask.SurveyController do
 
   defp render_initial_state(conn, _survey_id, _mode) do
     json(conn, %{"data" => %{}})
-  end
-
-  defp prepare_channels(_, []), do: :ok
-  defp prepare_channels(conn, [channel | rest]) do
-    runtime_channel = Ask.Channel.runtime_channel(channel)
-    case Ask.Runtime.Channel.prepare(runtime_channel) do
-      {:ok, _} -> prepare_channels(conn, rest)
-      error -> error
-    end
   end
 
   defp cancel_messages_and_respondents(survey_id), do: SurveyCanceller.start_cancelling(survey_id).consumers_pids

--- a/web/models/activity_log.ex
+++ b/web/models/activity_log.ex
@@ -19,7 +19,7 @@ defmodule Ask.ActivityLog do
     ["create_invite", "edit_invite", "delete_invite", "edit_collaborator", "remove_collaborator"]
 
   def valid_actions("survey"), do:
-    ["create", "edit", "rename", "change_description", "lock", "unlock", "delete", "start", "request_cancel", "completed_cancel", "download", "enable_public_link", "regenerate_public_link", "disable_public_link", "change_folder"]
+    ["create", "edit", "rename", "change_description", "lock", "unlock", "delete", "start", "repeat", "request_cancel", "completed_cancel", "download", "enable_public_link", "regenerate_public_link", "disable_public_link", "change_folder"]
 
   def valid_actions("questionnaire"), do:
     ["create", "edit", "rename", "delete", "add_mode", "remove_mode", "add_language", "remove_language", "create_step", "delete_step", "rename_step", "edit_step", "edit_settings", "create_section", "rename_section", "delete_section", "edit_section", "archive", "unarchive"]
@@ -197,6 +197,10 @@ defmodule Ask.ActivityLog do
 
   def start(project, conn, survey) do
     create("start", project, conn, survey, %{survey_name: survey.name})
+  end
+
+  def repeat(project, conn, survey) do
+    create("repeat", project, conn, survey, %{survey_name: survey.name})
   end
 
   def request_cancel(project, conn, survey) do

--- a/web/models/respondent_group.ex
+++ b/web/models/respondent_group.ex
@@ -3,6 +3,10 @@ defmodule Ask.RespondentGroup do
 
   schema "respondent_groups" do
     field :name, :string
+    # In Surveda informal talks, we use a lot the word "sample" to represent all the respondents
+    # of a group or survey.
+    # Here, the name "sample" is literal. In this field we keep only the very few first phone
+    # numbers shown to the end-user as a sample in the UI.
     field :sample, Ask.Ecto.Type.JSON
     field :respondents_count, :integer
     belongs_to :survey, Ask.Survey

--- a/web/models/survey.ex
+++ b/web/models/survey.ex
@@ -556,6 +556,8 @@ defmodule Ask.Survey do
 
   def panel_survey?(%{panel_survey_of: panel_survey_of}), do: !!panel_survey_of
 
+  def repeatable?(survey), do: terminated?(survey) and panel_survey?(survey) and survey.latest_panel_survey
+
   defp exhausted_respondents(respondents_by_disposition, count_partial_results) do
     disposition_filter = Respondent.metrics_final_dispositions(count_partial_results)
     sum_respondents_by_disposition_filter(respondents_by_disposition, disposition_filter)
@@ -589,7 +591,9 @@ defmodule Ask.Survey do
     Enum.any?(partial_relevant_configs, fn config -> Questionnaire.partial_relevant_enabled?(config) end)
   end
 
-  def succeeded?(survey), do: survey.state == "terminated" and survey.exit_code == 0
+  defp terminated?(survey), do: survey.state == "terminated"
+
+  def succeeded?(survey), do: terminated?(survey) and survey.exit_code == 0
 
   defp partial_relevant_configs(survey, true = _persist),
     do:

--- a/web/models/survey.ex
+++ b/web/models/survey.ex
@@ -614,4 +614,13 @@ defmodule Ask.Survey do
     changeset
     |> put_assoc(:questionnaires, questionnaires_changeset)
   end
+
+  def update_respondent_groups(changeset, respondent_group_ids) do
+    respondent_groups_changeset = Enum.map(respondent_group_ids, fn respondent_group_id ->
+      Repo.get!(RespondentGroup, respondent_group_id) |> change
+    end)
+
+    changeset
+    |> put_assoc(:respondent_groups, respondent_groups_changeset)
+  end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -84,6 +84,7 @@ defmodule Ask.Router do
           post "/launch", SurveyController, :launch
           post "/stop", SurveyController, :stop
           post "/config", SurveyController, :config
+          post "/repeat/", SurveyController, :repeat
           put "/update_locked_status", SurveyController, :update_locked_status, as: :update_locked_status
           get "/config", SurveyController, :config
           get "/stats", SurveyController, :stats

--- a/web/views/survey_view.ex
+++ b/web/views/survey_view.ex
@@ -1,6 +1,7 @@
 defmodule Ask.SurveyView do
   import Ask.Router.Helpers
   alias Ask.Endpoint
+  alias Ask.Repo
   use Ask.Web, :view
 
   alias Ask.Survey
@@ -56,6 +57,11 @@ defmodule Ask.SurveyView do
     }
   end
   def render("survey_detail.json", %{survey: survey}) do
+    survey =
+      survey
+      |> Repo.preload(:questionnaires)
+      |> Repo.preload(:quota_buckets)
+
     map = %{id: survey.id,
       name: survey.name,
       description: survey.description,
@@ -122,9 +128,7 @@ defmodule Ask.SurveyView do
   defp format_date(date), do: if(date, do: date |> Timex.format!("%FT%T%:z", :strftime), else: nil)
 
   defp questionnaire_ids(survey = %Ask.Survey{}) do
-    (survey
-    |> Ask.Repo.preload(:questionnaires)).questionnaires
-    |> Enum.map(&(&1.id))
+    Enum.map(survey.questionnaires, &(&1.id))
   end
 
   defp next_schedule_time(survey) do

--- a/web/views/survey_view.ex
+++ b/web/views/survey_view.ex
@@ -86,7 +86,7 @@ defmodule Ask.SurveyView do
       down_channels: survey.down_channels,
       folder_id: survey.folder_id,
       # Preserve the UI from handling the panel survey implementation details
-      is_panel_survey: Survey.is_panel_survey(survey)
+      is_panel_survey: Survey.panel_survey?(survey)
     }
 
     if Ask.Survey.launched?(survey) || survey.simulation do


### PR DESCRIPTION
### 🎯 The goal

This PR adds a new endpoint to create a new occurrence of a panel survey.

For: #1803
See: #1805

### 🚚 The refactors

Because repeating a survey includes starting it, creating respondent groups, and inserting respondents, some refactors were done.

1. Most of the logic for starting a survey was moved from the survey controller to a new module `Ask.Runtime.SurveyAction`. From now, this module is in charge of keeping the logic for repeating and starting a survey.
2. Most of the logic for creating respondent groups and inserting respondents was moved from the respondent group controller to a new module `Ask.Runtime.RespondentGroup`

### 🚧 The new logic

Repeating a survey has its own (new) logic. The top of the logic is in `Ask.Runtime.SurveyAction` and the down is in `Ask.Runtime.PanelSurvey` (also, a new module).

### ✅ Expected behavior
 - [x] Endpoint: `POST /api/v1/projects/1/surveys/300/repeat`
 - [x] It only repeats the latest occurrence of a panel survey, and only after it succeeded.
 - [x] It creates a new survey within the same panel_survey_group_id.
 - [x] It flags the new survey as the latest occurrence.
 - [x] It starts the new survey.
 - [x] It validates that the survey has a panel_survey_group_id
 - [x] It preserves the respondent id through the group

### 🚫 Excluded from this PR
 - [ ] Improve the respondent group creation logic: excluded from this iteration. For now, for each existing group, a new respondent group with the same name is created. Each respondent group has a copy of every respondent (except refused) and channel association.
 - [ ] Add regression tests: included in this iteration, but after merging this PR and doing #1804.