### PR TITLE
Unify the simulators look and feel

### DIFF
--- a/web/static/css/_quex-simulation.scss
+++ b/web/static/css/_quex-simulation.scss
@@ -21,6 +21,7 @@ $smallChatWindowBodyHeight: $smallSimulationHeight -
 .quex-simulation-container {
   display: grid;
   grid-gap: 2rem;
+  margin-bottom: 2rem;
 
   @media #{$large-and-up} {
     grid-template-columns: repeat(3, 1fr);
@@ -63,13 +64,6 @@ $smallChatWindowBodyHeight: $smallSimulationHeight -
   }
 }
 
-.wrapper .simulator-container {
-  @extend .row;
-  padding-top: 60px;
-  & main > div {
-    padding-top: 0;
-  }
-}
 .chat-window {
   @extend .z-depth-5;
   border-radius: 5px;

--- a/web/static/js/components/simulation/QuestionnaireSimulation.jsx
+++ b/web/static/js/components/simulation/QuestionnaireSimulation.jsx
@@ -152,14 +152,14 @@ class QuestionnaireSimulation extends Component<Props, State> {
     const closeSimulationButton = (
       <div>
         <Tooltip text='Close Simulation'>
-          <a key='one' className='btn-floating btn-large waves-effect waves-light red right' style={{marginTop: '-6.1rem'}} href='#' onClick={() => router.push(routes.editQuestionnaire(projectId, questionnaireId))}>
+          <a key='one' className='btn-floating btn-large waves-effect waves-light red right mtop' href='#' onClick={() => router.push(routes.editQuestionnaire(projectId, questionnaireId))}>
             <i className='material-icons'>close</i>
           </a>
         </Tooltip>
       </div>
     )
 
-    return <div className='simulator-container'>
+    return <div>
       {
         simulation
         ? <div>

--- a/web/static/js/components/surveys/SurveySimulation.jsx
+++ b/web/static/js/components/surveys/SurveySimulation.jsx
@@ -148,11 +148,13 @@ class SurveySimulation extends Component {
     }
 
     return (
-      <Card>
-        <ul className='collection simulation'>
-          {stepList}
-        </ul>
-      </Card>
+      <div className='quex-simulation-steps'>
+        <Card>
+          <ul className='collection simulation'>
+            {stepList}
+          </ul>
+        </Card>
+      </div>
     )
   }
 
@@ -172,6 +174,7 @@ class SurveySimulation extends Component {
       }
       stepList.push(this.stepItem(step, this.state.responses[step.store], 0, className, iconValue))
     } else if (step.type === 'section') {
+      className += ' section'
       // add the section step to the stepList
       stepList.push(this.stepItem(step, null, index, className, iconValue))
       let value = null


### PR DESCRIPTION
Surveda has two different ways of simulating questionnaires.

Ideally, they should share the same front end components, but they don't yet.

They look very similar, but not equal.

This PR:

- [x] Limits the step component height to fix #1799.
- [x] Uppercases section titles following the SMS simulator behavior.
- [x] Unifies the horizontal space between header, main, and footer.

Mobileweb simulation:

![mobileweb](https://user-images.githubusercontent.com/39921597/102504312-6c6bb180-405f-11eb-8d26-89bffdb3e3e3.png)

SMS simulation:

![sms](https://user-images.githubusercontent.com/39921597/102504398-8ad1ad00-405f-11eb-906d-6dec6922ec81.png)