### PR TITLE
Mobileweb simulation

### DIFF
--- a/lib/ask/runtime/questionnaire_simulator.ex
+++ b/lib/ask/runtime/questionnaire_simulator.ex
@@ -258,8 +258,12 @@ defmodule Ask.Runtime.QuestionnaireMobileWebSimulator do
   def get_last_simulation_response(respondent_id) do
     simulation = QuestionnaireSimulatorStore.get_respondent_simulation(respondent_id)
     if (simulation) do
-      %{last_simulation_response: last_simulation_response} = simulation
-      last_simulation_response
+      last_simulation_response = Map.get(simulation, :last_simulation_response)
+      if (last_simulation_response) do
+        last_simulation_response
+      else
+        Response.invalid_simulation
+      end
     else
       respondent_id
       |> QuestionnaireSimulationStep.expired

--- a/lib/ask/runtime/questionnaire_simulator.ex
+++ b/lib/ask/runtime/questionnaire_simulator.ex
@@ -10,8 +10,10 @@ defmodule Ask.QuestionnaireSimulationStep do
   alias Ask.Simulation.Status
   alias __MODULE__
 
+  defstruct [:respondent_id, :simulation_status, :disposition, :current_step, :questionnaire, submissions: []]
+
   def expired(respondent_id) do
-    %{respondent_id: respondent_id, simulation_status: Status.expired}
+    %QuestionnaireSimulationStep{respondent_id: respondent_id, simulation_status: Status.expired}
   end
 
   def build(%{respondent: respondent, submissions: submissions, questionnaire: quiz, section_order: section_order}, current_step, status, with_quiz) do

--- a/lib/ask/runtime/questionnaire_simulator.ex
+++ b/lib/ask/runtime/questionnaire_simulator.ex
@@ -1,33 +1,31 @@
-defmodule Ask.QuestionnaireSimulation do
-  defstruct [:respondent, :questionnaire, :section_order, :last_simulation_response, messages: [], submissions: []]
+defmodule Ask.QuestionnaireMobileWebSimulation do
+  defstruct [:respondent, :questionnaire, :section_order, :last_simulation_response, submissions: []]
+end
+
+defmodule Ask.QuestionnaireSmsSimulation do
+  defstruct [:respondent, :questionnaire, :section_order, messages: [], submissions: []]
 end
 
 defmodule Ask.QuestionnaireSimulationStep do
-  alias Ask.QuestionnaireSimulation
   alias Ask.Simulation.Status
   alias __MODULE__
 
-  defstruct [:respondent_id, :simulation_status, :disposition, :current_step, :reply, :questionnaire, messages_history: [], submissions: []]
-
-  def start_build(simulation, current_step, status, reply), do: build(simulation, current_step, status, true, reply)
-  def sync_build(simulation, current_step, status, reply), do: build(simulation, current_step, status, false, reply)
+  # def start_build(simulation, current_step, status, reply), do: build(simulation, current_step, status, true, reply)
+  # def sync_build(simulation, current_step, status, reply), do: build(simulation, current_step, status, false, reply)
 
   def expired(respondent_id) do
-    %QuestionnaireSimulationStep{respondent_id: respondent_id, simulation_status: Status.expired}
+    %{respondent_id: respondent_id, simulation_status: Status.expired}
   end
 
