### PR TITLE
Add start date to Schedule

### DIFF
--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -1,6 +1,6 @@
 defmodule Ask.Runtime.PanelSurvey do
   import Ecto.Query
-  alias Ask.{Survey, Repo, Respondent, RespondentGroupChannel}
+  alias Ask.{Survey, Repo, Respondent, RespondentGroupChannel, Schedule}
   alias Ask.Runtime.RespondentGroupAction
   alias Ecto.Multi
 
@@ -25,7 +25,7 @@ defmodule Ask.Runtime.PanelSurvey do
       # advanced settings
       cutoff: survey.cutoff,
       count_partial_results: survey.count_partial_results,
-      schedule: survey.schedule,
+      schedule: Schedule.remove_start_date(survey.schedule),
       sms_retry_configuration: survey.sms_retry_configuration,
       ivr_retry_configuration: survey.ivr_retry_configuration,
       mobileweb_retry_configuration: survey.mobileweb_retry_configuration,

--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -420,6 +420,7 @@
   "Skip logic": "",
   "Someone else already invited this user. Please try again": "",
   "Stand by": "",
+  "Start date": "",
   "Start typing a language": "",
   "Start typing a project": "",
   "Started": "",

--- a/test/controllers/short_link_controller_test.exs
+++ b/test/controllers/short_link_controller_test.exs
@@ -22,7 +22,7 @@ defmodule Ask.ShortLinkControllerTest do
     conn = get conn, short_link_path(conn, :access, link.hash)
 
     assert json_response(conn, 200)["data"] == [
-      %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "down_channels" => [], "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "folder_id" => nil}
+      %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "down_channels" => [], "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "folder_id" => nil}
     ]
   end
 end

--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -37,7 +37,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id)
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => survey.description, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => started_at |> Timex.format!("%FT%T%:z", :strftime), "ended_at" => ended_at |> Timex.format!("%FT%T%:z", :strftime), "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => survey.description, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => started_at |> Timex.format!("%FT%T%:z", :strftime), "ended_at" => ended_at |> Timex.format!("%FT%T%:z", :strftime), "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
       ]
     end
 
@@ -50,7 +50,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id, state: "running")
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "running", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "running", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
       ]
     end
 
@@ -64,7 +64,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id)
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => survey.description, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => started_at |> Timex.format!("%FT%T%:z", :strftime), "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => folder.id}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => survey.description, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => started_at |> Timex.format!("%FT%T%:z", :strftime), "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => folder.id}
       ]
     end
 
@@ -77,7 +77,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id, state: "completed")
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "terminated", "locked" => false, "exit_code" => 0, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "terminated", "locked" => false, "exit_code" => 0, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
       ]
     end
 
@@ -90,7 +90,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id, %{"since" => Timex.format!(Timex.shift(Timex.now, hours: 2), "%FT%T%:z", :strftime)})
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "running", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "running", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
       ]
     end
 
@@ -160,6 +160,7 @@ defmodule Ask.SurveyControllerTest do
             "fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true
           },
           "start_time" => "00:00:00",
+          "start_date" => nil,
           "end_time" => "23:59:59",
           "timezone" => "Etc/UTC",
           "blocked_days" => []
@@ -236,6 +237,7 @@ defmodule Ask.SurveyControllerTest do
             "fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true
           },
           "start_time" => "00:00:00",
+          "start_date" => nil,
           "end_time" => "23:59:59",
           "timezone" => "Etc/UTC",
           "blocked_days" => []
@@ -311,6 +313,7 @@ defmodule Ask.SurveyControllerTest do
             "fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true
           },
           "start_time" => "00:00:00",
+          "start_date" => nil,
           "end_time" => "23:59:59",
           "timezone" => "Etc/UTC",
           "blocked_days" => []
@@ -382,6 +385,7 @@ defmodule Ask.SurveyControllerTest do
             "fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true
           },
           "start_time" => "00:00:00",
+          "start_date" => nil,
           "end_time" => "23:59:59",
           "timezone" => "Etc/UTC",
           "blocked_days" => []

--- a/test/lib/ecto_types/schedule_test.exs
+++ b/test/lib/ecto_types/schedule_test.exs
@@ -171,4 +171,28 @@ defmodule Ask.ScheduleTest do
       assert Elixir.Timex.equal?(end_time, DateTime.from_naive!(~N[2019-12-08 01:00:00], "Etc/UTC"))
     end
   end
+
+  describe "start date" do
+    test "is honored by intersect?" do
+      {:ok, dt_out, _} = DateTime.from_iso8601("2021-02-11T12:00:00Z")
+      {:ok, dt_in, _} = DateTime.from_iso8601("2021-02-25T12:00:00Z")
+      schedule = %{Schedule.always() | start_date: ~D[2021-02-19]}
+
+      dt_out_intersect? = Schedule.intersect?(schedule, dt_out)
+      dt_in_intersect? = Schedule.intersect?(schedule, dt_in)
+
+      refute dt_out_intersect?
+      assert dt_in_intersect?
+    end
+
+    test "is honored by next_available_date_time" do
+      {:ok, dt, _} = DateTime.from_iso8601("2021-02-11T00:00:00Z")
+      schedule = %{Schedule.always() | start_date: ~D[2021-02-19], start_time: ~T[14:00:00]}
+
+      next_available_date_time = Schedule.next_available_date_time(schedule, dt)
+      {:ok, expected_next_available_date_time, _} = DateTime.from_iso8601("2021-02-19T14:00:00Z")
+
+      assert next_available_date_time == expected_next_available_date_time
+    end
+  end
 end

