### PR TITLE
Remove confusing clarification

### DIFF
--- a/web/models/respondent.ex
+++ b/web/models/respondent.ex
@@ -14,7 +14,7 @@ defmodule Ask.Respondent do
     # * pending: the initial state of a respondent, before communication starts
     # * active: a communication is being held with the respondent
     # * completed: the communication finished succesfully (it reached the end)
-    # * failed: communication couldn't be established or was cut, only for IVR
+    # * failed: communication couldn't be established or was cut
     # * rejected: communication ended because the respondent fell in a full quota bucket
     # * cancelled: when the survey is stopped and has "terminated" state, all the active
     #     respondents will be updated with this state.


### PR DESCRIPTION
[Here](https://github.com/instedd/surveda/blob/4f6ea5f8b2f1d43080432a64f6af67b161f2dc47/lib%2Fask%2Fruntime%2Fnuntium_channel.ex#L63) when a Nuntium channel fails, [here](https://github.com/instedd/surveda/blob/19dea92b4fefb5d9bcdbcb0408a8e6071a206ef1/lib%2Fask%2Fruntime%2Fsurvey.ex#L220) the respondent state is set as `failed`.

So, or the clarification is confusing, or we should change the behavior.