### PR TITLE
Export only the visible settings of the questionnaire (languages)

### DIFF
--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -81,7 +81,7 @@ defmodule Ask.Runtime.QuestionnaireExport do
     end)
   end
 
-  defp clean_i18n_quiz(quiz) do
+  def clean_i18n_quiz(quiz) do
     clean_i18n_fields = Map.keys(quiz)
 
     Enum.reduce(clean_i18n_fields, quiz, fn field, quiz_acc ->

--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -155,8 +155,17 @@ defmodule Ask.Runtime.QuestionnaireExport do
   end
 end
 
-# The path syntax is inspired by [JQ](https://stedolan.github.io/jq/)
+#
 defmodule Ask.Runtime.CleanI18n do
+  @moduledoc """
+  When a language is deleted, its associated settings are still there, but they aren't visible to
+  the end-user. After exporting and importing the questionnaire, the end-user doesn't expect these
+  settings to be still there.
+  This module helps cleaning the questionnaire from the setting related to the deleted languages.
+  The cleaning is done in memory before exporting it, so it doesn't affect the real questionnaire.
+  The path syntax is inspired by [JQ](https://stedolan.github.io/jq/)
+  """
+
   def clean(nil, _filter_languages, _path), do: nil
 
   def clean(entity, filter_languages, path) do

--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -123,6 +123,8 @@ defmodule Ask.Runtime.QuestionnaireExport do
     Map.put(quiz, key, clean_elem)
   end
 
+  def clean_i18n_entity(nil, _filter_languages, _path), do: nil
+
   # The path syntax is inspired in [JQ](https://stedolan.github.io/jq/)
   def clean_i18n_entity(entity, filter_languages, path) do
     forward_path = fn positions -> String.slice(path, positions..-1) end

--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -124,7 +124,7 @@ defmodule Ask.Runtime.QuestionnaireExport do
   end
 
   # The path syntax is inspired in JQ (https://stedolan.github.io/jq/)
-  defp clean_i18n_entity(entity, filter_languages, path) do
+  def clean_i18n_entity(entity, filter_languages, path) do
     forward_path = fn positions -> String.slice(path, positions..-1) end
     cond do
       # Base case

--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -1,0 +1,123 @@
+defmodule Ask.Runtime.QuestionnaireAction do
+  alias Ask.{Questionnaire, Repo, Audio}
+
+  def export(questionnaire) do
+    all_questionnaire_steps = Questionnaire.all_steps(questionnaire)
+    audio_ids = collect_steps_audio_ids(all_questionnaire_steps, [])
+    audio_ids = collect_settings_audio_ids(questionnaire.settings, audio_ids)
+    # for each audio: charges it in memory and then streams it.
+    audio_resource =
+      Stream.resource(
+        fn -> audio_ids end,
+        fn audio_ids ->
+          case audio_ids do
+            [id | tail] ->
+              audio = Repo.get_by(Audio, uuid: id)
+              {[audio], tail}
+
+            [] ->
+              {:halt, audio_ids}
+          end
+        end,
+        fn _ -> [] end
+      )
+
+    # The audio file import is based on this list
+    # If it's empty, nothing will be imported
+    audio_files =
+      Stream.map(audio_resource, fn audio ->
+        %{
+          "uuid" => audio.uuid,
+          "original_filename" => audio.filename,
+          "source" => audio.source
+        }
+      end)
+
+    audio_entries =
+      Stream.map(audio_resource, fn audio ->
+        # Zstream needs to recieve audio.data as enumerable in order to work, otherwise it throws Protocol.undefined error.
+        Zstream.entry("audios/" <> Audio.exported_audio_file_name(audio.uuid), [audio.data])
+      end)
+
+    manifest = %{
+      name: questionnaire.name,
+      modes: questionnaire.modes,
+      steps: questionnaire.steps,
+      quota_completed_steps: questionnaire.quota_completed_steps,
+      settings: questionnaire.settings,
+      partial_relevant_config: questionnaire.partial_relevant_config,
+      languages: questionnaire.languages,
+      default_language: questionnaire.default_language,
+      audio_files: audio_files
+    }
+
+    {:ok, json} = Poison.encode(manifest)
+
+    json_entry =
+      Stream.map([json], fn json ->
+        Zstream.entry("manifest.json", [json])
+      end)
+
+    zip_entries = Stream.concat(audio_entries, json_entry)
+    # since audio binary data is created as list for Zstream
+    # flatten is needed to allow the data to be sent in chunks
+    # otherwise the connection sends the whole list as a chunk
+    # and times out.
+    Zstream.zip(zip_entries)
+    |> Stream.flat_map(fn element ->
+      case is_list(element) do
+        true -> List.flatten(element)
+        false -> element
+      end
+    end)
+  end
+
+  defp collect_settings_audio_ids(settings, audio_ids) do
+    audio_ids = collect_setting_audio_id(settings["error_message"], audio_ids)
+    collect_setting_audio_id(settings["thank_you_message"], audio_ids)
+  end
+
+  defp collect_setting_audio_id(nil = _setting, audio_ids) do
+    audio_ids
+  end
+
+  defp collect_setting_audio_id(setting, audio_ids) do
+    collect_lang_prompt_audio_ids(setting, audio_ids)
+  end
+
+  defp collect_steps_audio_ids(nil, audio_ids) do
+    audio_ids
+  end
+
+  defp collect_steps_audio_ids(steps, audio_ids) do
+    steps |> Enum.reduce(audio_ids, fn(step, audio_ids) ->
+      collect_step_audio_ids(step, audio_ids)
+    end)
+  end
+
+  defp collect_step_audio_ids(%{"prompt" => %{"ivr" => %{"audio_id" => _audio_id}} = prompt}, audio_ids) do
+    collect_prompt_audio_ids(prompt, audio_ids)
+  end
+
+  defp collect_step_audio_ids(%{"prompt" => prompt}, audio_ids) do
+    collect_lang_prompt_audio_ids(prompt, audio_ids)
+  end
+
+  defp collect_step_audio_ids(_, audio_ids) do
+    audio_ids
+  end
+
+  defp collect_lang_prompt_audio_ids(prompt, audio_ids) do
+    prompt |> Enum.reduce(audio_ids, fn {_lang, lang_prompt}, audio_ids ->
+      collect_prompt_audio_ids(lang_prompt, audio_ids)
+    end)
+  end
+
+  defp collect_prompt_audio_ids(%{"ivr" => %{"audio_id" => audio_id} = _prompt}, audio_ids) do
+    [audio_id | audio_ids]
+  end
+
+  defp collect_prompt_audio_ids(_, audio_ids) do
+    audio_ids
+  end
+end

--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -135,10 +135,10 @@ defmodule Ask.Runtime.QuestionnaireExport do
         clean_i18n_entity(entity, filter_languages, forward_path.(1))
       # Clean every map element
       String.starts_with?(path, "[]") and is_map(entity) ->
-        clean_i18n_entity_map(entity, filter_languages, forward_path)
+        clean_i18n_entity_map(entity, filter_languages, forward_path.(2))
       # Clean every list element
       String.starts_with?(path, "[]") and is_list(entity) ->
-        clean_i18n_entity_list(entity, filter_languages, forward_path)
+        clean_i18n_entity_list(entity, filter_languages, forward_path.(2))
       # Clean the requested key of a map
       !!path and is_map(entity) ->
         clean_i18n_entity_map_key(entity, filter_languages, path, forward_path)
@@ -147,23 +147,19 @@ defmodule Ask.Runtime.QuestionnaireExport do
     end
   end
 
-  defp clean_i18n_entity_map_key(entity, langs, path, forward_path) do
-    key = String.split(path, ".")
-    elem = Map.get(entity, key)
-    path = forward_path.(String.length(key))
-    clean_i18n_entity_list(elem, langs, path)
+  defp clean_i18n_entity_map_key(_entity, _langs, _path, _forward_path) do
   end
 
-  defp clean_i18n_entity_list(entity, langs, forward_path) do
+  defp clean_i18n_entity_list(entity, langs, path) do
     Enum.map(entity, fn elem ->
-      clean_i18n_entity(elem, langs, forward_path.(2))
+      clean_i18n_entity(elem, langs, path)
     end)
   end
 
-  defp clean_i18n_entity_map(entity, langs, forward_path) do
+  defp clean_i18n_entity_map(entity, langs, path) do
     Enum.reduce(Map.keys(entity), entity, fn key, entity_acc ->
       elem = Map.get(entity, key)
-      clean_elem = clean_i18n_entity(elem, langs, forward_path.(2))
+      clean_elem = clean_i18n_entity(elem, langs, path)
       Map.put(entity_acc, key, clean_elem)
     end)
   end

--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -147,7 +147,10 @@ defmodule Ask.Runtime.QuestionnaireExport do
     end
   end
 
-  defp clean_i18n_entity_map_key(_entity, _langs, _path, _forward_path) do
+  defp clean_i18n_entity_map_key(entity, langs, path, forward_path) do
+    key = if String.contains?(path, "."), do: String.split(path, ".") |> Enum.at(0), else: path
+    path = forward_path.(String.length(key))
+    clean_i18n_entity_map(entity, langs, path, key)
   end
 
   defp clean_i18n_entity_list(entity, langs, path) do
@@ -156,11 +159,18 @@ defmodule Ask.Runtime.QuestionnaireExport do
     end)
   end
 
