### PR TITLE
Fix unexpected toast and undefined param

### DIFF
--- a/web/static/mobile_survey/js/components/Step.jsx
+++ b/web/static/mobile_survey/js/components/Step.jsx
@@ -19,7 +19,8 @@ type Props = {
   progress: number,
   errorMessage: ?string,
   introMessage: string,
-  colorStyle: PropTypes.object.isRequired
+  colorStyle: PropTypes.object.isRequired,
+  simulation: boolean
 }
 
 type State = {
@@ -47,6 +48,8 @@ class Step extends Component<Props, State> {
 }
 
   componentDidMount() {
+    const {simulation} = this.props
+
     window.addEventListener('scroll', this.hideMoreContentHint)
 
     // This is so that when the user switches between tabs,
@@ -54,7 +57,7 @@ class Step extends Component<Props, State> {
     // to the current step and so there's no way to submit
     // an answer for a previous question
     window.onfocus = () => {
-      if (this.state.userConsent) this.fetchStep()
+      if (!simulation && this.state.userConsent) this.fetchStep()
     }
   }
 
@@ -192,7 +195,8 @@ const mapStateToProps = (state) => ({
   token: window.token,
   apiUrl: window.apiUrl,
   introMessage: state.config.introMessage,
-  colorStyle: state.config.colorStyle
+  colorStyle: state.config.colorStyle,
+  simulation: !!window.simulation
 })
 
 Step.childContextTypes = {

--- a/web/templates/mobile_survey_simulation/index.html.eex
+++ b/web/templates/mobile_survey_simulation/index.html.eex
@@ -4,6 +4,7 @@
     window.mixEnv = "<%= Mix.env %>"
     window.respondentId = "<%= @respondent_id %>"
     window.apiUrl = "/mobile/simulation"
+    window.simulation = true
   </script>
   <script src="<%= static_path(@conn, "/js/mobileSurvey.js") %>"></script>
 </body>

--- a/web/templates/mobile_survey_simulation/index.html.eex
+++ b/web/templates/mobile_survey_simulation/index.html.eex
@@ -5,6 +5,7 @@
     window.respondentId = "<%= @respondent_id %>"
     window.apiUrl = "/mobile/simulation"
     window.simulation = true
+    window.token = "not-used"
   </script>
   <script src="<%= static_path(@conn, "/js/mobileSurvey.js") %>"></script>
 </body>


### PR DESCRIPTION
### 1. Don't fetch step onFocus when simulation

Trying to fetch an ended simulation makes the simulation API fail and makes #1825 happen.
The onFocus flow was designed for scenarios that we aren't simulating, where the user is able to leave and return the survey.
E.g after the simulation ends, the real API considers the scenario answering "The survey is over", which isn't simulated.

Fix #1825

### 2. Avoid sending undefined param

Sending the token is a security measure the simulation doesn't need.
It doesn't break anything, but `token=undefined` in the URL feels rare.