-  defp build(%QuestionnaireSimulation{respondent: respondent, messages: all_messages, submissions: submissions, questionnaire: quiz, section_order: section_order}, current_step, status, with_quiz, reply) do
-    step = %QuestionnaireSimulationStep{
+  def build(%{respondent: respondent, submissions: submissions, questionnaire: quiz, section_order: section_order}, current_step, status, with_quiz) do
+    step = %{
       respondent_id: respondent.id,
       simulation_status: status,
       disposition: respondent.disposition,
       current_step: current_step,
-      messages_history: all_messages,
-      submissions: submissions,
-      # The mobileweb simulation controller needs the reply to render properly
-      reply: reply
+      submissions: submissions
     }
-    if with_quiz, do: %{step | questionnaire: sort_quiz_sections(quiz, section_order)}, else: step
+    if with_quiz, do: Map.put(step, :questionnaire, sort_quiz_sections(quiz, section_order)), else: step
   end
 
   defp sort_quiz_sections(quiz, nil), do: quiz
@@ -37,44 +35,71 @@ defmodule Ask.QuestionnaireSimulationStep do
   end
 end
 
+defmodule Ask.QuestionnaireMobileWebSimulationStep do
+  defstruct [:respondent_id, :simulation_status, :disposition, :current_step, :reply, :questionnaire, submissions: []]
+
+  def start_build(simulation, current_step, status, reply) do
+    simulation_step = Ask.QuestionnaireSimulationStep.build(simulation, current_step, status, true)
+    Map.merge(%Ask.QuestionnaireMobileWebSimulationStep{reply: reply}, simulation_step)
+  end
+  def sync_build(simulation, current_step, status, reply) do
+    simulation_step = Ask.QuestionnaireSimulationStep.build(simulation, current_step, status, false)
+    Map.merge(%Ask.QuestionnaireMobileWebSimulationStep{reply: reply}, simulation_step)
+  end
+end
+
+defmodule Ask.QuestionnaireSmsSimulationStep do
+  defstruct [:respondent_id, :simulation_status, :disposition, :current_step, :questionnaire, messages_history: [], submissions: []]
+
+  def start_build(simulation, current_step, status, messages_history) do
+    simulation_step = Ask.QuestionnaireSimulationStep.build(simulation, current_step, status, true)
+    Map.merge(%Ask.QuestionnaireSmsSimulationStep{messages_history: messages_history}, simulation_step)
+  end
+
+  def sync_build(simulation, current_step, status, messages_history) do
+    simulation_step = Ask.QuestionnaireSimulationStep.build(simulation, current_step, status, false)
+    Map.merge(%Ask.QuestionnaireSmsSimulationStep{messages_history: messages_history}, simulation_step)
+  end
+end
+
 defmodule Ask.Runtime.SimulatorChannel do
   defstruct patterns: []
 end
 
 defmodule Ask.Runtime.QuestionnaireSimulator do
   alias Ask.{Survey, Respondent, Questionnaire, Project, SystemTime, Runtime, QuestionnaireSimulationStep}
-  alias Ask.Simulation.{Status, ATMessage, AOMessage, SubmittedStep, Response}
-  alias Ask.Runtime.{Session, Flow, QuestionnaireSimulatorStore}
+  alias Ask.Simulation.{Status, AOMessage, SubmittedStep, Response}
+  alias Ask.Runtime.{Session, QuestionnaireSimulatorStore, QuestionnaireSmsSimulator, QuestionnaireMobileWebSimulator}
 
-  @sms_mode "sms"
-  @mobileweb_mode "mobileweb"
-
-  def start_simulation(project, questionnaire, mode \\ @sms_mode) do
+  def start_simulation(project, questionnaire, mode) do
     if valid_questionnaire?(questionnaire, mode) do
-      start(project, questionnaire, mode)
+      case mode do
+        "sms" ->
+          QuestionnaireSmsSimulator.start(project, questionnaire)
+        "mobileweb" ->
+          QuestionnaireMobileWebSimulator.start(project, questionnaire)
+        _ ->
+          Response.invalid_simulation
+      end
     else
       Response.invalid_simulation
     end
   end
 
-  # The mobileweb simulator needs the last response to update the screen asynchronously
-  def get_last_simulation_response(respondent_id) do
-    simulation = QuestionnaireSimulatorStore.get_respondent_simulation(respondent_id)
-    if (simulation) do
-      %{last_simulation_response: last_simulation_response} = simulation
-      last_simulation_response
-    else
-      respondent_id
-      |> QuestionnaireSimulationStep.expired
-      |> Response.success
+  def process_respondent_response(respondent_id, response, mode) do
+    case mode do
+      "sms" ->
+        Ask.Runtime.QuestionnaireSmsSimulator.process_respondent_response(respondent_id, response)
+      "mobileweb" ->
+        Ask.Runtime.QuestionnaireMobileWebSimulator.process_respondent_response(respondent_id, response)
     end
   end
 
-  def process_respondent_response(respondent_id, response, mode \\ @sms_mode) do
+  def process_respondent_response(respondent_id, response, build_simulation, sync_simulation) do
     simulation = QuestionnaireSimulatorStore.get_respondent_simulation(respondent_id)
     if (simulation) do
-      {:ok, %{simulation: simulation, simulation_response: simulation_response}} = sync_simulation(simulation, response, mode)
-      QuestionnaireSimulatorStore.add_respondent_simulation(respondent_id, %Ask.QuestionnaireSimulation{simulation | last_simulation_response: simulation_response})
+      {:ok, %{simulation: simulation, simulation_response: simulation_response}} = sync_simulation.(simulation, response)
+      QuestionnaireSimulatorStore.add_respondent_simulation(respondent_id, build_simulation.(simulation, simulation_response))
       simulation_response
     else
       respondent_id
@@ -83,27 +108,23 @@ defmodule Ask.Runtime.QuestionnaireSimulator do
     end
   end
 
-  defp sync_simulation(simulation, response, mode) do
-    %{respondent: respondent, messages: messages} = simulation
-    updated_messages = messages ++ [ATMessage.new(response)]
-    simulation = %{simulation | messages: updated_messages}
-    # :answer is the response used by MobileSurveyController.get_step to call Survey.sync_step
-    # The mobile survey simulation controller emulates this behaviour
-    reply = if response == :answer, do: :answer, else: Flow.Message.reply(response)
-
-    case Runtime.Survey.sync_step(respondent, reply, mode, SystemTime.time.now, false) do
+  def sync_simulation(simulation, reply, mode, handle_app_reply) do
+    case Runtime.Survey.sync_step(simulation.respondent, reply, mode, SystemTime.time.now, false) do
       {:reply, reply, respondent} ->
-        handle_app_reply(simulation, respondent, reply, Status.active)
+        handle_app_reply.(simulation, respondent, reply, Status.active)
       {:end, {:reply, reply}, respondent} ->
-        handle_app_reply(simulation, respondent, reply, Status.ended)
+        handle_app_reply.(simulation, respondent, reply, Status.ended)
       {:end, respondent} ->
-        handle_app_reply(simulation, respondent, nil, Status.ended)
+        handle_app_reply.(simulation, respondent, nil, Status.ended)
     end
   end
 
   defp valid_questionnaire?(quiz, mode), do: quiz.modes |> Enum.member?(mode)
 
-  defp start(%Project{} = project, %Questionnaire{} = questionnaire, mode) when mode in [@sms_mode, @mobileweb_mode] do
+  def start(%Project{} = project, %Questionnaire{} = questionnaire, mode, start_build, options \\ []) do
+    delivery_confirm = Keyword.get(options, :delivery_confirm, nil)
+    append_last_simulation_response = Keyword.get(options, :append_last_simulation_response, nil)
+
     survey = %Survey{
       simulation: true,
       project_id: project.id,
@@ -131,27 +152,16 @@ defmodule Ask.Runtime.QuestionnaireSimulator do
     # Simulating what Broker does when starting a respondent: Session.start and then Survey.handle_session_step
     session_started = Session.start(questionnaire, new_respondent, %Ask.Runtime.SimulatorChannel{}, mode, Ask.Schedule.always(), [], nil, nil, [], nil, false, false)
     {:reply, reply, respondent} = Runtime.Survey.handle_session_step(session_started, SystemTime.time.now, false)
-    section_order = respondent.session.flow.section_order
 
-    # Simulating Nuntium confirmation on message delivery
-    %{respondent: respondent} = Runtime.Survey.delivery_confirm(sync_respondent(respondent), "", mode, false)
-
-    messages = AOMessage.create_all(reply)
-    submitted_steps = SubmittedStep.new_explanations(reply)
-    current_step = current_step(reply)
-
-    simulation = %Ask.QuestionnaireSimulation{questionnaire: questionnaire, respondent: sync_respondent(respondent), messages: messages, submissions: submitted_steps, section_order: section_order}
-    response =
+    respondent = if delivery_confirm, do: delivery_confirm.(respondent), else: respondent
+    %{simulation: simulation, response: response} = start_build.(respondent, reply)
+    simulation = if (append_last_simulation_response) do
+      append_last_simulation_response.(simulation, response)
+    else
       simulation
-      |> QuestionnaireSimulationStep.start_build(current_step, Status.active, reply)
-      |> Response.success
-
-    QuestionnaireSimulatorStore.add_respondent_simulation(respondent.id, %{simulation | last_simulation_response: response})
+    end
+    QuestionnaireSimulatorStore.add_respondent_simulation(respondent.id, simulation)
     response
-  end
-
-  defp start(_project, _questionnaire, _mode) do
-    Response.invalid_simulation
   end
 
   # Must update the respondent.session's respondent since if not will be outdated from respondent
@@ -161,29 +171,156 @@ defmodule Ask.Runtime.QuestionnaireSimulator do
   #  - and after that use the session.respondent
   #
   # If not synced, respondent data would be loss during simulation and the simulation could behave inaccurately
-  defp sync_respondent(respondent) do
+  def sync_respondent(respondent) do
     synced_session = if respondent.session, do: %{respondent.session | respondent: respondent}, else: respondent.session
     %{respondent | session: synced_session}
   end
 
-  defp handle_app_reply(simulation, respondent, reply, status) do
-    messages = simulation.messages ++ AOMessage.create_all(reply)
+  def handle_app_reply(simulation, respondent, reply, status, sync_build) do
     submitted_steps = simulation.submissions ++ SubmittedStep.build_from_responses(respondent, simulation) ++ SubmittedStep.new_explanations(reply)
     current_step = current_step(reply)
 
-    simulation = %{simulation | respondent: sync_respondent(respondent), messages: messages, submissions: submitted_steps}
+    simulation = %{simulation | respondent: sync_respondent(respondent), submissions: submitted_steps}
     simulation_response =
       simulation
-      |> QuestionnaireSimulationStep.sync_build(current_step, status, reply)
+      |> sync_build.(current_step, status, reply)
       |> Response.success
     {:ok, %{simulation: simulation, simulation_response: simulation_response}}
   end
 
-  defp current_step(reply) do
+  def current_step(reply) do
     case Ask.Runtime.Reply.steps(reply) |> List.last do
       nil -> nil
       step -> step.id
     end
+  end
+
+  def base_simulation(questionnaire, respondent, reply) do
+    submitted_steps = SubmittedStep.new_explanations(reply)
+    section_order = respondent.session.flow.section_order
+    respondent = sync_respondent(respondent)
+    %{
+      questionnaire: questionnaire,
+      respondent: respondent,
+      submissions: submitted_steps,
+      section_order: section_order
+    }
+  end
+end
+
+defmodule Ask.Runtime.QuestionnaireMobileWebSimulator do
+  alias Ask.Runtime.{Survey, QuestionnaireSimulator, QuestionnaireSimulatorStore, Flow}
+  alias Ask.{QuestionnaireMobileWebSimulation, QuestionnaireMobileWebSimulationStep, QuestionnaireSimulationStep}
+  alias Ask.Simulation.{Status, Response}
+  def start(project, questionnaire) do
+    start_build = fn respondent, reply ->
+      base_simulation = QuestionnaireSimulator.base_simulation(questionnaire, respondent, reply)
+      current_step = QuestionnaireSimulator.current_step(reply)
+
+      simulation = Map.merge(%QuestionnaireMobileWebSimulation{}, base_simulation)
+
+      response =
+        simulation
+        |> QuestionnaireMobileWebSimulationStep.start_build(current_step, Status.active, reply)
+        |> Response.success
+
+      %{simulation: simulation, response: response}
+    end
+
+    append_last_simulation_response = fn simulation, response ->
+      %{simulation | last_simulation_response: response}
+    end
+
+    QuestionnaireSimulator.start(project, questionnaire, "mobileweb", start_build, append_last_simulation_response: append_last_simulation_response)
+  end
+
+  def process_respondent_response(respondent_id, response) do
+    build_simulation = fn simulation, simulation_response ->
+      %Ask.QuestionnaireMobileWebSimulation{simulation | last_simulation_response: simulation_response}
+    end
+
+    sync_build = fn simulation, current_step, status, reply ->
+      QuestionnaireMobileWebSimulationStep.sync_build(simulation, current_step, status, reply)
+    end
+
+    handle_app_reply = fn simulation, respondent, reply, status ->
+      QuestionnaireSimulator.handle_app_reply(simulation, respondent, reply, status, sync_build)
+    end
+
+    sync_simulation = fn simulation, response ->
+      reply = if response == :answer, do: :answer, else: Flow.Message.reply(response)
+      QuestionnaireSimulator.sync_simulation(simulation, reply, "mobileweb", handle_app_reply)
+    end
+
+    QuestionnaireSimulator.process_respondent_response(respondent_id, response, build_simulation, sync_simulation)
+  end
+
+  def get_last_simulation_response(respondent_id) do
+    simulation = QuestionnaireSimulatorStore.get_respondent_simulation(respondent_id)
+    if (simulation) do
+      %{last_simulation_response: last_simulation_response} = simulation
+      last_simulation_response
+    else
+      respondent_id
+      |> QuestionnaireSimulationStep.expired
+      |> Response.success
+    end
+  end
+
+end
+
+defmodule Ask.Runtime.QuestionnaireSmsSimulator do
+  alias Ask.Runtime.{Survey, QuestionnaireSimulator, Flow}
+  alias Ask.{QuestionnaireSmsSimulation, QuestionnaireSmsSimulationStep}
+  alias Ask.Simulation.{AOMessage, ATMessage, Status, Response}
+  def start(project, questionnaire) do
+    start_build = fn respondent, reply ->
+      base_simulation = QuestionnaireSimulator.base_simulation(questionnaire, respondent, reply)
+      messages = AOMessage.create_all(reply)
+      current_step = QuestionnaireSimulator.current_step(reply)
+
+      simulation = Map.merge(%QuestionnaireSmsSimulation{messages: messages}, base_simulation)
+
+      response =
+        simulation
+        |> QuestionnaireSmsSimulationStep.start_build(current_step, Status.active, messages)
+        |> Response.success
+
+      %{simulation: simulation, response: response}
+    end
+
+    delivery_confirm = fn respondent ->
+      # Simulating Nuntium confirmation on message delivery
+      %{respondent: respondent} = Survey.delivery_confirm(QuestionnaireSimulator.sync_respondent(respondent), "", "sms", false)
+      respondent
+    end
+
+    QuestionnaireSimulator.start(project, questionnaire, "sms", start_build, delivery_confirm: delivery_confirm)
+  end
+
+  def process_respondent_response(respondent_id, response) do
+    build_simulation = fn simulation, _simulation_response ->
+      Map.merge(%QuestionnaireSmsSimulation{}, simulation)
+    end
+
+    handle_app_reply = fn simulation, respondent, reply, status ->
+      messages = simulation.messages ++ AOMessage.create_all(reply)
+
+      sync_build = fn simulation, current_step, status, _reply ->
+        QuestionnaireSmsSimulationStep.sync_build(simulation, current_step, status, messages)
+      end
+
+      QuestionnaireSimulator.handle_app_reply(simulation, respondent, reply, status, sync_build)
+    end
+
+    sync_simulation = fn simulation, response ->
+      messages = simulation.messages ++ [ATMessage.new(response)]
+      simulation = %{simulation | messages: messages}
+      reply = Flow.Message.reply(response)
+      QuestionnaireSimulator.sync_simulation(simulation, reply, "sms", handle_app_reply)
+    end
+
+    QuestionnaireSimulator.process_respondent_response(respondent_id, response, build_simulation, sync_simulation)
   end
 end
 

--- a/lib/ask/runtime/questionnaire_simulator.ex
+++ b/lib/ask/runtime/questionnaire_simulator.ex
@@ -10,9 +10,6 @@ defmodule Ask.QuestionnaireSimulationStep do
   alias Ask.Simulation.Status
   alias __MODULE__
 
-  # def start_build(simulation, current_step, status, reply), do: build(simulation, current_step, status, true, reply)
-  # def sync_build(simulation, current_step, status, reply), do: build(simulation, current_step, status, false, reply)
-
   def expired(respondent_id) do
     %{respondent_id: respondent_id, simulation_status: Status.expired}
   end

--- a/lib/ask/runtime/questionnaire_simulator.ex
+++ b/lib/ask/runtime/questionnaire_simulator.ex
@@ -309,6 +309,7 @@ defmodule Ask.Runtime.QuestionnaireSmsSimulator do
 
     handle_app_reply = fn simulation, respondent, reply, status ->
       messages = simulation.messages ++ AOMessage.create_all(reply)
+      simulation = Map.put(simulation, :messages, messages)
 
       sync_build = fn simulation, current_step, status, _reply ->
         QuestionnaireSmsSimulationStep.sync_build(simulation, current_step, status, messages)

--- a/lib/ask/runtime/reply.ex
+++ b/lib/ask/runtime/reply.ex
@@ -32,6 +32,20 @@ defmodule Ask.Runtime.Reply do
     List.last(steps)
     |> ReplyStep.num_digits
   end
+
+  def progress(reply) do
+    if reply.current_step && reply.total_steps && reply.total_steps > 0 do
+      100 * (reply.current_step / reply.total_steps)
+    else
+      # If no explicit progress is set in the reply, assume we are at the end.
+      # This happens in the "thank you" and "quota completed" messages.
+      100.0
+    end
+  end
+
+  def first_step(reply) do
+    reply |> steps() |> hd
+  end
 end
 
 defmodule Ask.Runtime.ReplyStep do

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -28,6 +28,7 @@ defmodule Ask.Runtime.Session do
     IVRMode,
     MobileWebMode,
     SMSSimulatorMode,
+    MobilewebSimulatorMode,
     ChannelPatterns,
     RetriesHistogram
   }
@@ -321,8 +322,8 @@ defmodule Ask.Runtime.Session do
     end
   end
 
-  defp mode_start(%Session{flow: flow, respondent: respondent, current_mode: %SMSSimulatorMode{}} = session) do
-    case flow |> Flow.step(session.current_mode  |> SessionMode.visitor, :answer, respondent.disposition) do
+  defp mode_start(%Session{flow: flow, respondent: respondent, current_mode: %SMSSimulatorMode{} = current_mode} = session) do
+    case flow |> Flow.step(current_mode  |> SessionMode.visitor, :answer, respondent.disposition) do
       {:end, _, reply} ->
         {:end, reply, respondent}
       {:ok, flow, reply} ->
@@ -361,6 +362,11 @@ defmodule Ask.Runtime.Session do
     respondent = runtime_channel
     |> Channel.ask(respondent, token, reply)
 
+    {:ok, %{session | flow: flow, respondent: respondent}, reply, current_timeout(session)}
+  end
+
+  defp mode_start(%Session{flow: flow, respondent: respondent, current_mode: %MobilewebSimulatorMode{}} = session) do
+    reply = mobile_contact_reply(session)
     {:ok, %{session | flow: flow, respondent: respondent}, reply, current_timeout(session)}
   end
 

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -28,7 +28,7 @@ defmodule Ask.Runtime.Session do
     IVRMode,
     MobileWebMode,
     SMSSimulatorMode,
-    MobilewebSimulatorMode,
+    MobileWebSimulatorMode,
     ChannelPatterns,
     RetriesHistogram
   }
