### PR TITLE
Log added respondents when survey is running

### DIFF
--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -37,7 +37,7 @@
   "Added mode <i>{{mode}}</i> to <i>{{questionnaireName}}": "",
   "Added section <i>{{sectionTitle}}</i> to <i>{{questionnaireName}}</i>": "",
   "Added step <i>{{stepTitle}}</i> to <i>{{questionnaireName}}</i>": "",
-  "Added {{respondentsCount}} respondents to <i>{{respondentGroupName}}</i> respondents list in <i>{{surveyName}}</i>": "",
+  "Added {{respondentsCount}} respondents from <i>{{fileName}}</i> to <i>{{surveyName}}</i>": "",
   "Admin": "",
   "All changes saved": "",
   "All quota fields are required, please fill them to continue": "",

--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -37,6 +37,7 @@
   "Added mode <i>{{mode}}</i> to <i>{{questionnaireName}}": "",
   "Added section <i>{{sectionTitle}}</i> to <i>{{questionnaireName}}</i>": "",
   "Added step <i>{{stepTitle}}</i> to <i>{{questionnaireName}}</i>": "",
+  "Added {{respondentsCount}} respondents to <i>{{respondentGroupName}}</i> respondents list in <i>{{surveyName}}</i>": "",
   "Admin": "",
   "All changes saved": "",
   "All quota fields are required, please fill them to continue": "",

--- a/test/controllers/respondent_group_controller_test.exs
+++ b/test/controllers/respondent_group_controller_test.exs
@@ -2,7 +2,7 @@ defmodule Ask.RespondentGroupControllerTest do
   use Ask.ConnCase
   use Ask.TestHelpers
 
-  alias Ask.{Project, RespondentGroup, Respondent, Channel, RespondentGroupChannel, Stats}
+  alias Ask.{Project, RespondentGroup, Respondent, Channel, RespondentGroupChannel, Stats, ActivityLog}
 
   setup %{conn: conn} do
     user = insert(:user)
@@ -461,12 +461,16 @@ defmodule Ask.RespondentGroupControllerTest do
       project = create_project_for_user(user)
       survey = insert(:survey, project: project)
       perform_add_test_for_survey(conn, project, survey)
+      # It doesn't log if the survey isn't running
+      refute Repo.get_by(ActivityLog, action: "add_respondents", entity_id: survey.id)
     end
 
     test "uploads CSV with more respondents even if the survey is running", %{conn: conn, user: user} do
       project = create_project_for_user(user)
       survey = insert(:survey, project: project, state: "running")
       perform_add_test_for_survey(conn, project, survey)
+      # It logs if the survey is running
+      assert Repo.get_by(ActivityLog, action: "add_respondents", entity_id: survey.id)
     end
 
     def perform_add_test_for_survey(conn, project, survey) do

--- a/web/controllers/respondent_group_controller.ex
+++ b/web/controllers/respondent_group_controller.ex
@@ -84,7 +84,7 @@ defmodule Ask.RespondentGroupController do
 
           if Survey.launched?(survey) and respondents_count > 0 do
             ActivityLog.add_respondents(project, conn, survey, %{
-              respondent_group_name: respondent_group.name,
+              file_name: file.filename,
               respondents_count: respondents_count
             }) |> Repo.insert!
           end

--- a/web/controllers/respondent_group_controller.ex
+++ b/web/controllers/respondent_group_controller.ex
@@ -85,7 +85,7 @@ defmodule Ask.RespondentGroupController do
           if Survey.launched?(survey) and respondents_count > 0 do
             ActivityLog.add_respondents(project, conn, survey, %{
               respondent_group_name: respondent_group.name,
-              respondents_count: Enum.count(file_phone_numbers)
+              respondents_count: respondents_count
             }) |> Repo.insert!
           end
 

--- a/web/controllers/respondent_group_controller.ex
+++ b/web/controllers/respondent_group_controller.ex
@@ -1,6 +1,6 @@
 defmodule Ask.RespondentGroupController do
   use Ask.Web, :api_controller
-  alias Ask.{Project, Survey, Respondent, RespondentGroup, Logger}
+  alias Ask.{Project, Survey, Respondent, RespondentGroup, Logger, ActivityLog}
 
   plug :find_and_check_survey_state when action in [:create, :update, :delete, :replace]
 
@@ -79,6 +79,15 @@ defmodule Ask.RespondentGroupController do
           |> remove_duplicates_with_respect_to(respondent_group)
 
           Ask.Runtime.RespondentGroup.insert_respondents(file_phone_numbers, respondent_group)
+
+          respondents_count = Enum.count(file_phone_numbers)
+
+          if Survey.launched?(survey) and respondents_count > 0 do
+            ActivityLog.add_respondents(project, conn, survey, %{
+              respondent_group_name: respondent_group.name,
+              respondents_count: Enum.count(file_phone_numbers)
+            }) |> Repo.insert!
+          end
 
           new_count = respondent_group.respondents_count + length(file_phone_numbers)
           new_sample = merge_sample(respondent_group.sample, file_phone_numbers)