-  defp clean_i18n_entity_map(entity, langs, path) do
-    Enum.reduce(Map.keys(entity), entity, fn key, entity_acc ->
+  defp clean_i18n_entity_map(entity, langs, path, filter_key \\ nil) do
+    clean_entity_key = fn entity, key ->
       elem = Map.get(entity, key)
-      clean_elem = clean_i18n_entity(elem, langs, path)
-      Map.put(entity_acc, key, clean_elem)
+      if filter_key == nil or filter_key == key do
+        clean_i18n_entity(elem, langs, path)
+      else
+        elem
+      end
+    end
+
+    Enum.reduce(Map.keys(entity), entity, fn key, entity_acc ->
+      Map.put(entity_acc, key, clean_entity_key.(entity, key))
     end)
   end
 

--- a/test/lib/runtime/questionnaire_action_test.exs
+++ b/test/lib/runtime/questionnaire_action_test.exs
@@ -20,7 +20,7 @@ defmodule Ask.Runtime.QuestionnaireExportTest do
     end
   end
 
-  describe "I18N.clean" do
+  describe "CleanI18n" do
     test "base case" do
       entity = %{"en" => "foo", "es" => "bar"}
 

--- a/test/lib/runtime/questionnaire_action_test.exs
+++ b/test/lib/runtime/questionnaire_action_test.exs
@@ -52,5 +52,13 @@ defmodule Ask.QuestionnaireExportTest do
 
       assert clean == quiz
     end
+
+    test "works when quota_completed_steps is nil" do
+      quiz = insert(:questionnaire, languages: ["en"], quota_completed_steps: nil)
+
+      clean = QuestionnaireExport.clean_i18n_quiz(quiz)
+
+      assert clean == quiz
+    end
   end
 end

--- a/test/lib/runtime/questionnaire_action_test.exs
+++ b/test/lib/runtime/questionnaire_action_test.exs
@@ -1,48 +1,6 @@
-defmodule Ask.QuestionnaireExportTest do
+defmodule Ask.Runtime.QuestionnaireExportTest do
   use Ask.ModelCase
-  alias Ask.Runtime.QuestionnaireExport
-
-  describe "clean_i18n_entity" do
-    test "base case" do
-      entity = %{"en" => "foo", "es" => "bar"}
-
-      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], "")
-
-      assert clean == %{"en" => "foo"}
-    end
-
-    test "move forward" do
-      entity = %{"en" => "foo", "es" => "bar"}
-
-      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], ".")
-
-      assert clean == %{"en" => "foo"}
-    end
-
-    test "clean every map element" do
-      entity = %{"bar" => %{"en" => "foo", "es" => "bar"}}
-
-      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], "[]")
-
-      assert clean == %{"bar" => %{"en" => "foo"}}
-    end
-
-    test "clean every list element" do
-      entity = [%{"en" => "foo", "es" => "bar"}]
-
-      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], "[]")
-
-      assert clean == [%{"en" => "foo"}]
-    end
-
-    test "clean the requested key of a map" do
-      entity = %{"a" => %{"en" => "foo", "es" => "bar"}, "b" => %{"en" => "foo", "es" => "bar"}}
-
-      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], "a")
-
-      assert clean == %{"a" => %{"en" => "foo"}, "b" => %{"en" => "foo", "es" => "bar"}}
-    end
-  end
+  alias Ask.Runtime.{QuestionnaireExport, CleanI18n}
 
   describe "clean_i18n_quiz" do
     test "doesn't change a quiz with no deleted languages" do