@@ -365,7 +365,7 @@ defmodule Ask.Runtime.Session do
     {:ok, %{session | flow: flow, respondent: respondent}, reply, current_timeout(session)}
   end
 
-  defp mode_start(%Session{flow: flow, respondent: respondent, current_mode: %MobilewebSimulatorMode{}} = session) do
+  defp mode_start(%Session{flow: flow, respondent: respondent, current_mode: %MobileWebSimulatorMode{}} = session) do
     reply = mobile_contact_reply(session)
     {:ok, %{session | flow: flow, respondent: respondent}, reply, current_timeout(session)}
   end

--- a/lib/ask/runtime/session_mode.ex
+++ b/lib/ask/runtime/session_mode.ex
@@ -5,7 +5,7 @@ defprotocol Ask.Runtime.SessionMode do
 end
 
 defmodule Ask.Runtime.SessionModeProvider do
-  alias Ask.Runtime.{SessionMode, SMSMode, IVRMode, MobileWebMode, SMSSimulatorMode}
+  alias Ask.Runtime.{SessionMode, SMSMode, IVRMode, MobileWebMode, SMSSimulatorMode, MobilewebSimulatorMode}
   alias Ask.{Repo, Channel}
 
   defp mode_provider("sms"), do: SMSMode
@@ -16,6 +16,10 @@ defmodule Ask.Runtime.SessionModeProvider do
 
   def new("sms", %Ask.Runtime.SimulatorChannel{} = channel, retries) do
     SMSSimulatorMode.new(channel, retries)
+  end
+
+  def new("mobileweb", %Ask.Runtime.SimulatorChannel{} = channel, retries) do
+    MobilewebSimulatorMode.new(channel, retries)
   end
 
   def new(mode, channel, retries) when not is_nil(channel) and is_list(retries) do
@@ -170,6 +174,32 @@ defmodule Ask.Runtime.MobileWebMode do
         mode: "mobileweb",
         channel_id: channel.id,
         retries: retries
+      }
+    end
+
+    def visitor(_) do
+      WebVisitor.new("mobileweb")
+    end
+
+    def mode(_) do
+      "mobileweb"
+    end
+  end
+end
+
+defmodule Ask.Runtime.MobilewebSimulatorMode do
+  alias __MODULE__
+  alias Ask.Runtime.Flow.WebVisitor
+
+  defstruct [:channel, :retries]
+
+  def new(channel, retries), do: %MobilewebSimulatorMode{channel: channel, retries: retries}
+  def load(_mode_dump), do: %MobilewebSimulatorMode{}
+
+  defimpl Ask.Runtime.SessionMode, for: Ask.Runtime.MobilewebSimulatorMode do
+    def dump(%MobilewebSimulatorMode{}) do
+      %{
+        mode: "mobileweb",
       }
     end
 

--- a/lib/ask/runtime/session_mode.ex
+++ b/lib/ask/runtime/session_mode.ex
@@ -5,7 +5,7 @@ defprotocol Ask.Runtime.SessionMode do
 end
 
 defmodule Ask.Runtime.SessionModeProvider do
-  alias Ask.Runtime.{SessionMode, SMSMode, IVRMode, MobileWebMode, SMSSimulatorMode, MobilewebSimulatorMode}
+  alias Ask.Runtime.{SessionMode, SMSMode, IVRMode, MobileWebMode, SMSSimulatorMode, MobileWebSimulatorMode}
   alias Ask.{Repo, Channel}
 
   defp mode_provider("sms"), do: SMSMode
@@ -19,7 +19,7 @@ defmodule Ask.Runtime.SessionModeProvider do
   end
 
   def new("mobileweb", %Ask.Runtime.SimulatorChannel{} = channel, retries) do
-    MobilewebSimulatorMode.new(channel, retries)
+    MobileWebSimulatorMode.new(channel, retries)
   end
 
   def new(mode, channel, retries) when not is_nil(channel) and is_list(retries) do
@@ -187,17 +187,17 @@ defmodule Ask.Runtime.MobileWebMode do
   end
 end
 
-defmodule Ask.Runtime.MobilewebSimulatorMode do
+defmodule Ask.Runtime.MobileWebSimulatorMode do
   alias __MODULE__
   alias Ask.Runtime.Flow.WebVisitor
 
   defstruct [:channel, :retries]
 
-  def new(channel, retries), do: %MobilewebSimulatorMode{channel: channel, retries: retries}
-  def load(_mode_dump), do: %MobilewebSimulatorMode{}
+  def new(channel, retries), do: %MobileWebSimulatorMode{channel: channel, retries: retries}
+  def load(_mode_dump), do: %MobileWebSimulatorMode{}
 
-  defimpl Ask.Runtime.SessionMode, for: Ask.Runtime.MobilewebSimulatorMode do
-    def dump(%MobilewebSimulatorMode{}) do
+  defimpl Ask.Runtime.SessionMode, for: Ask.Runtime.MobileWebSimulatorMode do
+    def dump(%MobileWebSimulatorMode{}) do
       %{
         mode: "mobileweb",
       }

--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -207,6 +207,7 @@
   "Launch survey": "",
   "Leave project": "",
   "List the texts you want to store for each possible choice and define valid values by commas.": "",
+  "Loading": "",
   "Loading activities...": "",
   "Loading channels...": "",
   "Loading projects...": "",

--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -207,7 +207,6 @@
   "Launch survey": "",
   "Leave project": "",
   "List the texts you want to store for each possible choice and define valid values by commas.": "",
-  "Loading": "",
   "Loading activities...": "",
   "Loading channels...": "",
   "Loading projects...": "",

--- a/test/controllers/questionnaire_controller_test.exs
+++ b/test/controllers/questionnaire_controller_test.exs
@@ -1228,7 +1228,7 @@ defmodule Ask.QuestionnaireControllerTest do
       conn_ = post conn, project_questionnaire_questionnaires_start_simulation_path(conn, :start_simulation, questionnaire.project, questionnaire), mode: "sms"
       respondent_id = json_response(conn_, 200)["respondent_id"]
 
-      conn = post conn, project_questionnaire_questionnaires_sync_simulation_path(conn, :sync_simulation, questionnaire.project, questionnaire), respondent_id: respondent_id, response: "2"
+      conn = post conn, project_questionnaire_questionnaires_sync_simulation_path(conn, :sync_simulation, questionnaire.project, questionnaire), respondent_id: respondent_id, response: "2", mode: "sms"
       first_step_id = hd(steps)["id"]
       second_step_id = (steps |> Enum.at(1))["id"]
       response = json_response(conn, 200)
@@ -1261,7 +1261,7 @@ defmodule Ask.QuestionnaireControllerTest do
       questionnaire = insert(:questionnaire, project: project) |> Repo.preload(:project)
       respondent_id = Ecto.UUID.generate()
 