--- a/web/models/activity_log.ex
+++ b/web/models/activity_log.ex
@@ -19,7 +19,7 @@ defmodule Ask.ActivityLog do
     ["create_invite", "edit_invite", "delete_invite", "edit_collaborator", "remove_collaborator"]
 
   def valid_actions("survey"), do:
-    ["create", "edit", "rename", "change_description", "lock", "unlock", "delete", "start", "repeat", "request_cancel", "completed_cancel", "download", "enable_public_link", "regenerate_public_link", "disable_public_link", "change_folder"]
+    ["create", "edit", "rename", "change_description", "lock", "unlock", "delete", "start", "repeat", "request_cancel", "completed_cancel", "download", "enable_public_link", "regenerate_public_link", "disable_public_link", "change_folder", "add_respondents"]
 
   def valid_actions("questionnaire"), do:
     ["create", "edit", "rename", "delete", "add_mode", "remove_mode", "add_language", "remove_language", "create_step", "delete_step", "rename_step", "edit_step", "edit_settings", "create_section", "rename_section", "delete_section", "edit_section", "archive", "unarchive"]
@@ -153,6 +153,14 @@ defmodule Ask.ActivityLog do
     create("rename", project, conn, survey, %{
       old_survey_name: old_survey_name,
       new_survey_name: new_survey_name
+    })
+  end
+
+  def add_respondents(project, conn, survey, %{respondent_group_name: respondent_group_name, respondents_count: respondents_count}) do
+    create("add_respondents", project, conn, survey, %{
+      survey_name: survey.name,
+      respondent_group_name: respondent_group_name,
+      respondents_count: respondents_count
     })
   end
 

--- a/web/models/activity_log.ex
+++ b/web/models/activity_log.ex
@@ -156,10 +156,10 @@ defmodule Ask.ActivityLog do
     })
   end
 
-  def add_respondents(project, conn, survey, %{respondent_group_name: respondent_group_name, respondents_count: respondents_count}) do
+  def add_respondents(project, conn, survey, %{file_name: file_name, respondents_count: respondents_count}) do
     create("add_respondents", project, conn, survey, %{
       survey_name: survey.name,
-      respondent_group_name: respondent_group_name,
+      file_name: file_name,
       respondents_count: respondents_count
     })
   end

--- a/web/static/js/components/activity/ActivityDescription.jsx
+++ b/web/static/js/components/activity/ActivityDescription.jsx
@@ -85,6 +85,9 @@ class ActivityDescription extends Component {
             return t('Disabled <i>{{surveyName}}</i> {{reportType}} link', {surveyName: surveyName, reportType: reportType})
           case 'regenerate_public_link':
             return t('Reset <i>{{surveyName}}</i> {{reportType}} link', {surveyName: surveyName, reportType: reportType})
+          case 'add_respondents':
+            const {respondentsCount, respondentGroupName} = metadata
+            return t('Added {{respondentsCount}} respondents to <i>{{respondentGroupName}}</i> respondents list in <i>{{surveyName}}</i>', {surveyName, respondentsCount, respondentGroupName})
           default:
             return ''
         }

--- a/web/static/js/components/activity/ActivityDescription.jsx
+++ b/web/static/js/components/activity/ActivityDescription.jsx
@@ -86,8 +86,8 @@ class ActivityDescription extends Component {
           case 'regenerate_public_link':
             return t('Reset <i>{{surveyName}}</i> {{reportType}} link', {surveyName: surveyName, reportType: reportType})
           case 'add_respondents':
-            const {respondentsCount, respondentGroupName} = metadata
-            return t('Added {{respondentsCount}} respondents to <i>{{respondentGroupName}}</i> respondents list in <i>{{surveyName}}</i>', {surveyName, respondentsCount, respondentGroupName})
+            const {respondentsCount, fileName} = metadata
+            return t('Added {{respondentsCount}} respondents from <i>{{fileName}}</i> to <i>{{surveyName}}</i>', {surveyName, respondentsCount, fileName})
           default:
             return ''
         }


### PR DESCRIPTION
There are more actions related to the addition and deletion of respondents.

1. Respondents list creation.
2. Respondents' addition to an existing respondent list.
3. Respondents' replacement of an existing respondent list.
4. Respondents list deletion.

For now, to avoid overloading the activity log unnecessarily, we decided to log only the addition of respondents to an existing respondents list when the survey is running.

This is how it looks:

![Added respondents log](https://user-images.githubusercontent.com/39921597/106821811-a66b3400-665c-11eb-9bcf-d0d80cc12192.png)

Fix #1830