@@ -59,6 +17,40 @@ defmodule Ask.QuestionnaireExportTest do
       clean = QuestionnaireExport.clean_i18n_quiz(quiz)
 
       assert clean == quiz
+    end
+  end
+
+  describe "I18N.clean" do
+    test "base case" do
+      entity = %{"en" => "foo", "es" => "bar"}
+
+      clean = CleanI18n.clean(entity, ["en"], "")
+
+      assert clean == %{"en" => "foo"}
+    end
+
+    test "clean every map element" do
+      entity = %{"bar" => %{"en" => "foo", "es" => "bar"}}
+
+      clean = CleanI18n.clean(entity, ["en"], ".[]")
+
+      assert clean == %{"bar" => %{"en" => "foo"}}
+    end
+
+    test "clean every list element" do
+      entity = [%{"en" => "foo", "es" => "bar"}]
+
+      clean = CleanI18n.clean(entity, ["en"], ".[]")
+
+      assert clean == [%{"en" => "foo"}]
+    end
+
+    test "clean the requested key of a map" do
+      entity = %{"a" => %{"en" => "foo", "es" => "bar"}, "b" => %{"en" => "foo", "es" => "bar"}}
+
+      clean = CleanI18n.clean(entity, ["en"], ".a")
+
+      assert clean == %{"a" => %{"en" => "foo"}, "b" => %{"en" => "foo", "es" => "bar"}}
     end
   end
 end