-      conn = post conn, project_questionnaire_questionnaires_sync_simulation_path(conn, :sync_simulation, questionnaire.project, questionnaire), respondent_id: respondent_id, response: "2"
+      conn = post conn, project_questionnaire_questionnaires_sync_simulation_path(conn, :sync_simulation, questionnaire.project, questionnaire), respondent_id: respondent_id, response: "2", mode: "sms"
       %{
         "respondent_id" => ^respondent_id,
         "simulation_status" => "expired"
@@ -1279,7 +1279,7 @@ defmodule Ask.QuestionnaireControllerTest do
       conn_ = post conn, project_questionnaire_questionnaires_start_simulation_path(conn, :start_simulation, questionnaire.project, questionnaire), mode: "sms"
       respondent_id = json_response(conn_, 200)["respondent_id"]
 
-      conn = post conn, project_questionnaire_questionnaires_sync_simulation_path(conn, :sync_simulation, questionnaire.project, questionnaire), respondent_id: respondent_id, response: "2"
+      conn = post conn, project_questionnaire_questionnaires_sync_simulation_path(conn, :sync_simulation, questionnaire.project, questionnaire), respondent_id: respondent_id, response: "2", mode: "sms"
       first_step_id = step["id"]
 
       assert %{

--- a/test/controllers/questionnaire_controller_test.exs
+++ b/test/controllers/questionnaire_controller_test.exs
@@ -1264,8 +1264,6 @@ defmodule Ask.QuestionnaireControllerTest do
       conn = post conn, project_questionnaire_questionnaires_sync_simulation_path(conn, :sync_simulation, questionnaire.project, questionnaire), respondent_id: respondent_id, response: "2"
       %{
         "respondent_id" => ^respondent_id,
-        "submissions" => [],
-        "messages_history" => [],
         "simulation_status" => "expired"
       } = json_response(conn, 200)
     end

--- a/test/lib/runtime/questionnaire_simulator_store_test.exs
+++ b/test/lib/runtime/questionnaire_simulator_store_test.exs
@@ -3,7 +3,7 @@ defmodule Ask.Runtime.QuestionnaireSimulatorStoreTest do
   use Ask.DummySteps
   use Ask.MockTime
   alias Ask.Runtime.QuestionnaireSimulatorStore
-  alias Ask.QuestionnaireSimulation
+  alias Ask.QuestionnaireSmsSimulation
 
   setup do
     QuestionnaireSimulatorStore.start_link()
@@ -12,7 +12,7 @@ defmodule Ask.Runtime.QuestionnaireSimulatorStoreTest do
 
   test "if simulation is added to the store, then it can be retrieved immediately" do
     respondent_id = Ecto.UUID.generate()
-    simulation = %QuestionnaireSimulation{messages: [%{body: "hello", type: "ao"}]}
+    simulation = %QuestionnaireSmsSimulation{messages: [%{body: "hello", type: "ao"}]}
     QuestionnaireSimulatorStore.add_respondent_simulation(respondent_id, simulation)
     assert simulation == QuestionnaireSimulatorStore.get_respondent_simulation(respondent_id)
   end
@@ -21,7 +21,7 @@ defmodule Ask.Runtime.QuestionnaireSimulatorStoreTest do
   test "if simulation is added to the store, then it can be retrieved before its ttl expires" do
     set_actual_time()
     respondent_id = Ecto.UUID.generate()
-    simulation = %QuestionnaireSimulation{messages: [%{body: "hello", type: "ao"}]}
+    simulation = %QuestionnaireSmsSimulation{messages: [%{body: "hello", type: "ao"}]}
     QuestionnaireSimulatorStore.add_respondent_simulation(respondent_id, simulation)
 
     time_passes(minutes: 4, seconds: 59) # ttl is 5 minutes
@@ -32,9 +32,9 @@ defmodule Ask.Runtime.QuestionnaireSimulatorStoreTest do
 
   test "adding a new simulation under an existing key is allowed and should update the stored value" do
     respondent_id = Ecto.UUID.generate()
-    simulation = %QuestionnaireSimulation{messages: [%{body: "hello", type: "ao"}]}
+    simulation = %QuestionnaireSmsSimulation{messages: [%{body: "hello", type: "ao"}]}
     QuestionnaireSimulatorStore.add_respondent_simulation(respondent_id, simulation)
-    new_simulation = %QuestionnaireSimulation{messages: [%{body: "hello", type: "ao"}, %{body: "hi", type: "at"}]}
+    new_simulation = %QuestionnaireSmsSimulation{messages: [%{body: "hello", type: "ao"}, %{body: "hi", type: "at"}]}
     QuestionnaireSimulatorStore.add_respondent_simulation(respondent_id, new_simulation)
     assert new_simulation == QuestionnaireSimulatorStore.get_respondent_simulation(respondent_id)
   end
@@ -43,7 +43,7 @@ defmodule Ask.Runtime.QuestionnaireSimulatorStoreTest do
   test "if entry ttl expired, then the store should remove that entry" do
     set_actual_time()
     respondent_id = Ecto.UUID.generate()
-    simulation = %QuestionnaireSimulation{messages: [%{body: "hello", type: "ao"}]}
+    simulation = %QuestionnaireSmsSimulation{messages: [%{body: "hello", type: "ao"}]}
     QuestionnaireSimulatorStore.add_respondent_simulation(respondent_id, simulation)
 
     time_passes(minutes: 5, seconds: 1) # more than 5 minutes (default value) have passed

--- a/test/lib/runtime/questionnaire_simulator_test.exs
+++ b/test/lib/runtime/questionnaire_simulator_test.exs
@@ -260,10 +260,10 @@ defmodule QuestionnaireSimulatorTest do
           responses = case mode do
             "sms" ->
               ["1", "Y", "7", "4"]
-              "mobileweb" ->
-                ["yes", "yes", "7", "4"]
-              end
-              [first, second, third, fourth] = responses
+            "mobileweb" ->
+              ["yes", "yes", "7", "4"]
+          end
+          [first, second, third, fourth] = responses
 
           %{respondent_id: respondent_id} = start_simulation.(quiz, mode)
           process_respondent_response(respondent_id, first, mode)

--- a/test/lib/runtime/questionnaire_simulator_test.exs
+++ b/test/lib/runtime/questionnaire_simulator_test.exs
@@ -101,7 +101,7 @@ defmodule QuestionnaireSimulatorTest do
       assert [] == submissions
     end
 
-    test "should include all the responses", %{start_simulation: start_simulation} do
+    test "should include all the questions and responses", %{start_simulation: start_simulation} do
       steps = @dummy_steps
       quiz = questionnaire_with_steps(steps)
       %{respondent_id: respondent_id} = start_simulation.(quiz)
@@ -109,16 +109,33 @@ defmodule QuestionnaireSimulatorTest do
       process_respondent_response(respondent_id, "1") # 1 is a yes response
       process_respondent_response(respondent_id, "Y") # Y is a yes response
       process_respondent_response(respondent_id, "7") # numeric response
-      %{submissions: submissions} = process_respondent_response(respondent_id, "4") # numeric response
+
+      %{submissions: submissions, messages_history: messages_history} = process_respondent_response(respondent_id, "4") # numeric response
 
       [first, second, third, fourth] = steps
+
       expected_submissions = [
         expected_submission(first, "Yes"),
         expected_submission(second, "Yes"),
         expected_submission(third, "7"),
         expected_submission(fourth, "4")
       ]
+
       assert expected_submissions == submissions
+
+      expected_messages_history = [
+        %{body: "Do you smoke? Reply 1 for YES, 2 for NO", type: "ao"},
+        %{body: "1", type: "at"},
+        %{body: "Do you exercise? Reply 1 for YES, 2 for NO", type: "ao"},
+        %{body: "Y", type: "at"},
+        %{body: "Which is the second perfect number??", type: "ao"},
+        %{body: "7", type: "at"},
+        %{body: "What's the number of this question??", type: "ao"},
+        %{body: "4", type: "at"},
+        %{body: "Thank you for taking the survey", type: "ao"}
+      ]
+
+      assert expected_messages_history == messages_history
     end
 
     test "should include all the responses even if the quiz doesn't have a thank-you-message", %{start_simulation: start_simulation} do

--- a/test/lib/runtime/questionnaire_simulator_test.exs
+++ b/test/lib/runtime/questionnaire_simulator_test.exs
@@ -10,7 +10,7 @@ defmodule QuestionnaireSimulatorTest do
     project = insert(:project)
     QuestionnaireSimulatorStore.start_link()
     start_simulation = fn quiz ->
-      {:ok, simulation} = QuestionnaireSimulator.start_simulation(project, quiz)
+      {:ok, simulation} = QuestionnaireSimulator.start_simulation(project, quiz, "sms")
       simulation
     end
     {:ok, project: project, start_simulation: start_simulation}
@@ -23,7 +23,7 @@ defmodule QuestionnaireSimulatorTest do
   end
 
   def process_respondent_response(respondent_id, response) do
-    {:ok, simulation_step} = QuestionnaireSimulator.process_respondent_response(respondent_id, response)
+    {:ok, simulation_step} = QuestionnaireSimulator.process_respondent_response(respondent_id, response, "sms")
     simulation_step
   end
 
@@ -165,11 +165,6 @@ defmodule QuestionnaireSimulatorTest do
     test "when start_simulation with ivr mode", %{project: project} do
       quiz = questionnaire_with_steps(@dummy_steps)
       assert {:error, :invalid_simulation} == QuestionnaireSimulator.start_simulation(project, quiz, "ivr")
-    end
-
-    test "when start_simulation with mobile_web mode", %{project: project} do
-      quiz = questionnaire_with_steps(@dummy_steps)
-      assert {:error, :invalid_simulation} == QuestionnaireSimulator.start_simulation(project, quiz, "mobile-web")
     end
 
     test "when start_simulation with sms mode but questionnaire doesn't have sms mode", %{project: project}  do
@@ -321,7 +316,7 @@ defmodule QuestionnaireSimulatorTest do
   end
 
   defp assert_dummy_steps(project, quiz) do
-    {:ok, %{respondent_id: respondent_id, disposition: disposition, messages_history: messages, simulation_status: status, current_step: current_step}} = QuestionnaireSimulator.start_simulation(project, quiz)
+    {:ok, %{respondent_id: respondent_id, disposition: disposition, messages_history: messages, simulation_status: status, current_step: current_step}} = QuestionnaireSimulator.start_simulation(project, quiz, "sms")
     [first, second, third, fourth] = quiz |> Questionnaire.all_steps|> Enum.map(fn step -> step["id"] end)
     assert "contacted" == disposition
     assert "Do you smoke? Reply 1 for YES, 2 for NO" == List.last(messages).body

--- a/test/lib/runtime/questionnaire_simulator_test.exs
+++ b/test/lib/runtime/questionnaire_simulator_test.exs
@@ -96,20 +96,20 @@ defmodule QuestionnaireSimulatorTest do
 
         %{respondent_id: respondent_id, disposition: disposition, simulation_status: status} = simulation
         assert "contacted" == disposition
-        assert_last_message(simulation, "Do you smoke? Reply 1 for YES, 2 for NO", mode)
+        on_sms_assert_last_message(simulation, "Do you smoke? Reply 1 for YES, 2 for NO", mode)
         assert Simulation.Status.active == status
 
         %{disposition: disposition} = simulation = process_respondent_response(respondent_id, "No", mode)
         assert "started" == disposition
-        assert_last_message(simulation, "Do you exercise? Reply 1 for YES, 2 for NO", mode)
+        on_sms_assert_last_message(simulation, "Do you exercise? Reply 1 for YES, 2 for NO", mode)
 
         %{disposition: disposition} = simulation = process_respondent_response(respondent_id, "Yes", mode)
         assert "interim partial" == disposition
-        assert_last_message(simulation, "Is this the last question?", mode)
+        on_sms_assert_last_message(simulation, "Is this the last question?", mode)
 
         %{disposition: disposition, simulation_status: status} = simulation = process_respondent_response(respondent_id, "Yes", mode)
         assert "completed" == disposition
-        assert_last_message(simulation, "Thanks for completing this survey", mode)
+        on_sms_assert_last_message(simulation, "Thanks for completing this survey", mode)
         assert Simulation.Status.ended == status
       end)
     end
@@ -490,28 +490,28 @@ defmodule QuestionnaireSimulatorTest do
     %{respondent_id: respondent_id, disposition: disposition, simulation_status: status, current_step: current_step} = simulation
     [first, second, third, fourth] = quiz |> Questionnaire.all_steps|> Enum.map(fn step -> step["id"] end)
     assert "contacted" == disposition
-    assert_last_message(simulation, "Do you smoke? Reply 1 for YES, 2 for NO", mode)
+    on_sms_assert_last_message(simulation, "Do you smoke? Reply 1 for YES, 2 for NO", mode)
     assert current_step == first
     assert Ask.Simulation.Status.active == status
 
     %{disposition: disposition, current_step: current_step} = simulation = process_respondent_response(respondent_id, "No", mode)
     assert "started" == disposition
-    assert_last_message(simulation, "Do you exercise? Reply 1 for YES, 2 for NO", mode)
+    on_sms_assert_last_message(simulation, "Do you exercise? Reply 1 for YES, 2 for NO", mode)
     assert current_step == second
 
     %{disposition: disposition, current_step: current_step} = simulation = process_respondent_response(respondent_id, "Yes", mode)
     assert "started" == disposition
-    assert_last_message(simulation, "Which is the second perfect number??", mode)
+    on_sms_assert_last_message(simulation, "Which is the second perfect number??", mode)
     assert current_step == third
 
     %{disposition: disposition, current_step: current_step} = simulation = process_respondent_response(respondent_id, "7", mode)
     assert "started" == disposition
-    assert_last_message(simulation, "What's the number of this question??", mode)
+    on_sms_assert_last_message(simulation, "What's the number of this question??", mode)
     assert current_step == fourth
 
     %{disposition: disposition, simulation_status: status, current_step: current_step} = simulation = process_respondent_response(respondent_id, "4", mode)
     assert "completed" == disposition
-    assert_last_message(simulation, "Thanks for completing this survey", mode)
+    on_sms_assert_last_message(simulation, "Thanks for completing this survey", mode)
     assert current_step == nil
     assert Ask.Simulation.Status.ended == status
   end
@@ -536,7 +536,7 @@ defmodule QuestionnaireSimulatorTest do
     simulation
   end
 
-  defp assert_last_message(simulation, message, mode) do
+  defp on_sms_assert_last_message(simulation, message, mode) do
     if mode == "sms" do
       messages = Map.get(simulation, :messages_history)
       assert message == List.last(messages).body

--- a/test/support/dummy_steps.ex
+++ b/test/support/dummy_steps.ex
@@ -1322,12 +1322,13 @@ defmodule Ask.QuestionnaireRelevantSteps do
       title: "Do you sleep well?",
       prompt: prompt(
         sms: sms_prompt("Do you sleep well? Reply 1 for YES, 2 for NO"),
-        ivr: tts_prompt("Do you sleep well? Press 8 for YES, 9 for NO")
+        ivr: tts_prompt("Do you sleep well? Press 8 for YES, 9 for NO"),
+        mobileweb: "Do you sleep well?"
       ),
       store: "Sleep",
       choices: [
-        choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["8"])),
-        choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["9"]))
+        choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["8"], mobileweb: ["Yes"])),
+        choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["9"], mobileweb: ["No"]))
       ],
       relevant: true
     ),
@@ -1336,7 +1337,8 @@ defmodule Ask.QuestionnaireRelevantSteps do
      title: "How many hours do you sleep?",
      prompt: prompt(
        sms: sms_prompt("How many hours do you sleep??"),
-       ivr: tts_prompt("How many hours do you sleep")
+       ivr: tts_prompt("How many hours do you sleep"),
+       mobileweb: "How many hours do you sleep?"
      ),
      store: "SleepHours",
      skip_logic: default_numeric_skip_logic(),

--- a/test/support/dummy_steps.ex
+++ b/test/support/dummy_steps.ex
@@ -90,10 +90,13 @@ defmodule Ask.StepBuilder do
     }
   end
 