--- a/test/lib/ecto_types/schedule_test.exs
+++ b/test/lib/ecto_types/schedule_test.exs
@@ -14,32 +14,40 @@ defmodule Ask.ScheduleTest do
 
   describe "dump:" do
     test "should dump weekdays" do
-      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}"} == Schedule.dump(%Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], timezone: Schedule.default_timezone()})
+      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}"} == Schedule.dump(%Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], timezone: Schedule.default_timezone()})
     end
 
     test "should dump default" do
-      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"end_time\":\"18:00:00\",\"day_of_week\":[],\"blocked_days\":[]}"} == Schedule.dump(Schedule.default())
+      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[],\"blocked_days\":[]}"} == Schedule.dump(Schedule.default())
     end
 
     test "should dump always" do
-      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"00:00:00\",\"end_time\":\"23:59:59\",\"day_of_week\":[\"sun\",\"mon\",\"tue\",\"wed\",\"thu\",\"fri\",\"sat\"],\"blocked_days\":[]}"} == Schedule.dump(Schedule.always())
+      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"00:00:00\",\"start_date\":null,\"end_time\":\"23:59:59\",\"day_of_week\":[\"sun\",\"mon\",\"tue\",\"wed\",\"thu\",\"fri\",\"sat\"],\"blocked_days\":[]}"} == Schedule.dump(Schedule.always())
     end
 
     test "should dump blocked_days" do
-      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"]}"} == Schedule.dump(%Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], timezone: Schedule.default_timezone(), blocked_days: [~D[2016-01-01], ~D[2017-02-03]]})
+      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"]}"} == Schedule.dump(%Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], timezone: Schedule.default_timezone(), blocked_days: [~D[2016-01-01], ~D[2017-02-03]]})
     end
   end
 
   describe "load:" do
     test "should load weekdays" do
-      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[18:00:00], blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
     end
 
     test "should load blocked_days" do
-      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"]}")
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[18:00:00], blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"]}")
     end
-  end
 
+    test "should load without start_date for backward compatibility" do
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[18:00:00], blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
+    end
+
+    test "should load start_date" do
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: ~D[2016-01-01], end_time: ~T[18:00:00], blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":\"2016-01-01\",\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
+    end
+
+  end
   describe "cast:" do
     test "shuld cast to itself" do
       assert {:ok, %Schedule{day_of_week: %DayOfWeek{}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], blocked_days: [], timezone: "Etc/UTC"}} == Schedule.cast(Schedule.default())
@@ -48,36 +56,36 @@ defmodule Ask.ScheduleTest do
     test "should cast string times" do
       assert {
         :ok,
-        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], end_time: ~T[19:00:00], blocked_days: [], timezone: "Etc/UTC"}
-      } == Schedule.cast(%{day_of_week: %{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: "09:00:00", end_time: "19:00:00", timezone: "Etc/UTC", blocked_days: []})
+        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[19:00:00], blocked_days: [], timezone: "Etc/UTC"}
+      } == Schedule.cast(%{day_of_week: %{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: "09:00:00", start_date: nil, end_time: "19:00:00", timezone: "Etc/UTC", blocked_days: []})
     end
 
     test "should cast string days" do
       assert {
         :ok,
-        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], end_time: ~T[19:00:00], blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "Etc/UTC"}
-      } == Schedule.cast(%{day_of_week: %{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], end_time: "19:00:00", timezone: "Etc/UTC", blocked_days: ["2016-01-01", "2017-02-03"]})
+        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[19:00:00], blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "Etc/UTC"}
+      } == Schedule.cast(%{day_of_week: %{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_time: "19:00:00", timezone: "Etc/UTC", blocked_days: ["2016-01-01", "2017-02-03"]})
     end
 
     test "should cast string times with string keys" do
       assert {
         :ok,
-        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], end_time: ~T[19:00:00], blocked_days: [], timezone: "Etc/UTC"}
-      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => "09:00:00", "end_time" => "19:00:00", "timezone" => "Etc/UTC"})
+        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[19:00:00], blocked_days: [], timezone: "Etc/UTC"}
+      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => "09:00:00", "start_date" => nil, "end_time" => "19:00:00", "timezone" => "Etc/UTC"})
     end
 
     test "should cast string days with string keys" do
       assert {
         :ok,
         %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], end_time: ~T[19:00:00], blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "Etc/UTC"}
-      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => "09:00:00", "end_time" => ~T[19:00:00], "timezone" => "Etc/UTC", "blocked_days" => ["2016-01-01", "2017-02-03"]})
+      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => "09:00:00", "start_date" => nil, "end_time" => ~T[19:00:00], "timezone" => "Etc/UTC", "blocked_days" => ["2016-01-01", "2017-02-03"]})
     end
 
     test "shuld cast a struct with string keys" do
       assert {
         :ok,
         %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], end_time: ~T[19:00:00], blocked_days: []}