--- a/test/lib/runtime/questionnaire_action_test.exs
+++ b/test/lib/runtime/questionnaire_action_test.exs
@@ -1,0 +1,46 @@
+defmodule Ask.QuestionnaireExportTest do
+  use Ask.ModelCase
+  alias Ask.Runtime.QuestionnaireExport
+
+  describe "clean_i18n_entity" do
+    test "base case" do
+      entity = %{"en" => "foo", "es" => "bar"}
+
+      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], "")
+
+      assert clean == %{"en" => "foo"}
+    end
+
+    test "move forward" do
+      entity = %{"en" => "foo", "es" => "bar"}
+
+      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], ".")
+
+      assert clean == %{"en" => "foo"}
+    end
+
+    test "clean every map element" do
+      entity = %{"bar" => %{"en" => "foo", "es" => "bar"}}
+
+      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], "[]")
+
+      assert clean == %{"bar" => %{"en" => "foo"}}
+    end
+
+    test "clean every list element" do
+      entity = [%{"en" => "foo", "es" => "bar"}]
+
+      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], "[]")
+
+      assert clean == [%{"en" => "foo"}]
+    end
+
+    test "clean the requested key of a map" do
+      entity = %{"a" => %{"en" => "foo", "es" => "bar"}, "b" => %{"en" => "foo", "es" => "bar"}}
+
+      clean = QuestionnaireExport.clean_i18n_entity(entity, ["en"], "a")
+
+      assert clean == %{"a" => %{"en" => "foo"}, "b" => %{"en" => "foo", "es" => "bar"}}
+    end
+  end
+end

--- a/test/lib/runtime/questionnaire_action_test.exs
+++ b/test/lib/runtime/questionnaire_action_test.exs
@@ -43,4 +43,14 @@ defmodule Ask.QuestionnaireExportTest do
       assert clean == %{"a" => %{"en" => "foo"}, "b" => %{"en" => "foo", "es" => "bar"}}
     end
   end
+
+  describe "clean_i18n_quiz" do
+    test "doesn't change a quiz with no deleted languages" do
+      quiz = insert(:questionnaire, languages: ["en"])
+
+      clean = QuestionnaireExport.clean_i18n_quiz(quiz)
+
+      assert clean == quiz
+    end
+  end
 end

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -15,7 +15,11 @@ defmodule Ask.QuestionnaireController do
     Gettext
   }
   alias Ecto.Multi
-  alias Ask.Runtime.{QuestionnaireSimulator, QuestionnaireMobileWebSimulator}
+  alias Ask.Runtime.{
+    QuestionnaireSimulator,
+    QuestionnaireMobileWebSimulator,
+    QuestionnaireAction
+  }
 
   plug :validate_params when action in [:create, :update]
   action_fallback Ask.FallbackController
@@ -263,69 +267,9 @@ defmodule Ask.QuestionnaireController do
     |> load_project(project_id)
 
     questionnaire = load_questionnaire_not_snapshot(project.id, id)
-    all_questionnaire_steps = Questionnaire.all_steps(questionnaire)
-    audio_ids = collect_steps_audio_ids(all_questionnaire_steps, [])
-    audio_ids = collect_settings_audio_ids(questionnaire.settings, audio_ids)
-    #for each audio: charges it in memory and then streams it.
-    audio_resource = Stream.resource(
-      fn -> audio_ids end,
-      fn audio_ids ->
-        case audio_ids do
-        [id |tail] ->
-          audio = Repo.get_by(Audio, uuid: id)
-          {[audio], tail}
-        [] ->
-          {:halt, audio_ids}
-      end
-      end,
-      fn _ -> [] end
-    )
 