-  def prompt(mobileweb: text) do
+  def prompt(mobileweb: mobileweb) do
     %{
       "en" => %{
-        "mobileweb" => text
+        "mobileweb" => mobileweb
+      },
+      "es" => %{
+        "mobileweb" => "#{mobileweb} (Spanish)"
       }
     }
   end
@@ -119,6 +122,19 @@ defmodule Ask.StepBuilder do
     }
   end
 
+  def prompt(sms: sms, mobileweb: mobileweb) do
+    %{
+      "en" => %{
+        "sms" => sms,
+        "mobileweb" => mobileweb
+      },
+      "es" => %{
+        "sms" => "#{sms} (Spanish)",
+        "mobileweb" => "#{mobileweb} (Spanish)"
+      }
+    }
+  end
+
   def prompt(sms: sms, ivr: ivr, mobileweb: mobileweb) do
     %{
       "en" => %{
@@ -129,7 +145,7 @@ defmodule Ask.StepBuilder do
       "es" => %{
         "sms" => "#{sms} (Spanish)",
         "ivr" => ivr,
-        "mobileweb" => mobileweb
+        "mobileweb" => "#{mobileweb} (Spanish)"
       }
     }
   end
@@ -191,6 +207,17 @@ defmodule Ask.StepBuilder do
         "en" => sms
       },
       "ivr" => ivr
+    }
+  end
+
+  def responses(sms: sms, mobileweb: mobileweb) do
+    %{
+      "sms" => %{
+        "en" => sms
+      },
+      "mobileweb" => %{
+        "en" => mobileweb
+      }
     }
   end
 

--- a/test/support/dummy_steps.ex
+++ b/test/support/dummy_steps.ex
@@ -119,6 +119,21 @@ defmodule Ask.StepBuilder do
     }
   end
 
+  def prompt(sms: sms, ivr: ivr, mobileweb: mobileweb) do
+    %{
+      "en" => %{
+        "sms" => sms,
+        "ivr" => ivr,
+        "mobileweb" => mobileweb
+      },
+      "es" => %{
+        "sms" => "#{sms} (Spanish)",
+        "ivr" => ivr,
+        "mobileweb" => mobileweb
+      }
+    }
+  end
+
   def sms_prompt(prompt) do
     prompt
   end
@@ -179,6 +194,18 @@ defmodule Ask.StepBuilder do
     }
   end
 
+  def responses(sms: sms, ivr: ivr, mobileweb: mobileweb) do
+    %{
+      "sms" => %{
+        "en" => sms
+      },
+      "ivr" => ivr,
+      "mobileweb" => %{
+        "en" => mobileweb
+      }
+    }
+  end
+
   def responses(ivr: ivr) do
     %{
       "ivr" => ivr
@@ -225,12 +252,13 @@ defmodule Ask.DummySteps do
           title: "Do you smoke?",
           prompt: prompt(
             sms: sms_prompt("Do you smoke? Reply 1 for YES, 2 for NO"),
-            ivr: tts_prompt("Do you smoke? Press 8 for YES, 9 for NO")
+            ivr: tts_prompt("Do you smoke? Press 8 for YES, 9 for NO"),
+            mobileweb: "Do you smoke?"
           ),
           store: "Smokes",
           choices: [
-            choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["8"])),
-            choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["9"]))
+            choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["8"], mobileweb: ["Yes"])),
+            choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["9"], mobileweb: ["No"]))
           ]
         ),
         multiple_choice_step(
@@ -238,12 +266,13 @@ defmodule Ask.DummySteps do
           title: "Do you exercise",
           prompt: prompt(
             sms: sms_prompt("Do you exercise? Reply 1 for YES, 2 for NO"),
-            ivr: tts_prompt("Do you exercise? Press 1 for YES, 2 for NO")
+            ivr: tts_prompt("Do you exercise? Press 1 for YES, 2 for NO"),
+            mobileweb: "Do you exercise?"
           ),
           store: "Exercises",
           choices: [
-            choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["1"])),
-            choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["2"]))
+            choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["1"], mobileweb: ["Yes"])),
+            choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["2"], mobileweb: ["No"]))
           ]
         ),
         numeric_step(
@@ -251,7 +280,8 @@ defmodule Ask.DummySteps do
           title: "Which is the second perfect number?",
           prompt: prompt(
             sms: sms_prompt("Which is the second perfect number??"),
-            ivr: tts_prompt("Which is the second perfect number")
+            ivr: tts_prompt("Which is the second perfect number"),
+            mobileweb: "Which is the second perfect number?"
             ),
           store: "Perfect Number",
           skip_logic: default_numeric_skip_logic(),
@@ -263,7 +293,8 @@ defmodule Ask.DummySteps do
           title: "What's the number of this question?",
           prompt: prompt(
             sms: sms_prompt("What's the number of this question??"),
-            ivr: tts_prompt("What's the number of this question")
+            ivr: tts_prompt("What's the number of this question"),
+            mobileweb: "What's the number of this question",
             ),
           store: "Question",
           skip_logic: default_numeric_skip_logic(),

--- a/web/controllers/mobile_survey_controller.ex
+++ b/web/controllers/mobile_survey_controller.ex
@@ -82,9 +82,9 @@ defmodule Ask.MobileSurveyController do
         respondent.state in ["pending", "active", "rejected"] ->
           case Survey.sync_step(respondent, value, "mobileweb") do
             {:reply, reply, _} ->
-              {first_step(reply), progress(reply), reply.error_message}
+              {Reply.first_step(reply), Reply.progress(reply), reply.error_message}
             {:end, {:reply, reply}, _} ->
-              {first_step(reply), progress(reply), reply.error_message}
+              {Reply.first_step(reply), Reply.progress(reply), reply.error_message}
             {:end, _} ->
               {end_step(), end_progress(), nil}
           end
@@ -98,20 +98,6 @@ defmodule Ask.MobileSurveyController do
       progress: progress,
       error_message: error_message
     })
-  end
-
-  defp first_step(reply) do
-    reply |> Reply.steps() |> hd
-  end
-
-  defp progress(reply) do
-    if reply.current_step && reply.total_steps && reply.total_steps > 0 do
-      100 * (reply.current_step / reply.total_steps)
-    else
-      # If no explicit progress is set in the reply, assume we are at the end.
-      # This happens in the "thank you" and "quota completed" messages.
-      100.0
-    end
   end
 
   defp end_step(msg \\ "The survey has ended") do

--- a/web/controllers/mobile_survey_simulation_controller.ex
+++ b/web/controllers/mobile_survey_simulation_controller.ex
@@ -1,14 +1,14 @@
 defmodule Ask.MobileSurveySimulationController do
-  alias Ask.Runtime.{QuestionnaireSimulatorStore}
+  alias Ask.Runtime.{QuestionnaireSimulator, QuestionnaireSimulatorStore, Reply}
   use Ask.Web, :controller
 
-  def index(conn, %{"respondent_id" => respondent_id, "token" => token}) do
+  def index(conn, %{"respondent_id" => respondent_id}) do
     %{respondent: respondent} = QuestionnaireSimulatorStore.get_respondent_simulation(respondent_id)
     color_style = respondent.session.flow.questionnaire.settings["mobile_web_color_style"]
-    render_index(conn, respondent, token, color_style)
+    render_index(conn, respondent, color_style)
   end
 
-  defp render_index(conn, respondent, token, color_style) do
+  defp render_index(conn, respondent, color_style) do
     questionnaire = respondent.session.flow.questionnaire
     default_language = questionnaire.default_language
 
@@ -21,6 +21,23 @@ defmodule Ask.MobileSurveySimulationController do
 
     conn
     |> put_layout({Ask.LayoutView, "mobile_survey.html"})
-    |> render("index.html", respondent_id: respondent.id, token: token, color_style: color_style, title: title, mobile_web_intro_message: mobile_web_intro_message)
+    |> render("index.html", respondent_id: respondent.id, color_style: color_style, title: title, mobile_web_intro_message: mobile_web_intro_message)
   end
+
+  def get_step(conn, %{"respondent_id" => respondent_id}) do
+    {:ok, simulation_step} = QuestionnaireSimulator.process_respondent_response(respondent_id, :answer, "mobileweb")
+    render_reply(conn, simulation_step.reply)
+  end
+
+  def send_reply(conn, %{"respondent_id" => respondent_id, "value" => value}) do
+    {:ok, simulation_step} = QuestionnaireSimulator.process_respondent_response(respondent_id, value, "mobileweb")
+    render_reply(conn, simulation_step.reply)
+  end
+
+  defp render_reply(conn, reply), do:
+    json(conn, %{
+      step: Reply.first_step(reply),
+      progress: Reply.progress(reply),
+      error_message: reply.error_message
+    })
 end

--- a/web/controllers/mobile_survey_simulation_controller.ex
+++ b/web/controllers/mobile_survey_simulation_controller.ex
@@ -1,0 +1,26 @@
+defmodule Ask.MobileSurveySimulationController do
+  alias Ask.Runtime.{QuestionnaireSimulatorStore}
+  use Ask.Web, :controller
+
+  def index(conn, %{"respondent_id" => respondent_id, "token" => token}) do
+    %{respondent: respondent} = QuestionnaireSimulatorStore.get_respondent_simulation(respondent_id)
+    color_style = respondent.session.flow.questionnaire.settings["mobile_web_color_style"]
+    render_index(conn, respondent, token, color_style)
+  end
+
+  defp render_index(conn, respondent, token, color_style) do
+    questionnaire = respondent.session.flow.questionnaire
+    default_language = questionnaire.default_language
+
+    {title, mobile_web_intro_message} = case questionnaire do
+      %{settings: %{"title" => %{^default_language => some_title}, "mobile_web_intro_message" => intro_message }} ->
+        {some_title, intro_message}
+      _ ->
+        {"Your survey", "Go ahead"}
+    end
+
+    conn
+    |> put_layout({Ask.LayoutView, "mobile_survey.html"})
+    |> render("index.html", respondent_id: respondent.id, token: token, color_style: color_style, title: title, mobile_web_intro_message: mobile_web_intro_message)
+  end
+end

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -402,7 +402,7 @@ defmodule Ask.QuestionnaireController do
       render(conn, "simulation.json", simulation: simulation_response)
   end
 
-  def get_last_simulation_response(conn, %{"project_id" => project_id, "respondent_id" => respondent_id, "mode" => "mobileweb"}) do
+  def get_last_simulation_response(conn, %{"project_id" => project_id, "respondent_id" => respondent_id}) do
     # Load project to authorize connection
     conn |> load_project(project_id)
     with {:ok, simulation_response} <- QuestionnaireMobileWebSimulator.get_last_simulation_response(respondent_id), do:

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -406,11 +406,9 @@ defmodule Ask.QuestionnaireController do
       render(conn, "simulation.json", simulation: simulation_response)
   end
 
-  # TODO: Restrict to MobileWeb mode only
-  def get_last_simulation_response(conn, %{"project_id" => project_id}) do
+  def get_last_simulation_response(conn, %{"project_id" => project_id, "respondent_id" => respondent_id, "mode" => "mobileweb"}) do
     # Load project to authorize connection
     conn |> load_project(project_id)
-    respondent_id = conn.params["respondent_id"]
     with {:ok, simulation_response} <- QuestionnaireMobileWebSimulator.get_last_simulation_response(respondent_id), do:
       render(conn, "simulation.json", simulation: simulation_response)
   end

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -391,7 +391,7 @@ defmodule Ask.QuestionnaireController do
     with {:ok, questionnaire} <- load_questionnaire(project, id),
          {:ok, simulation} <- QuestionnaireSimulator.start_simulation(project, questionnaire, mode)
     do