-      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => ~T[09:00:00], "end_time" => ~T[19:00:00]})
+      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => ~T[09:00:00], "start_date" => nil, "end_time" => ~T[19:00:00]})
     end
 
     test "shuld cast nil" do

--- a/test/lib/runtime/survey_action_test.exs
+++ b/test/lib/runtime/survey_action_test.exs
@@ -38,6 +38,21 @@ defmodule Ask.SurveyActionTest do
       refute incentives_enabled
     end
 
+    test "removes the start date of the schedule" do
+      survey = completed_panel_survey()
+      start_date = ~D[2016-01-01]
+      survey = set_start_date(survey, start_date)
+
+      {result, data} = SurveyAction.repeat(survey)
+      assert result == :ok
+      assert survey.schedule
+      assert survey.schedule.start_date == start_date
+      new_occurrence = Map.get(data, :survey)
+      assert new_occurrence
+      assert new_occurrence.schedule
+      refute new_occurrence.schedule.start_date
+    end
+
     test "doesn't repeat a regular survey" do
       survey = regular_survey()
 
@@ -187,6 +202,13 @@ defmodule Ask.SurveyActionTest do
       repeated_survey: Repo.get(Survey, survey.id),
       new_occurrence: new_occurrence
     }
+  end
+
+  defp set_start_date(survey, start_date) do
+    schedule = Map.put(survey.schedule, :start_date, start_date)
+
+    Survey.changeset(survey, %{schedule: schedule})
+    |> Repo.update!()
   end
 
   defp repeated_survey() do

--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -1626,7 +1626,7 @@ a.disabled {
     right: 0;
     width: 400px;
   }