-    # The audio file import is based on this list
-    # If it's empty, nothing will be imported
-    audio_files = Stream.map(audio_resource, fn audio ->
-      %{
-        "uuid" => audio.uuid,
-        "original_filename" => audio.filename,
-        "source" => audio.source
-      }
-    end)
+    zip_file = QuestionnaireAction.export(questionnaire)
 
-    audio_entries = Stream.map(audio_resource, fn audio ->
-      #Zstream needs to recieve audio.data as enumerable in order to work, otherwise it throws Protocol.undefined error.
-      Zstream.entry("audios/" <> Audio.exported_audio_file_name(audio.uuid), [audio.data])
-    end)
-
-    manifest = %{
-      name: questionnaire.name,
-      modes: questionnaire.modes,
-      steps: questionnaire.steps,
-      quota_completed_steps: questionnaire.quota_completed_steps,
-      settings: questionnaire.settings,
-      partial_relevant_config: questionnaire.partial_relevant_config,
-      languages: questionnaire.languages,
-      default_language: questionnaire.default_language,
-      audio_files: audio_files
-    }
-    {:ok, json} = Poison.encode(manifest)
-    json_entry = Stream.map([json], fn json ->
-      Zstream.entry("manifest.json", [json])
-    end)
-
-    zip_entries = Stream.concat(audio_entries, json_entry)
-    #since audio binary data is created as list for Zstream
-    #flatten is needed to allow the data to be sent in chunks
-    #otherwise the connection sends the whole list as a chunk
-    #and times out.
-    zip_file = Zstream.zip(zip_entries)
-               |> Stream.flat_map(
-                    fn element ->
-                      case is_list(element) do
-                        :true -> List.flatten(element)
-                        :false -> element
-                      end
-                    end
-                  )
     conn = conn
            |> put_resp_content_type("application/octet-stream")
            |> put_resp_header("content-disposition", "attachment; filename=#{questionnaire.id}.zip")
@@ -423,57 +367,6 @@ defmodule Ask.QuestionnaireController do
         conn |> put_status(422) |> json(%{errors: json_errors}) |> halt
     end
   end
-
-  defp collect_settings_audio_ids(settings, audio_ids) do
-    audio_ids = collect_setting_audio_id(settings["error_message"], audio_ids)
-    collect_setting_audio_id(settings["thank_you_message"], audio_ids)
-  end
-
-  defp collect_setting_audio_id(nil = _setting, audio_ids) do
-    audio_ids
-  end
-
-  defp collect_setting_audio_id(setting, audio_ids) do
-    collect_lang_prompt_audio_ids(setting, audio_ids)
-  end
-
-  defp collect_steps_audio_ids(nil, audio_ids) do
-    audio_ids
-  end
-
-  defp collect_steps_audio_ids(steps, audio_ids) do
-    steps |> Enum.reduce(audio_ids, fn(step, audio_ids) ->
-      collect_step_audio_ids(step, audio_ids)
-    end)
-  end
-
-  defp collect_step_audio_ids(%{"prompt" => %{"ivr" => %{"audio_id" => _audio_id}} = prompt}, audio_ids) do
-    collect_prompt_audio_ids(prompt, audio_ids)
-  end
-
-  defp collect_step_audio_ids(%{"prompt" => prompt}, audio_ids) do
-    collect_lang_prompt_audio_ids(prompt, audio_ids)
-  end
-
-  defp collect_step_audio_ids(_, audio_ids) do
-    audio_ids
-  end
-
-
-  defp collect_lang_prompt_audio_ids(prompt, audio_ids) do
-    prompt |> Enum.reduce(audio_ids, fn {_lang, lang_prompt}, audio_ids ->
-      collect_prompt_audio_ids(lang_prompt, audio_ids)
-    end)
-  end
-
-  defp collect_prompt_audio_ids(%{"ivr" => %{"audio_id" => audio_id} = _prompt}, audio_ids) do
-    [audio_id | audio_ids]
-  end
-
-  defp collect_prompt_audio_ids(_, audio_ids) do
-    audio_ids
-  end
-
   defp load_questionnaire(project, id) do
     questionnaire = project
     |> assoc(:questionnaires)


### PR DESCRIPTION
### The context 🌌 

When some settings are deleted/disabled (languages, modes, partial relevant flag), the associated settings are still there (they become visible after the deleted/disabled setting is back). But they aren't visible to the end-user.

### The symptom 🌡️ 

After exporting and importing the questionnaire, the end-user doesn't expect these settings to be still there.

### The fix 🔧 

This PR avoid exporting the settings of every deleted language.

### The pending work 🚧 

Avoid exporting any other invisible setting to the end-user.

---

It fixes #1801 