-      render(conn, "simulation.json", simulation: simulation)
+      render(conn, "simulation.json", simulation: simulation, mode: mode)
     end
   end
 

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -15,7 +15,7 @@ defmodule Ask.QuestionnaireController do
     Gettext
   }
   alias Ecto.Multi
-  alias Ask.Runtime.QuestionnaireSimulator
+  alias Ask.Runtime.{QuestionnaireSimulator, QuestionnaireMobileWebSimulator}
 
   plug :validate_params when action in [:create, :update]
   action_fallback Ask.FallbackController
@@ -395,21 +395,23 @@ defmodule Ask.QuestionnaireController do
     end
   end
 
+  # TODO: Restrict to SMS mode only
   def sync_simulation(conn, %{"project_id" => project_id}) do
     # Load project to authorize connection
     conn |> load_project(project_id)
 
     respondent_id = conn.params["respondent_id"]
     response = conn.params["response"]
-    with {:ok, simulation_response} <- QuestionnaireSimulator.process_respondent_response(respondent_id, response), do:
+    with {:ok, simulation_response} <- QuestionnaireSimulator.process_respondent_response(respondent_id, response, "sms"), do:
       render(conn, "simulation.json", simulation: simulation_response)
   end
 
+  # TODO: Restrict to MobileWeb mode only
   def get_last_simulation_response(conn, %{"project_id" => project_id}) do
     # Load project to authorize connection
     conn |> load_project(project_id)
     respondent_id = conn.params["respondent_id"]
-    with {:ok, simulation_response} <- QuestionnaireSimulator.get_last_simulation_response(respondent_id), do:
+    with {:ok, simulation_response} <- QuestionnaireMobileWebSimulator.get_last_simulation_response(respondent_id), do:
       render(conn, "simulation.json", simulation: simulation_response)
   end
 

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -395,13 +395,9 @@ defmodule Ask.QuestionnaireController do
     end
   end
 
-  # TODO: Restrict to SMS mode only
-  def sync_simulation(conn, %{"project_id" => project_id}) do
+  def sync_simulation(conn, %{"project_id" => project_id, "respondent_id" => respondent_id, "response" => response, "mode" => "sms"}) do
     # Load project to authorize connection
     conn |> load_project(project_id)
-
-    respondent_id = conn.params["respondent_id"]
-    response = conn.params["response"]
     with {:ok, simulation_response} <- QuestionnaireSimulator.process_respondent_response(respondent_id, response, "sms"), do:
       render(conn, "simulation.json", simulation: simulation_response)
   end

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -389,9 +389,9 @@ defmodule Ask.QuestionnaireController do
     project = conn |> load_project(project_id)
     mode = conn.params["mode"]
     with {:ok, questionnaire} <- load_questionnaire(project, id),
-         {:ok, simulation} <- QuestionnaireSimulator.start_simulation(project, questionnaire, mode)
+         {:ok, simulation_response} <- QuestionnaireSimulator.start_simulation(project, questionnaire, mode)
     do
-      render(conn, "simulation.json", simulation: simulation, mode: mode)
+      render(conn, "simulation.json", simulation: simulation_response, mode: mode)
     end
   end
 
@@ -401,8 +401,16 @@ defmodule Ask.QuestionnaireController do
 
     respondent_id = conn.params["respondent_id"]
     response = conn.params["response"]
-    with {:ok, simulation} <- QuestionnaireSimulator.process_respondent_response(respondent_id, response), do:
-      render(conn, "simulation.json", simulation: simulation)
+    with {:ok, simulation_response} <- QuestionnaireSimulator.process_respondent_response(respondent_id, response), do:
+      render(conn, "simulation.json", simulation: simulation_response)
+  end
+
+  def get_last_simulation_response(conn, %{"project_id" => project_id}) do
+    # Load project to authorize connection
+    conn |> load_project(project_id)
+    respondent_id = conn.params["respondent_id"]
+    with {:ok, simulation_response} <- QuestionnaireSimulator.get_last_simulation_response(respondent_id), do:
+      render(conn, "simulation.json", simulation: simulation_response)
   end
 
   defp validate_params(conn, _params) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -170,6 +170,7 @@ defmodule Ask.Router do
   get "/callbacks/:provider/*path", Ask.CallbackController, :callback
   post "/callbacks/:provider/*path", Ask.CallbackController, :callback
   get "/mobile/:respondent_id", Ask.MobileSurveyController, :index
+  get "/mobile/simulation/:respondent_id", Ask.MobileSurveySimulationController, :index
   get "/mobile/get_step/:respondent_id", Ask.MobileSurveyController, :get_step
   post "/mobile/send_reply/:respondent_id", Ask.MobileSurveyController, :send_reply
   get "/mobile/errors/unauthorized", Ask.MobileSurveyController, :unauthorized_error

--- a/web/router.ex
+++ b/web/router.ex
@@ -114,6 +114,8 @@ defmodule Ask.Router do
           post "/import_zip", QuestionnaireController, :import_zip, as: :questionnaires_import_zip
           post "/simulation", QuestionnaireController, :start_simulation, as: :questionnaires_start_simulation
           post "/simulation/message", QuestionnaireController, :sync_simulation, as: :questionnaires_sync_simulation
+          # TODO: This should be a GET endpoint. Fix front-end normalize error and change it.
+          post "/simulation/:respondent_id", QuestionnaireController, :get_last_simulation_response, as: :get_last_simulation_response
           put "/update_archived_status", QuestionnaireController, :update_archived_status, as: :update_archived_status
         end
         get "/autocomplete_vars", ProjectController, :autocomplete_vars, as: :autocomplete_vars
@@ -169,8 +171,10 @@ defmodule Ask.Router do
   post "/callbacks/:provider", Ask.CallbackController, :callback
   get "/callbacks/:provider/*path", Ask.CallbackController, :callback
   post "/callbacks/:provider/*path", Ask.CallbackController, :callback
-  get "/mobile/:respondent_id", Ask.MobileSurveyController, :index
   get "/mobile/simulation/:respondent_id", Ask.MobileSurveySimulationController, :index
+  get "/mobile/simulation/get_step/:respondent_id", Ask.MobileSurveySimulationController, :get_step
+  post "/mobile/simulation/send_reply/:respondent_id", Ask.MobileSurveySimulationController, :send_reply
+  get "/mobile/:respondent_id", Ask.MobileSurveyController, :index
   get "/mobile/get_step/:respondent_id", Ask.MobileSurveyController, :get_step
   post "/mobile/send_reply/:respondent_id", Ask.MobileSurveyController, :send_reply
   get "/mobile/errors/unauthorized", Ask.MobileSurveyController, :unauthorized_error

--- a/web/router.ex
+++ b/web/router.ex
@@ -114,8 +114,7 @@ defmodule Ask.Router do
           post "/import_zip", QuestionnaireController, :import_zip, as: :questionnaires_import_zip
           post "/simulation", QuestionnaireController, :start_simulation, as: :questionnaires_start_simulation
           post "/simulation/message", QuestionnaireController, :sync_simulation, as: :questionnaires_sync_simulation
-          # TODO: This should be a GET endpoint. Fix front-end normalize error and change it.
-          post "/simulation/:respondent_id", QuestionnaireController, :get_last_simulation_response, as: :get_last_simulation_response
+          get "/simulation/:respondent_id", QuestionnaireController, :get_last_simulation_response, as: :get_last_simulation_response
           put "/update_archived_status", QuestionnaireController, :update_archived_status, as: :update_archived_status
         end
         get "/autocomplete_vars", ProjectController, :autocomplete_vars, as: :autocomplete_vars

--- a/web/static/css/_quex-simulation.scss
+++ b/web/static/css/_quex-simulation.scss
@@ -239,20 +239,6 @@ $smallChatWindowBodyHeight: $smallSimulationHeight -
   border-radius: 5px;
   box-shadow: 0 2px 10px 2px rgba(0, 0, 0, 0.4);
 
