### PR TITLE
Preserve incentives flag in incarnations

### DIFF
--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -31,7 +31,8 @@ defmodule Ask.Runtime.PanelSurvey do
       mobileweb_retry_configuration: survey.mobileweb_retry_configuration,
       fallback_delay: survey.fallback_delay,
       quota_vars: survey.quota_vars,
-      quotas: survey.quotas
+      quotas: survey.quotas,
+      incentives_enabled: survey.incentives_enabled
     }
 
     questionnaire_ids = Enum.map(survey.questionnaires, fn q -> q.id end)

--- a/test/lib/runtime/survey_action_test.exs
+++ b/test/lib/runtime/survey_action_test.exs
@@ -19,6 +19,25 @@ defmodule Ask.SurveyActionTest do
       refute survey.latest_panel_survey
     end
 
+    test "preserves the incentives enabled flag" do
+      # Incentives enabled
+      survey = completed_panel_survey()
+
+      {:ok, %{survey: %{incentives_enabled: incentives_enabled}}} = SurveyAction.repeat(survey)
+
+      assert incentives_enabled
+
+      # Incentives disabled
+      survey =
+        completed_panel_survey()
+        |> Survey.changeset(%{incentives_enabled: false})
+        |> Repo.update!()
+
+      {:ok, %{survey: %{incentives_enabled: incentives_enabled}}} = SurveyAction.repeat(survey)
+
+      refute incentives_enabled
+    end
+
     test "doesn't repeat a regular survey" do
       survey = regular_survey()
 


### PR DESCRIPTION
When a respondent id is uploaded, downloading the incentives file is disabled.

Preserve this setting in panel survey incarnations.

Fix #1846