-  &.start-date {
+  &.single-date-picker {
     top: -65px;
     i[disabled] {
       @extend .grey-text;
@@ -1636,6 +1636,11 @@ a.disabled {
 
 .Cal__Header__root {
   display:none;
+}
+
+.single-date-picker .Cal__Day__selection {
+  background-color: color("green", "base") !important;
+  color: #fff !important;
 }
 
 .multi-date-picker .Cal__Day__selection:before {

--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -1626,6 +1626,12 @@ a.disabled {
     right: 0;
     width: 400px;
   }
+  &.start-date {
+    top: -65px;
+    i[disabled] {
+      @extend .grey-text;
+    }
+  }
 }
 
 .Cal__Header__root {

--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -1638,7 +1638,7 @@ a.disabled {
   display:none;
 }
 
-.Cal__Day__selection:before {
+.multi-date-picker .Cal__Day__selection:before {
   content: 'block';
   font-family: 'Material Icons';
   font-weight: normal;
@@ -1653,7 +1653,7 @@ a.disabled {
   right: -5px;
   opacity: 0.9;
 }
-.Cal__Day__selection {
+.multi-date-picker .Cal__Day__selection {
   color: #ff551b !important;
 }
 

--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -1638,7 +1638,7 @@ a.disabled {
   display:none;
 }
 
-.row.start-date {
+.row.mb0 {
   margin-bottom: 0;
 }
 

--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -1638,6 +1638,10 @@ a.disabled {
   display:none;
 }
 
+.row.start-date {
+  margin-bottom: 0;
+}
+
 .single-date-picker .Cal__Day__selection {
   background-color: color("green", "base") !important;
   color: #fff !important;

--- a/web/static/js/actions/survey.js
+++ b/web/static/js/actions/survey.js
@@ -15,6 +15,7 @@ export const TOGGLE_DAY = 'SURVEY_TOGGLE_DAY'
 export const SET_SCHEDULE_TO = 'SURVEY_SET_SCHEDULE_TO'
 export const SET_SCHEDULE_FROM = 'SURVEY_SET_SCHEDULE_FROM'
 export const ADD_SCHEDULE_BLOCKED_DAY = 'SURVEY_ADD_SCHEDULE_BLOCKED_DAY'
+export const SELECT_SCHEDULE_START_DATE = 'SURVEY_SELECT_SCHEDULE_START_DATE'
 export const REMOVE_SCHEDULE_BLOCKED_DAY = 'SURVEY_REMOVE_SCHEDULE_BLOCKED_DAY'
 export const CLEAR_SCHEDULE_BLOCKED_DAYS = 'SURVEY_CLEAR_SCHEDULE_BLOCKED_DAYS'
 export const SELECT_MODE = 'SURVEY_SELECT_MODE'
@@ -214,6 +215,11 @@ export const setScheduleTo = (hour: string, previousHour: string) => ({
 
 export const clearBlockedDays = () => ({
   type: CLEAR_SCHEDULE_BLOCKED_DAYS
+})
+
+export const selectScheduleStartDate = (date: string) => ({
+  type: SELECT_SCHEDULE_START_DATE,
+  date
 })
 
 export const addScheduleBlockedDay = (day: string) => ({

--- a/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
+++ b/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
@@ -2,7 +2,7 @@ import * as actions from '../../actions/survey'
 import * as uiActions from '../../actions/ui'
 import { connect } from 'react-redux'
 import React, { PropTypes, Component } from 'react'
-import { TimeDropdown, DatePicker, dayLabel, Card, InputWithLabel } from '../ui'
+import { TimeDropdown, DatePicker, dayLabel, Card } from '../ui'
 import SurveyWizardRetryAttempts from './SurveyWizardRetryAttempts'
 import { translate } from 'react-i18next'
 import TimezoneAutocomplete from '../timezones/TimezoneAutocomplete'
@@ -27,6 +27,16 @@ class SurveyWizardScheduleStep extends Component {
     this.updateFrom = this.updateFrom.bind(this)
     this.updateTo = this.updateTo.bind(this)
     this.toggleBlockedDays = this.toggleBlockedDays.bind(this)
+    this.state = {
+      showStartDatePicker: false
+    }
+  }
+
+  toggleStartDatePicker(event: any) {
+    this.setState({
+      showStartDatePicker: !this.state.showStartDatePicker
+    })
+    event.preventDefault()
   }
 
   updateFrom(event) {
@@ -121,21 +131,30 @@ class SurveyWizardScheduleStep extends Component {
             <input
               type='text'
               value={(startDate && this.formatDate(startDate)) || ''}
+              disabled={readOnly}
             />
+            <div className='right datepicker start-date'>
+              {
+                readOnly
+                ? <i disabled className='material-icons'>today</i>
+                : <a className='black-text' href='#' onClick={event => { this.toggleStartDatePicker(event) }}><i className='material-icons'>today</i></a>
+              }
+              {
+                this.state.showStartDatePicker
+                  ? <Card className='datepicker-card'>
+                    <InfiniteCalendar selected={startDate} onSelect={date => {
+                      const formattedDate = dateformat(date, 'yyyy-mm-dd')
+                      const selectedDate = isEqual(formattedDate, startDate)
+                      ? null
+                      : formattedDate
+                      dispatch(actions.selectScheduleStartDate(selectedDate))
+                    }} />
+                  </Card>
+                : null
+              }
+            </div>
           </div>
         </div>
-        <span className='right datepicker'>
-          <a className='black-text' href='#' onClick={this.toggleDatePicker}><i className='material-icons'>today</i></a>
-          <Card className='datepicker-card'>
-            <InfiniteCalendar selected={startDate} onSelect={date => {
-              const formattedDate = dateformat(date, 'yyyy-mm-dd')
-              const selectedDate = isEqual(formattedDate, startDate)
-              ? null
-              : formattedDate
-              dispatch(actions.selectScheduleStartDate(selectedDate))
-            }} />
-          </Card>
-        </span>
         <div className='row'>
           <div className='col s12'>
             <div className='input-field'>

--- a/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
+++ b/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
@@ -2,7 +2,7 @@ import * as actions from '../../actions/survey'
 import * as uiActions from '../../actions/ui'
 import { connect } from 'react-redux'
 import React, { PropTypes, Component } from 'react'
-import { TimeDropdown, DatePicker, dayLabel } from '../ui'
+import { TimeDropdown, DatePicker, dayLabel, Card, InputWithLabel } from '../ui'
 import SurveyWizardRetryAttempts from './SurveyWizardRetryAttempts'
 import { translate } from 'react-i18next'
 import TimezoneAutocomplete from '../timezones/TimezoneAutocomplete'
@@ -67,6 +67,15 @@ class SurveyWizardScheduleStep extends Component {
     dispatch(actions.toggleDay(day))
   }
 
+  dateFromString(date: string) {
+    const splitted = date.split('-')
+    return new Date(parseInt(splitted[0]), parseInt(splitted[1]) - 1, parseInt(splitted[2]))
+  }
+
+  formatDate(date: string) {
+    return dateformat(this.dateFromString(date), 'mmm dd, yyyy')
+  }
+
   render() {
     const { survey, readOnly, ui, t, dispatch } = this.props
     const days = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
@@ -106,13 +115,27 @@ class SurveyWizardScheduleStep extends Component {
           <TimeDropdown label={t('From')} defaultValue={defaultFrom} onChange={this.updateFrom} readOnly={readOnly} min={null} extraOption={{ at: 0, item: { label: '12:00 AM', value: '00:00:00' } }} />
           <TimeDropdown label={t('To')} defaultValue={defaultTo} onChange={this.updateTo} readOnly={readOnly} min={defaultFrom} extraOption={{ at: 23, item: { label: '12:00 AM', value: '23:59:59' } }} />
         </div>
-        <InfiniteCalendar selected={startDate} onSelect={date => {
-          const formattedDate = dateformat(date, 'yyyy-mm-dd')
-          const selectedDate = isEqual(formattedDate, startDate)
-          ? null
-          : formattedDate
-          dispatch(actions.selectScheduleStartDate(selectedDate))
-        }} />
+        <div className='row'>
+          <div className='col s12'>
+            <label className='grey-text'>{this.props.t('Start date')}</label>
+            <input
+              type='text'
+              value={(startDate && this.formatDate(startDate)) || ''}
+            />
+          </div>
+        </div>
+        <span className='right datepicker'>
+          <a className='black-text' href='#' onClick={this.toggleDatePicker}><i className='material-icons'>today</i></a>
+          <Card className='datepicker-card'>
+            <InfiniteCalendar selected={startDate} onSelect={date => {
+              const formattedDate = dateformat(date, 'yyyy-mm-dd')
+              const selectedDate = isEqual(formattedDate, startDate)
+              ? null
+              : formattedDate
+              dispatch(actions.selectScheduleStartDate(selectedDate))
+            }} />
+          </Card>
+        </span>
         <div className='row'>
           <div className='col s12'>
             <div className='input-field'>

--- a/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
+++ b/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
@@ -125,7 +125,7 @@ class SurveyWizardScheduleStep extends Component {
           <TimeDropdown label={t('From')} defaultValue={defaultFrom} onChange={this.updateFrom} readOnly={readOnly} min={null} extraOption={{ at: 0, item: { label: '12:00 AM', value: '00:00:00' } }} />
           <TimeDropdown label={t('To')} defaultValue={defaultTo} onChange={this.updateTo} readOnly={readOnly} min={defaultFrom} extraOption={{ at: 23, item: { label: '12:00 AM', value: '23:59:59' } }} />
         </div>
-        <div className='row'>
+        <div className='row start-date'>
           <div className='col s12'>
             <label className='grey-text'>{this.props.t('Start date')}</label>
             <input

--- a/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
+++ b/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
@@ -2,13 +2,13 @@ import * as actions from '../../actions/survey'
 import * as uiActions from '../../actions/ui'
 import { connect } from 'react-redux'
 import React, { PropTypes, Component } from 'react'
-import { TimeDropdown, DatePicker, dayLabel, Card } from '../ui'
+import { TimeDropdown, DatePicker, dayLabel } from '../ui'
 import SurveyWizardRetryAttempts from './SurveyWizardRetryAttempts'
 import { translate } from 'react-i18next'
 import TimezoneAutocomplete from '../timezones/TimezoneAutocomplete'
-import InfiniteCalendar from 'react-infinite-calendar'
-import { isEqual } from 'lodash'
 import dateformat from 'dateformat'
+import { isEqual } from 'lodash'
+import SingleDatePicker from '../ui/SingleDatePicker'
 
 class SurveyWizardScheduleStep extends Component {
   static propTypes = {
@@ -133,26 +133,13 @@ class SurveyWizardScheduleStep extends Component {
               value={(startDate && this.formatDate(startDate)) || ''}
               disabled={readOnly}
             />
-            <div className='right datepicker start-date'>
-              {
-                readOnly
-                ? <i disabled className='material-icons'>today</i>
-                : <a className='black-text' href='#' onClick={event => { this.toggleStartDatePicker(event) }}><i className='material-icons'>today</i></a>
-              }
-              {
-                this.state.showStartDatePicker
-                  ? <Card className='datepicker-card'>
-                    <InfiniteCalendar selected={startDate} onSelect={date => {
-                      const formattedDate = dateformat(date, 'yyyy-mm-dd')
-                      const selectedDate = isEqual(formattedDate, startDate)
-                      ? null
-                      : formattedDate
-                      dispatch(actions.selectScheduleStartDate(selectedDate))
-                    }} />
-                  </Card>
-                : null
-              }
-            </div>
+            <SingleDatePicker readOnly={readOnly} selected={startDate} onSelect={date => {
+              const formattedDate = dateformat(date, 'yyyy-mm-dd')
+              const selectedDate = isEqual(formattedDate, startDate)
+              ? null
+              : formattedDate
+              dispatch(actions.selectScheduleStartDate(selectedDate))
+            }} />
           </div>
         </div>
         <div className='row'>

--- a/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
+++ b/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
@@ -115,7 +115,7 @@ class SurveyWizardScheduleStep extends Component {
           <TimeDropdown label={t('From')} defaultValue={defaultFrom} onChange={this.updateFrom} readOnly={readOnly} min={null} extraOption={{ at: 0, item: { label: '12:00 AM', value: '00:00:00' } }} />
           <TimeDropdown label={t('To')} defaultValue={defaultTo} onChange={this.updateTo} readOnly={readOnly} min={defaultFrom} extraOption={{ at: 23, item: { label: '12:00 AM', value: '23:59:59' } }} />
         </div>
-        <div className='row start-date'>
+        <div className='row mb0'>
           <div className='col s12'>
             <label className='grey-text'>{this.props.t('Start date')}</label>
             <input

--- a/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
+++ b/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
@@ -27,16 +27,6 @@ class SurveyWizardScheduleStep extends Component {
     this.updateFrom = this.updateFrom.bind(this)
     this.updateTo = this.updateTo.bind(this)
     this.toggleBlockedDays = this.toggleBlockedDays.bind(this)
-    this.state = {
-      showStartDatePicker: false
-    }
-  }
-
-  toggleStartDatePicker(event: any) {
-    this.setState({
-      showStartDatePicker: !this.state.showStartDatePicker
-    })
-    event.preventDefault()
   }
 
   updateFrom(event) {

--- a/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
+++ b/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
@@ -6,6 +6,9 @@ import { TimeDropdown, DatePicker, dayLabel } from '../ui'
 import SurveyWizardRetryAttempts from './SurveyWizardRetryAttempts'
 import { translate } from 'react-i18next'
 import TimezoneAutocomplete from '../timezones/TimezoneAutocomplete'
+import InfiniteCalendar from 'react-infinite-calendar'
+import { isEqual } from 'lodash'
+import dateformat from 'dateformat'
 
 class SurveyWizardScheduleStep extends Component {
   static propTypes = {
@@ -65,7 +68,7 @@ class SurveyWizardScheduleStep extends Component {
   }
 
   render() {
-    const { survey, readOnly, ui, t } = this.props
+    const { survey, readOnly, ui, t, dispatch } = this.props
     const days = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
 
     // Survey might be loaded without details
@@ -75,6 +78,8 @@ class SurveyWizardScheduleStep extends Component {
     if (!survey || !survey.schedule || !survey.schedule.dayOfWeek) {
       return <div>{t('Loading...')}</div>
     }
+
+    const { startDate } = survey.schedule
 
     return (
       <div>
@@ -98,9 +103,16 @@ class SurveyWizardScheduleStep extends Component {
           ))}
         </div>
         <div className='row'>
-          <TimeDropdown label={t('From')} defaultValue={defaultFrom} onChange={this.updateFrom} readOnly={readOnly} min={null} extraOption={{at: 0, item: {label: '12:00 AM', value: '00:00:00'}}} />
-          <TimeDropdown label={t('To')} defaultValue={defaultTo} onChange={this.updateTo} readOnly={readOnly} min={defaultFrom} extraOption={{at: 23, item: {label: '12:00 AM', value: '23:59:59'}}} />
+          <TimeDropdown label={t('From')} defaultValue={defaultFrom} onChange={this.updateFrom} readOnly={readOnly} min={null} extraOption={{ at: 0, item: { label: '12:00 AM', value: '00:00:00' } }} />
+          <TimeDropdown label={t('To')} defaultValue={defaultTo} onChange={this.updateTo} readOnly={readOnly} min={defaultFrom} extraOption={{ at: 23, item: { label: '12:00 AM', value: '23:59:59' } }} />
         </div>
+        <InfiniteCalendar selected={startDate} onSelect={date => {
+          const formattedDate = dateformat(date, 'yyyy-mm-dd')
+          const selectedDate = isEqual(formattedDate, startDate)
+          ? null
+          : formattedDate
+          dispatch(actions.selectScheduleStartDate(selectedDate))
+        }} />
         <div className='row'>
           <div className='col s12'>
             <div className='input-field'>

--- a/web/static/js/components/ui/DatePicker.jsx
+++ b/web/static/js/components/ui/DatePicker.jsx
@@ -9,6 +9,28 @@ import 'react-infinite-calendar/styles.css'
 
 import i18n from '../../i18next'
 
+export const datePickerDisplayOptions = {
+  showHeader: true,
+  showWeekdays: true
+}
+
+export const datePickerTheme = {
+  accentColor: '#4CAF50',
+  floatingNav: {
+    background: 'rgba(245, 245, 245, 0.94)',
+    chevron: '#9a9a9a',
+    color: '#9a9a9a'
+  },
+  headerColor: '#FFF',
+  selectionColor: '#FFF',
+  textColor: {
+    active: '#9a9a9a',
+    default: '#333'
+  },
+  todayColor: '#e0e0e0',
+  weekdayColor: '#FFF'
+}
+
 const MultipleDatesCalendar = withMultipleDates(Calendar)
 
 const enLocale = {
@@ -45,6 +67,12 @@ const frLocale = {
   },
   weekdays: ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'],
   weekStartsOn: 1
+}
+
+export const datePickerLocales = {
+  'en': enLocale,
+  'es': esLocale,
+  'fr': frLocale
 }
 
 export class DatePicker extends Component<any, any> {
@@ -137,27 +165,9 @@ export class DatePicker extends Component<any, any> {
                 ? <Card className='datepicker-card'>
                   <InfiniteCalendar
                     Component={MultipleDatesCalendar}
-                    theme={{
-                      accentColor: '#4CAF50',
-                      floatingNav: {
-                        background: 'rgba(245, 245, 245, 0.94)',
-                        chevron: '#9a9a9a',
-                        color: '#9a9a9a'
-                      },
-                      headerColor: '#FFF',
-                      selectionColor: '#FFF',
-                      textColor: {
-                        active: '#9a9a9a',
-                        default: '#333'
-                      },
-                      todayColor: '#e0e0e0',
-                      weekdayColor: '#FFF'
-                    }}
-                    displayOptions={{
-                      showHeader: true,
-                      showWeekdays: true
-                    }}
-                    locale={this.getLocale(i18n.language)}
+                    theme={datePickerTheme}
+                    displayOptions={datePickerDisplayOptions}
+                    locale={datePickerLocales[i18n.language]}
                     width='100%'
                     displayDate={false}
                     height={300}

--- a/web/static/js/components/ui/DatePicker.jsx
+++ b/web/static/js/components/ui/DatePicker.jsx
@@ -131,7 +131,7 @@ export class DatePicker extends Component<any, any> {
           }
           {
             !readOnly
-            ? <span className='right datepicker'>
+            ? <span className='right datepicker multi-date-picker'>
               <a className='black-text' href='#' onClick={this.toggleDatePicker}><i className='material-icons'>today</i></a>
               { this.state.showDatePicker
                 ? <Card className='datepicker-card'>
@@ -176,4 +176,3 @@ export class DatePicker extends Component<any, any> {
     )
   }
 }
-

--- a/web/static/js/components/ui/SingleDatePicker.jsx
+++ b/web/static/js/components/ui/SingleDatePicker.jsx
@@ -1,0 +1,48 @@
+// @flow
+import { Card } from '../ui'
+import InfiniteCalendar from 'react-infinite-calendar'
+import React, { Component } from 'react'
+
+type Props = {
+  readOnly: boolean,
+  selected: String | null,
+  onSelect: Function
+}
+
+type State = {
+  showDatePicker: boolean
+}
+
+export default class SingleDatePicker extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      showDatePicker: false
+    }
+  }
+
+  toggleStartDatePicker(event: any) {
+    this.setState({
+      showDatePicker: !this.state.showDatePicker
+    })
+    event.preventDefault()
+  }
+
+  render() {
+    const { readOnly, selected, onSelect } = this.props
+    return <div className='right datepicker start-date'>
+      {
+        readOnly
+        ? <i disabled className='material-icons'>today</i>
+        : <a className='black-text' href='#' onClick={event => { this.toggleStartDatePicker(event) }}><i className='material-icons'>today</i></a>
+      }
+      {
+        this.state.showDatePicker
+          ? <Card className='datepicker-card'>
+            <InfiniteCalendar selected={selected} onSelect={onSelect} />
+          </Card>
+        : null
+      }
+    </div>
+  }
+}

--- a/web/static/js/components/ui/SingleDatePicker.jsx
+++ b/web/static/js/components/ui/SingleDatePicker.jsx
@@ -32,7 +32,7 @@ export default class SingleDatePicker extends Component<Props, State> {
 
   render() {
     const { readOnly, selected, onSelect } = this.props
-    return <div className='right datepicker start-date'>
+    return <div className='right datepicker single-date-picker'>
       {
         readOnly
         ? <i disabled className='material-icons'>today</i>

--- a/web/static/js/components/ui/SingleDatePicker.jsx
+++ b/web/static/js/components/ui/SingleDatePicker.jsx
@@ -2,6 +2,7 @@
 import { Card } from '../ui'
 import InfiniteCalendar from 'react-infinite-calendar'
 import React, { Component } from 'react'
+import i18n from '../../i18next'
 
 type Props = {
   readOnly: boolean,
@@ -13,11 +14,57 @@ type State = {
   showDatePicker: boolean
 }
 
+const enLocale = {
+  name: 'en',
+  blank: 'Select a date...',
+  headerFormat: 'ddd, MMM Do',
+  todayLabel: {
+    long: 'Today'
+  },
+  weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  weekStartsOn: 0
+}
+
+const esLocale = {
+  name: 'es',
+  blank: 'Elija una fecha...',
+  headerFormat: 'ddd, MMM Do',
+  locale: require('date-fns/locale/es'),
+  todayLabel: {
+    long: 'Hoy'
+  },
+  weekdays: ['Dom', 'Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab'],
+  weekStartsOn: 0
+}
+
+const frLocale = {
+  name: 'fr',
+  blank: 'Aucune date sélectionnée',
+  headerFormat: 'dddd, D MMM',
+  locale: require('date-fns/locale/fr'),
+  todayLabel: {
+    long: "Aujourd'hui",
+    short: 'Auj.'
+  },
+  weekdays: ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'],
+  weekStartsOn: 1
+}
 export default class SingleDatePicker extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
       showDatePicker: false
+    }
+  }
+
+  getLocale(locale: string) {
+    switch (locale) {
+      case 'en':
+        return enLocale
+      case 'fr':
+        return frLocale
+      case 'es':
+        return esLocale
     }
   }
 
@@ -39,7 +86,32 @@ export default class SingleDatePicker extends Component<Props, State> {
       {
         this.state.showDatePicker
           ? <Card className='datepicker-card'>
-            <InfiniteCalendar selected={selected} onSelect={onSelect} />
+            <InfiniteCalendar selected={selected} onSelect={onSelect}
+              theme={{
+                accentColor: '#4CAF50',
+                floatingNav: {
+                  background: 'rgba(245, 245, 245, 0.94)',
+                  chevron: '#9a9a9a',
+                  color: '#9a9a9a'
+                },
+                headerColor: '#FFF',
+                selectionColor: '#FFF',
+                textColor: {
+                  active: '#9a9a9a',
+                  default: '#333'
+                },
+                todayColor: '#e0e0e0',
+                weekdayColor: '#FFF'
+              }}
+              displayOptions={{
+                showHeader: true,
+                showWeekdays: true
+              }}
+              locale={this.getLocale(i18n.language)}
+              width='100%'
+              displayDate={false}
+              height={300}
+             />
           </Card>
         : null
       }

--- a/web/static/js/components/ui/SingleDatePicker.jsx
+++ b/web/static/js/components/ui/SingleDatePicker.jsx
@@ -3,6 +3,7 @@ import { Card } from '../ui'
 import InfiniteCalendar from 'react-infinite-calendar'
 import React, { Component } from 'react'
 import i18n from '../../i18next'
+import { datePickerTheme, datePickerLocales, datePickerDisplayOptions } from './DatePicker'
 
 type Props = {
   readOnly: boolean,
@@ -14,57 +15,11 @@ type State = {
   showDatePicker: boolean
 }
 
-const enLocale = {
-  name: 'en',
-  blank: 'Select a date...',
-  headerFormat: 'ddd, MMM Do',
-  todayLabel: {
-    long: 'Today'
-  },
-  weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-  weekStartsOn: 0
-}
-
-const esLocale = {
-  name: 'es',
-  blank: 'Elija una fecha...',
-  headerFormat: 'ddd, MMM Do',
-  locale: require('date-fns/locale/es'),
-  todayLabel: {
-    long: 'Hoy'
-  },
-  weekdays: ['Dom', 'Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab'],
-  weekStartsOn: 0
-}
-
-const frLocale = {
-  name: 'fr',
-  blank: 'Aucune date sélectionnée',
-  headerFormat: 'dddd, D MMM',
-  locale: require('date-fns/locale/fr'),
-  todayLabel: {
-    long: "Aujourd'hui",
-    short: 'Auj.'
-  },
-  weekdays: ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'],
-  weekStartsOn: 1
-}
 export default class SingleDatePicker extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
       showDatePicker: false
-    }
-  }
-
-  getLocale(locale: string) {
-    switch (locale) {
-      case 'en':
-        return enLocale
-      case 'fr':
-        return frLocale
-      case 'es':
-        return esLocale
     }
   }
 
@@ -87,27 +42,9 @@ export default class SingleDatePicker extends Component<Props, State> {
         this.state.showDatePicker
           ? <Card className='datepicker-card'>
             <InfiniteCalendar selected={selected} onSelect={onSelect}
-              theme={{
-                accentColor: '#4CAF50',
-                floatingNav: {
-                  background: 'rgba(245, 245, 245, 0.94)',
-                  chevron: '#9a9a9a',
-                  color: '#9a9a9a'
-                },
-                headerColor: '#FFF',
-                selectionColor: '#FFF',
-                textColor: {
-                  active: '#9a9a9a',
-                  default: '#333'
-                },
-                todayColor: '#e0e0e0',
-                weekdayColor: '#FFF'
-              }}
-              displayOptions={{
-                showHeader: true,
-                showWeekdays: true
-              }}
-              locale={this.getLocale(i18n.language)}
+              theme={datePickerTheme}
+              displayOptions={datePickerDisplayOptions}
+              locale={datePickerLocales[i18n.language]}
               width='100%'
               displayDate={false}
               height={300}

--- a/web/static/js/reducers/survey.js
+++ b/web/static/js/reducers/survey.js
@@ -31,6 +31,7 @@ export const dataReducer = (state: Survey, action: any): Survey => {
     case actions.SET_SCHEDULE_TO: return setScheduleTo(state, action)
     case actions.SET_SCHEDULE_FROM: return setScheduleFrom(state, action)
     case actions.ADD_SCHEDULE_BLOCKED_DAY: return addScheduleBlockedDay(state, action)
+    case actions.SELECT_SCHEDULE_START_DATE: return selectScheduleStartDate(state, action)
     case actions.REMOVE_SCHEDULE_BLOCKED_DAY: return removeScheduleBlockedDay(state, action)
     case actions.CLEAR_SCHEDULE_BLOCKED_DAYS: return clearScheduleBlockedDays(state, action)
     case actions.SELECT_MODE: return selectMode(state, action)
@@ -422,6 +423,16 @@ const addScheduleBlockedDay = (state, action) => {
         ...state.schedule.blockedDays,
         action.day
       ]))
+    }
+  }
+}
+
+const selectScheduleStartDate = (state, action) => {
+  return {
+    ...state,
+    schedule: {
+      ...state.schedule,
+      startDate: action.date
     }
   }
 }


### PR DESCRIPTION
### The motivation 🥕 

In regular surveys, and particularly in panel surveys, it'd be useful to schedule the start date of a survey.
This PR adds the `start date` setting to the survey Schedule section.

### Expected behavior 🗒️ 

- [x] use block date UI in settings
- [x] prevent the survey from sending messages before that date. the survey will appear as started.
- [x] add legend start date in card
- [x] (not editable once the survey is launched)

### Done ✅ 

- [x] Select and deselect the start date from the UI
- [x] Honor the end-user selection
- [x] Disable selection after the survey is launched
- [x] UI styling
- [x] Test schedule manually
- [x] Add tests

### Pending 🗒️ 

- [ ] Validate start date is after today and before the first blocked-date

Fix #1838

### How it looks 📷 

![Editing survey schedule](https://user-images.githubusercontent.com/39921597/109853838-1d342680-7c35-11eb-86f5-8da71df85562.png)

---

![Scheduled running survey](https://user-images.githubusercontent.com/39921597/109534757-70be3d00-7a9a-11eb-9b7a-25073ccac0ea.png)

---

![Running survey schedule](https://user-images.githubusercontent.com/39921597/109534047-ae6e9600-7a99-11eb-8187-4061a7bc875b.png)

---

### Last minor style change 🖌️ 

Reduced space between start-date and block-dates

![Reduced space between start-date and block-dates](https://user-images.githubusercontent.com/39921597/110001786-80848e00-7cf3-11eb-8fb4-4c49c7e2391f.png)