-  .chat-header {
-    @extend .valign-wrapper;
-
-    button {
-      background: $chatBorderBackground;
-      border: none;
-      line-height: 0;
-      width: 30%;
-    }
-
-    .title {
-      position: relative;
-    }
-  }
   iframe {
     width: 100%;
     height: $simulationHeight - $chatWindowHeaderHeight;

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -519,6 +519,11 @@ export const startSimulation = (projectId, questionnaireId, mode) => {
   return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation`, arrayOf(referenceSchema), 'POST', { mode }, passthroughCallback)
 }
 
+export const fetchSimulation = (projectId, questionnaireId, respondentId) => {
+  // TODO: This should use GET. Fix the normalize error and change it.
+  return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation/${respondentId}`, arrayOf(referenceSchema), 'POST', {}, passthroughCallback)
+}
+
 export const messageSimulation = (projectId, questionnaireId, respondentId, message) => {
   const body = {
     respondentId,

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -524,10 +524,11 @@ export const fetchSimulation = (projectId, questionnaireId, respondentId, mode) 
   return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation/${respondentId}`, arrayOf(referenceSchema), 'POST', { mode }, passthroughCallback)
 }
 
-export const messageSimulation = (projectId, questionnaireId, respondentId, message) => {
+export const messageSimulation = (projectId, questionnaireId, respondentId, message, mode) => {
   const body = {
     respondentId,
-    response: message
+    response: message,
+    mode
   }
   return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation/message`, arrayOf(referenceSchema), 'POST', body, passthroughCallback)
 }

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -516,12 +516,11 @@ export const refreshDispositionHistoryLink = (projectId, surveyId) => {
 }
 
 export const startSimulation = (projectId, questionnaireId, mode) => {
-  return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation`, arrayOf(referenceSchema), 'POST', { mode }, passthroughCallback)
+  return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation`, null, 'POST', { mode }, passthroughCallback)
 }
 
 export const fetchSimulation = (projectId, questionnaireId, respondentId, mode) => {
-  // TODO: This should use GET. Fix the normalize error and change it.
-  return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation/${respondentId}`, arrayOf(referenceSchema), 'POST', { mode }, passthroughCallback)
+  return apiFetchJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation/${respondentId}`, null, {}, passthroughCallback)
 }
 
 export const messageSimulation = (projectId, questionnaireId, respondentId, message, mode) => {
@@ -530,7 +529,7 @@ export const messageSimulation = (projectId, questionnaireId, respondentId, mess
     response: message,
     mode
   }
-  return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation/message`, arrayOf(referenceSchema), 'POST', body, passthroughCallback)
+  return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation/message`, null, 'POST', body, passthroughCallback)
 }
 
 export const deleteResultsLink = (projectId, surveyId) => {

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -519,9 +519,9 @@ export const startSimulation = (projectId, questionnaireId, mode) => {
   return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation`, arrayOf(referenceSchema), 'POST', { mode }, passthroughCallback)
 }
 
-export const fetchSimulation = (projectId, questionnaireId, respondentId) => {
+export const fetchSimulation = (projectId, questionnaireId, respondentId, mode) => {
   // TODO: This should use GET. Fix the normalize error and change it.
-  return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation/${respondentId}`, arrayOf(referenceSchema), 'POST', {}, passthroughCallback)
+  return apiPutOrPostJSONWithCallback(`projects/${projectId}/questionnaires/${questionnaireId}/simulation/${respondentId}`, arrayOf(referenceSchema), 'POST', { mode }, passthroughCallback)
 }
 
 export const messageSimulation = (projectId, questionnaireId, respondentId, message) => {

--- a/web/static/js/components/questionnaires/TestQuestionnaireModal.jsx
+++ b/web/static/js/components/questionnaires/TestQuestionnaireModal.jsx
@@ -90,7 +90,7 @@ class TestQuestionnaireModal extends Component {
     let channelOptions = []
     channelOptions.push(<option key={0} value=''>{t('Select a channel...')}</option>)
 
-    if (mode == 'sms') channelOptions.push(<option key='simulation' value='simulation'>{t('Simulation')}</option>)
+    if (['sms', 'mobileweb'].includes(mode)) channelOptions.push(<option key='simulation' value='simulation'>{t('Simulation')}</option>)
 
     for (const channelId in channels) {
       const channel = channels[channelId]

--- a/web/static/js/components/simulation/MobileWebWindow.jsx
+++ b/web/static/js/components/simulation/MobileWebWindow.jsx
@@ -1,0 +1,27 @@
+// @flow
+import React, { Component } from 'react'
+import { translate } from 'react-i18next'
+
+type MobileWebWindowProps = {
+  indexUrl: string,
+  t: Function
+}
+
+class MobileWebWindow extends Component<MobileWebWindowProps> {
+  render() {
+    const { indexUrl, t } = this.props
+
+    return (
+      <div className='mobile-web-iframe-container'>
+        <div className='chat-header'>
+          <div className='title'>
+            {t('Mobileweb mode')}
+          </div>
+        </div>
+        <iframe src={indexUrl} className={'mobile-web'} />
+      </div>
+    )
+  }
+}
+
+export default translate()(MobileWebWindow)

--- a/web/static/js/components/simulation/QuestionnaireSimulation.jsx
+++ b/web/static/js/components/simulation/QuestionnaireSimulation.jsx
@@ -72,7 +72,7 @@ class QuestionnaireSimulation extends Component<Props, State> {
     if (projectId && questionnaireId) {
       this.fetchQuestionnaireForTitle()
       // We only support SMS for now
-      if (mode == 'sms') {
+      if (['sms', 'mobileweb'].includes(mode)) {
         startSimulation(projectId, questionnaireId, mode).then(result => {
           this.setState({ simulation: {
             messagesHistory: result.messagesHistory,
@@ -147,7 +147,7 @@ class QuestionnaireSimulation extends Component<Props, State> {
 
   render() {
     const { simulation } = this.state
-    const { router, projectId, questionnaireId } = this.props
+    const { router, projectId, questionnaireId, mode } = this.props
     const simulationIsActive = simulation && simulation.simulationStatus == 'active'
     const closeSimulationButton = (
       <div>
@@ -157,6 +157,11 @@ class QuestionnaireSimulation extends Component<Props, State> {
           </a>
         </Tooltip>
       </div>
+    )
+    const phoneWindow = () => (
+      mode == 'sms'
+      ? <ChatWindow messages={simulation.messagesHistory} onSendMessage={this.handleATMessage} chatTitle={'SMS mode'} readOnly={!simulationIsActive} scrollToBottom />
+      : null
     )
 
     return <div>
@@ -171,7 +176,7 @@ class QuestionnaireSimulation extends Component<Props, State> {
               submissions={simulation.submissions}
               simulationIsEnded={simulation.simulationStatus == 'ended'}
             />
-            <ChatWindow messages={simulation.messagesHistory} onSendMessage={this.handleATMessage} chatTitle={'SMS mode'} readOnly={!simulationIsActive} scrollToBottom />
+            {phoneWindow()}
           </div>
         </div>
         : 'Loading'

--- a/web/static/js/components/simulation/QuestionnaireSimulation.jsx
+++ b/web/static/js/components/simulation/QuestionnaireSimulation.jsx
@@ -124,11 +124,11 @@ class QuestionnaireSimulation extends Component<Props, State> {
   }
 
   handleATMessage = message => {
-    const { projectId, questionnaireId } = this.props
+    const { projectId, questionnaireId, mode } = this.props
     const { simulation } = this.state
     if (simulation) {
       this.addMessage(message)
-      messageSimulation(projectId, questionnaireId, simulation.respondentId, message.body).then(result => {
+      messageSimulation(projectId, questionnaireId, simulation.respondentId, message.body, mode).then(result => {
         this.onSimulationChanged(result)
       })
     }

--- a/web/static/js/components/simulation/QuestionnaireSimulation.jsx
+++ b/web/static/js/components/simulation/QuestionnaireSimulation.jsx
@@ -153,7 +153,7 @@ class QuestionnaireSimulation extends Component<Props, State> {
     const { simulation } = this.state
     const { router, projectId, questionnaireId, mode, t } = this.props
 
-    if (!simulation) return <div>{t('Loading')}</div>
+    if (!simulation) return <div>{t('Loading...')}</div>
 
     const simulationIsActive = simulation && simulation.simulationStatus == 'active'
     const closeSimulationButton = (

--- a/web/static/js/components/simulation/QuestionnaireSimulation.jsx
+++ b/web/static/js/components/simulation/QuestionnaireSimulation.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import * as routes from '../../routes'
 import { Tooltip } from '../ui'
-import { startSimulation, messageSimulation } from '../../api.js'
+import { startSimulation, messageSimulation, fetchSimulation } from '../../api.js'
 import ChatWindow from './ChatWindow'
 import MobileWebWindow from './MobileWebWindow'
 import DispositionChart from './DispositionChart'
@@ -54,6 +54,15 @@ class QuestionnaireSimulation extends Component<Props, State> {
 
   componentDidMount = () => {
     browserHistory.listen(this.onRouteChange)
+    window.addEventListener('message', event => {
+      const { simulation } = this.state
+      if (event.data.simulationChanged && simulation) {
+        const { projectId, questionnaireId } = this.props
+        return fetchSimulation(projectId, questionnaireId, simulation.respondentId).then(result => {
+          this.onSimulationChanged(result)
+        })
+      }
+    })
   }
 
   onRouteChange = () => {
@@ -82,7 +91,7 @@ class QuestionnaireSimulation extends Component<Props, State> {
     }
   }
 
-  handleMessageResult = result => {
+  onSimulationChanged = result => {
     const { simulation } = this.state
     const { t } = this.props
     if (result.simulationStatus == 'expired') {
@@ -119,7 +128,7 @@ class QuestionnaireSimulation extends Component<Props, State> {
     if (simulation) {
       this.addMessage(message)
       messageSimulation(projectId, questionnaireId, simulation.respondentId, message.body).then(result => {
-        this.handleMessageResult(result)
+        this.onSimulationChanged(result)
       })
     }
   }

--- a/web/static/js/components/simulation/QuestionnaireSimulation.jsx
+++ b/web/static/js/components/simulation/QuestionnaireSimulation.jsx
@@ -55,10 +55,11 @@ class QuestionnaireSimulation extends Component<Props, State> {
   componentDidMount = () => {
     browserHistory.listen(this.onRouteChange)
     window.addEventListener('message', event => {
+      const { mode } = this.props
       const { simulation } = this.state
       if (event.data.simulationChanged && simulation) {
         const { projectId, questionnaireId } = this.props
-        return fetchSimulation(projectId, questionnaireId, simulation.respondentId).then(result => {
+        return fetchSimulation(projectId, questionnaireId, simulation.respondentId, mode).then(result => {
           this.onSimulationChanged(result)
         })
       }

--- a/web/static/js/components/simulation/QuestionnaireSimulation.jsx
+++ b/web/static/js/components/simulation/QuestionnaireSimulation.jsx
@@ -8,6 +8,7 @@ import * as routes from '../../routes'
 import { Tooltip } from '../ui'
 import { startSimulation, messageSimulation } from '../../api.js'
 import ChatWindow from './ChatWindow'
+import MobileWebWindow from './MobileWebWindow'
 import DispositionChart from './DispositionChart'
 import SimulationSteps from './SimulationSteps'
 import { translate } from 'react-i18next'
@@ -29,7 +30,8 @@ type Simulation = {
   disposition: string,
   respondentId: string,
   currentStep: string,
-  questionnaire: Questionnaire
+  questionnaire: Questionnaire,
+  indexUrl: string
 }
 
 type Props = {
@@ -74,15 +76,7 @@ class QuestionnaireSimulation extends Component<Props, State> {
       // We only support SMS for now
       if (['sms', 'mobileweb'].includes(mode)) {
         startSimulation(projectId, questionnaireId, mode).then(result => {
-          this.setState({ simulation: {
-            messagesHistory: result.messagesHistory,
-            submissions: result.submissions,
-            simulationStatus: result.simulationStatus,
-            disposition: result.disposition,
-            respondentId: result.respondentId,
-            currentStep: result.currentStep,
-            questionnaire: result.questionnaire
-          }})
+          this.setState({simulation: result})
         })
       }
     }
@@ -147,7 +141,10 @@ class QuestionnaireSimulation extends Component<Props, State> {
 
   render() {
     const { simulation } = this.state
-    const { router, projectId, questionnaireId, mode } = this.props
+    const { router, projectId, questionnaireId, mode, t } = this.props
+
+    if (!simulation) return <div>{t('Loading')}</div>
+
     const simulationIsActive = simulation && simulation.simulationStatus == 'active'
     const closeSimulationButton = (
       <div>
@@ -158,29 +155,25 @@ class QuestionnaireSimulation extends Component<Props, State> {
         </Tooltip>
       </div>
     )
-    const phoneWindow = () => (
-      mode == 'sms'
-      ? <ChatWindow messages={simulation.messagesHistory} onSendMessage={this.handleATMessage} chatTitle={'SMS mode'} readOnly={!simulationIsActive} scrollToBottom />
-      : null
-    )
+    const phoneWindow = () => {
+      if (mode == 'sms') {
+        return <ChatWindow messages={simulation.messagesHistory} onSendMessage={this.handleATMessage} chatTitle={'SMS mode'} readOnly={!simulationIsActive} scrollToBottom />
+      } else if (mode == 'mobileweb') {
+        return <MobileWebWindow indexUrl={simulation.indexUrl} />
+      }
+    }
 
     return <div>
-      {
-        simulation
-        ? <div>
-          {closeSimulationButton}
-          <div className='quex-simulation-container'>
-            <DispositionChart disposition={simulation.disposition} />
-            <SimulationSteps steps={simulation.questionnaire.steps}
-              currentStepId={simulation.currentStep}
-              submissions={simulation.submissions}
-              simulationIsEnded={simulation.simulationStatus == 'ended'}
-            />
-            {phoneWindow()}
-          </div>
-        </div>
-        : 'Loading'
-      }
+      {closeSimulationButton}
+      <div className='quex-simulation-container'>
+        <DispositionChart disposition={simulation.disposition} />
+        <SimulationSteps steps={simulation.questionnaire.steps}
+          currentStepId={simulation.currentStep}
+          submissions={simulation.submissions}
+          simulationIsEnded={simulation.simulationStatus == 'ended'}
+        />
+        {phoneWindow()}
+      </div>
     </div>
   }
 }

--- a/web/static/js/components/surveys/SurveySimulation.jsx
+++ b/web/static/js/components/surveys/SurveySimulation.jsx
@@ -314,7 +314,7 @@ class SurveySimulation extends Component {
   }
 
   render() {
-    const { t, mode } = this.props
+    const { t } = this.props
     const { disposition } = this.state
     return (
       <div>
@@ -324,20 +324,14 @@ class SurveySimulation extends Component {
           </a>
         </Tooltip>
         <ConfirmationModal modalId='survey_stop_simulation_modal' ref='stopSimulationModal' confirmationText={t('Stop')} header={t('Stop simulation')} showCancel />
-        {
-          mode == 'mobileweb'
-          ? this.mobileWebSimulation()
-          : (
-            <div className='row'>
-              <div className='col s12 m4'>
-                <DispositionChart disposition={disposition} />
-              </div>
-              <div className='col s12 m8'>
-                {this.stepsComponent()}
-              </div>
-            </div>
-          )
-        }
+        <div className='row'>
+          <div className='col s12 m4'>
+            <DispositionChart disposition={disposition} />
+          </div>
+          <div className='col s12 m8'>
+            {this.stepsComponent()}
+          </div>
+        </div>
       </div>
     )
   }

--- a/web/static/mobile_survey/js/actions/step.js
+++ b/web/static/mobile_survey/js/actions/step.js
@@ -3,8 +3,8 @@ import * as api from '../api'
 
 export const RECEIVE = 'STEP_RECEIVE'
 
-export const fetchStep = (dispatch: (action: any) => any, respondentId: any, token: string) => {
-  return api.fetchStep(respondentId, token).then((response: any) => {
+export const fetchStep = (dispatch: (action: any) => any, respondentId: any, token: string, apiUrl: string) => {
+  return api.fetchStep(respondentId, token, apiUrl).then((response: any) => {
     if (response.status == 401 || response.status == 403) {
       window.location = window.location.origin + '/mobile/errors/unauthorized?id=' + respondentId
     } else {
@@ -15,8 +15,8 @@ export const fetchStep = (dispatch: (action: any) => any, respondentId: any, tok
   })
 }
 
-export const sendReply = (dispatch: (action: any) => any, respondentId: any, token: string, stepId: any, value: any) => {
-  return api.sendReply(respondentId, token, stepId, value).then((response: any) => {
+export const sendReply = (dispatch: (action: any) => any, respondentId: any, token: string, stepId: any, value: any, apiUrl: string) => {
+  return api.sendReply(respondentId, token, stepId, value, apiUrl).then((response: any) => {
     response.json().then(json => {
       dispatch(receiveStep(json))
     })

--- a/web/static/mobile_survey/js/api.js
+++ b/web/static/mobile_survey/js/api.js
@@ -1,14 +1,14 @@
 // @flow
 import 'isomorphic-fetch'
 
-export const fetchStep = (id: any, token: string) => {
-  return fetch(`/mobile/get_step/${encodeURIComponent(id)}?token=${encodeURIComponent(token)}`, {
+export const fetchStep = (id: any, token: string, apiUrl: string) => {
+  return fetch(`${apiUrl}/get_step/${encodeURIComponent(id)}?token=${encodeURIComponent(token)}`, {
     credentials: 'same-origin'
   })
 }
 
-export const sendReply = (respondentId: any, token: string, stepId: any, value: any) => {
-  return fetch(`/mobile/send_reply/${encodeURIComponent(respondentId)}?value=${encodeURIComponent(value)}&step_id=${encodeURIComponent(stepId)}&token=${encodeURIComponent(token)}`, {
+export const sendReply = (respondentId: any, token: string, stepId: any, value: any, apiUrl: string) => {
+  return fetch(`${apiUrl}/send_reply/${encodeURIComponent(respondentId)}?value=${encodeURIComponent(value)}&step_id=${encodeURIComponent(stepId)}&token=${encodeURIComponent(token)}`, {
     method: 'POST',
     credentials: 'same-origin'
   })

--- a/web/templates/layout/mobile_survey_simulation.html.eex
+++ b/web/templates/layout/mobile_survey_simulation.html.eex
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <%= render "_favicon.html" %>
+
+    <title><%= @title %></title>
+    <link rel="stylesheet" href="<%= static_path(@conn, "/css/mobileSurvey.css") %>">
+    <script>
+      window.mixEnv = "<%= Mix.env %>"
+      window.appConfig = <%= raw(config(@conn)) %>
+    </script>
+  </head>
+
+  <%= render @view_module, @view_template, assigns %>
+</html>

--- a/web/templates/mobile_survey/index.html.eex
+++ b/web/templates/mobile_survey/index.html.eex
@@ -4,6 +4,7 @@
     window.mixEnv = "<%= Mix.env %>"
     window.respondentId = <%= @respondent_id %>
     window.token = "<%= @token %>"
+    window.apiUrl = "/mobile"
   </script>
   <script src="<%= static_path(@conn, "/js/mobileSurvey.js") %>"></script>
 </body>

--- a/web/templates/mobile_survey_simulation/404.html.eex
+++ b/web/templates/mobile_survey_simulation/404.html.eex
@@ -1,0 +1,14 @@
+<body>
+  <div id="root" role="main"></div>
+    <div ref='stepContent'>
+      <header>
+        <nav>
+          <h1>Sorry</h1>
+        </nav>
+      </header>
+      <main>
+        <div className={'prompt'}><h1>This survey is no longer available</h1></div>
+      </main>
+    </div>
+  </div>
+</body>

--- a/web/templates/mobile_survey_simulation/index.html.eex
+++ b/web/templates/mobile_survey_simulation/index.html.eex
@@ -3,7 +3,7 @@
   <script>
     window.mixEnv = "<%= Mix.env %>"
     window.respondentId = "<%= @respondent_id %>"
-    window.token = "<%= @token %>"
+    window.apiUrl = "/mobile/simulation"
   </script>
   <script src="<%= static_path(@conn, "/js/mobileSurvey.js") %>"></script>
 </body>

--- a/web/templates/mobile_survey_simulation/index.html.eex
+++ b/web/templates/mobile_survey_simulation/index.html.eex
@@ -1,0 +1,9 @@
+<body>
+  <div id="root" role="main" data-config="<%= Poison.encode!(%{introMessage: @mobile_web_intro_message, colorStyle: @color_style}) %>"></div>
+  <script>
+    window.mixEnv = "<%= Mix.env %>"
+    window.respondentId = "<%= @respondent_id %>"
+    window.token = "<%= @token %>"
+  </script>
+  <script src="<%= static_path(@conn, "/js/mobileSurvey.js") %>"></script>
+</body>

--- a/web/templates/mobile_survey_simulation/unauthorized.html.eex
+++ b/web/templates/mobile_survey_simulation/unauthorized.html.eex
@@ -1,0 +1,17 @@
+<body>
+  <script>
+    window.header_color = ("<%= @header_color %>")
+  </script>
+  <div id="root" role="main"></div>
+    <div ref='stepContent'>
+      <header>
+        <nav style="background-color: <%= @header_color %>;">
+          <h1>Unauthorized</h1>
+        </nav>
+      </header>
+      <main>
+        <div className={'prompt'}><h1>You are not authorized to participate in the survey</h1></div>
+      </main>
+    </div>
+  </div>
+</body>

--- a/web/views/mobile_survey_simulation_view.ex
+++ b/web/views/mobile_survey_simulation_view.ex
@@ -1,0 +1,3 @@
+defmodule Ask.MobileSurveySimulationView do
+  use Ask.Web, :view
+end

--- a/web/views/questionnaire_view.ex
+++ b/web/views/questionnaire_view.ex
@@ -31,7 +31,7 @@ defmodule Ask.QuestionnaireView do
 
   def render("simulation.json", %{simulation: %{respondent_id: respondent_id} = simulation, mode: "mobileweb"}) do
     render_simulation(simulation)
-    |> Map.put(:index_url, "/mobile/simulation/#{respondent_id}?token=foo")
+    |> Map.put(:index_url, "/mobile/simulation/#{respondent_id}")
   end
 
   def render("simulation.json", %{simulation: simulation}) do

--- a/web/views/questionnaire_view.ex
+++ b/web/views/questionnaire_view.ex
@@ -42,11 +42,11 @@ defmodule Ask.QuestionnaireView do
     %{
       respondent_id: simulation.respondent_id,
       simulation_status: simulation.simulation_status,
-      disposition: simulation.disposition,
-      messages_history: simulation.messages_history,
-      submissions: simulation.submissions,
-      current_step: simulation.current_step,
-      questionnaire: render("questionnaire.json", %{questionnaire: simulation.questionnaire})
+      disposition: Map.get(simulation, :disposition),
+      messages_history: Map.get(simulation, :messages_history),
+      submissions: Map.get(simulation, :submissions),
+      current_step: Map.get(simulation, :current_step),
+      questionnaire: render("questionnaire.json", %{questionnaire: Map.get(simulation, :questionnaire)})
     }
     |> Enum.filter(fn {_, value} -> value end)
     |> Map.new()

--- a/web/views/questionnaire_view.ex
+++ b/web/views/questionnaire_view.ex
@@ -1,4 +1,5 @@
 defmodule Ask.QuestionnaireView do
+  alias Ask.QuestionnaireSmsSimulationStep
   use Ask.Web, :view
 
   def render("index.json", %{questionnaires: questionnaires}) do
@@ -38,17 +39,39 @@ defmodule Ask.QuestionnaireView do
     render_simulation(simulation)
   end
 
+  defp render_simulation(%QuestionnaireSmsSimulationStep{
+    messages_history: messages_history,
+  } = simulation) do
+    simulation = prepare_simulation(simulation)
+    simulation = Map.put(simulation, :messages_history, messages_history)
+    render_prepared_simulation(simulation)
+  end
+
   defp render_simulation(simulation) do
+    simulation = prepare_simulation(simulation)
+    render_prepared_simulation(simulation)
+  end
+
+  defp prepare_simulation(%{
+    respondent_id: respondent_id,
+    simulation_status: simulation_status,
+    disposition: disposition,
+    submissions: submissions,
+    current_step: current_step,
+    questionnaire: questionnaire
+  }) do
     %{
-      respondent_id: simulation.respondent_id,
-      simulation_status: simulation.simulation_status,
-      disposition: Map.get(simulation, :disposition),
-      messages_history: Map.get(simulation, :messages_history),
-      submissions: Map.get(simulation, :submissions),
-      current_step: Map.get(simulation, :current_step),
-      questionnaire: render("questionnaire.json", %{questionnaire: Map.get(simulation, :questionnaire)})
+      respondent_id: respondent_id,
+      simulation_status: simulation_status,
+      disposition: disposition,
+      submissions: submissions,
+      current_step: current_step,
+      questionnaire: render("questionnaire.json", %{questionnaire: questionnaire})
     }
-    |> Enum.filter(fn {_, value} -> value end)
+  end
+
+  defp render_prepared_simulation(simulation) do
+    Enum.filter(simulation, fn {_, value} -> value end)
     |> Map.new()
   end
 end

--- a/web/views/questionnaire_view.ex
+++ b/web/views/questionnaire_view.ex
@@ -29,7 +29,16 @@ defmodule Ask.QuestionnaireView do
     }
   end
 
+  def render("simulation.json", %{simulation: %{respondent_id: respondent_id} = simulation, mode: "mobileweb"}) do
+    render_simulation(simulation)
+    |> Map.put(:index_url, "/mobile/simulation/#{respondent_id}?token=foo")
+  end
+
   def render("simulation.json", %{simulation: simulation}) do
+    render_simulation(simulation)
+  end
+
+  defp render_simulation(simulation) do
     %{
       respondent_id: simulation.respondent_id,
       simulation_status: simulation.simulation_status,


### PR DESCRIPTION
## 🥕 The motivation

When editing a Survey, having a quick demo in every mode is very useful.
The easiest way of having a demo is the questionnaire simulator because channels aren't needed.
But the mobile web mode isn't supported by the questionnaire simulator yet.

Fix #1808

## 🎯 The goal

This PR makes the questionnaire simulator support the Mobile Web mode.

## 🗒️ The To-Do list:

- [x] Support explanations in Mobile Web mode.
- [x] Split the simulator into the SMS and the Mobile Web simulator. 
- [x] Remove phone from survey simulation screen.
- [x] Restrict endpoints to SMS or Mobile Web only.
- [x] Fix the front-end normalize error to use GET in the new `/simulation/:respondent_id` endpoint.
- [x] Fix missing question in SMS mode.
- [x] Add tests.