### PR TITLE
Delete panel surveys

### DIFF
--- a/web/models/survey.ex
+++ b/web/models/survey.ex
@@ -23,6 +23,7 @@ defmodule Ask.Survey do
   }
   alias Ask.Runtime.ChannelStatusServer
   alias Ask.Ecto.Type.JSON
+  alias Ecto.Multi
 
   @max_int 2147483647
   @default_fallback_delay 120
@@ -639,5 +640,9 @@ defmodule Ask.Survey do
 
     changeset
     |> put_assoc(:respondent_groups, respondent_groups_changeset)
+  end
+
+  def delete_multi(survey) do
+    Multi.delete(Multi.new, :survey, survey)
   end
 end


### PR DESCRIPTION
### Expected Behaviour:
- [x] If it's the only one, just drop it
- [x] Removing one in the middle is fine
- [x] Removing the original should make the second one to act as the original
- [x] Removing the last one should allow the user to create a new incarnation from the previous one from the normal flow.

Fix #1821