### PR TITLE
Add end date to schedule

### DIFF
--- a/lib/ask/ecto_types/schedule.ex
+++ b/lib/ask/ecto_types/schedule.ex
@@ -186,14 +186,17 @@ defmodule Ask.Schedule do
     Map.put(schedule, :start_date, nil)
   end
 
-  def end_date_passed?(%{end_date: nil} = _schedule) do
+  def end_date_passed?(schedule, date_time \\ DateTime.utc_now())
+
+  def end_date_passed?(%{end_date: nil} = _schedule, _date_time) do
     false
   end
 
   def end_date_passed?(
         %{end_date: end_date, timezone: timezone} = _schedule,
-        date_time \\ DateTime.utc_now()
+        date_time
       ) do
+
     date_time
     |> Timex.to_datetime(timezone)
     |> DateTime.to_date()

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -85,6 +85,9 @@ defmodule Ask.Runtime.Broker do
 
   def poll_survey(survey, now) do
     if Schedule.end_date_passed?(survey.schedule, now) do
+      # Between the 00:00 of the end_date and this survey poll (the poll_interval is 1 minute)
+      # the survey will be active during a short but unexpected time window.
+      # We explicitly decided to ignore this corner case to gain solidity and simplicity
       stop_survey(survey)
     else
       channels = survey |> Survey.survey_channels

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -3,7 +3,7 @@ defmodule Ask.Runtime.Broker do
   import Ecto.Query
   import Ecto
   alias Ask.{Repo, Logger, Survey, Respondent, RespondentGroup, QuotaBucket, RespondentDispositionHistory, SystemTime, Schedule, SurvedaMetrics}
-  alias Ask.Runtime.{Session, RetriesHistogram, ChannelStatusServer}
+  alias Ask.Runtime.{Session, RetriesHistogram, ChannelStatusServer, SurveyAction}
 
   @poll_interval :timer.minutes(1)
   @server_ref {:global, __MODULE__}
@@ -75,53 +75,77 @@ defmodule Ask.Runtime.Broker do
   end
 
   defp poll_survey(survey) do
-    channels = survey |> Survey.survey_channels
-    channel_is_down = channels |> Enum.any?(fn c ->
-      status = c.id |> ChannelStatusServer.get_channel_status
-      (status != :up && status != :unknown)
-    end)
-    case channel_is_down do
-      false ->
-        try do
-          by_state = Survey.respondents_by_state(survey)
-          %{
-            "active" => active,
-            "pending" => pending,
-            "completed" => completed,
-          } = by_state
+    if (Schedule.end_date_passed?(survey.schedule)) do
+      stop_survey(survey)
+    else
+      channels = survey |> Survey.survey_channels
+      channel_is_down? = channels |> Enum.any?(fn c ->
+        status = c.id |> ChannelStatusServer.get_channel_status
+        (status != :up && status != :unknown)
+      end)
+      poll_survey(survey, channel_is_down?)
+    end
+  end
 
-          reached_quotas = reached_quotas?(survey)
-          survey_completed = survey.cutoff <= completed || reached_quotas
-          batch_size = batch_size(survey, by_state)
-          Logger.info "Polling survey #{survey.id} (active=#{active}, pending=#{pending}, completed=#{completed}, batch_size=#{batch_size})"
-          SurvedaMetrics.increment_counter_with_label(:surveda_survey_poll, [survey.id])
+  defp stop_survey(survey) do
+    try do
+      {:ok, _} = SurveyAction.stop(survey)
+      :ok
+    rescue
+      e ->
+        handle_exception(survey, e, "Error occurred while stopping survey (id: #{survey.id})")
+        Sentry.capture_exception(e, [
+          stacktrace: System.stacktrace(),
+          extra: %{survey_id: survey.id}])
+    end
+  end
 
-          cond do
-            (active == 0 && (pending == 0 || survey_completed)) ->
-              Logger.info "Survey #{survey.id} completed"
-              complete(survey)
+  defp handle_exception(survey, e, message) do
+    if Mix.env == :test do
+      IO.inspect e
+      IO.inspect System.stacktrace()
+      raise e
+    end
+    Logger.error(e, message)
+    Sentry.capture_exception(e, [
+      stacktrace: System.stacktrace(),
+      extra: %{survey_id: survey.id}])
+  end
 
-            active < batch_size && pending > 0 && !survey_completed ->
-              count = batch_size - active
-              Logger.info "Survey #{survey.id}. Starting up to #{count} respondents."
-              start_some(survey, count)
+  defp poll_survey(survey, true = _channel_is_down) do
+    ChannelStatusServer.log_info "Survey #{survey.id} was not polled because a channel is down"
+  end
 
-            true -> :ok
-          end
-        rescue
-          e ->
-            if Mix.env == :test do
-              IO.inspect e
-              IO.inspect System.stacktrace()
-              raise e
-            end
-            Logger.error(e, "Error occurred while polling survey (id: #{survey.id})")
-            Sentry.capture_exception(e, [
-              stacktrace: System.stacktrace(),
-              extra: %{survey_id: survey.id}])
-        end
-      true ->
-        ChannelStatusServer.log_info "Survey #{survey.id} was not polled because a channel is down"
+  defp poll_survey(survey, false = _channel_is_down) do
+    try do
+      by_state = Survey.respondents_by_state(survey)
+      %{
+        "active" => active,
+        "pending" => pending,
+        "completed" => completed,
+      } = by_state
+
+      reached_quotas = reached_quotas?(survey)
+      survey_completed = survey.cutoff <= completed || reached_quotas
+      batch_size = batch_size(survey, by_state)
+      Logger.info "Polling survey #{survey.id} (active=#{active}, pending=#{pending}, completed=#{completed}, batch_size=#{batch_size})"
+      SurvedaMetrics.increment_counter_with_label(:surveda_survey_poll, [survey.id])
+
+      cond do
+        (active == 0 && (pending == 0 || survey_completed)) ->
+          Logger.info "Survey #{survey.id} completed"
+          complete(survey)
+
+        active < batch_size && pending > 0 && !survey_completed ->
+          count = batch_size - active
+          Logger.info "Survey #{survey.id}. Starting up to #{count} respondents."
+          start_some(survey, count)
+
+        true -> :ok
+      end
+    rescue
+      e ->
+        handle_exception(survey, e, "Error occurred while polling survey (id: #{survey.id})")
     end
   end
 

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -83,7 +83,7 @@ defmodule Ask.Runtime.Broker do
     |> Enum.each(fn survey -> poll_survey(survey, now) end)
   end
 
-  defp poll_survey(survey, now) do
+  def poll_survey(survey, now) do
     if Schedule.end_date_passed?(survey.schedule, now) do
       stop_survey(survey)
     else
@@ -135,8 +135,7 @@ defmodule Ask.Runtime.Broker do
 
   defp stop_survey(survey) do
     try do
-      {:ok, _} = SurveyAction.stop(survey)
-      :ok
+      SurveyAction.stop(survey)
     rescue
       e ->
         handle_exception(survey, e, "Error occurred while stopping survey (id: #{survey.id})")

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -1,5 +1,5 @@
 defmodule Ask.Runtime.SurveyAction do
-  alias Ask.{Survey, Logger, Repo, Questionnaire, ActivityLog}
+  alias Ask.{Survey, Logger, Repo, Questionnaire, ActivityLog, SurveyCanceller, Project}
   alias Ask.Runtime.PanelSurvey
   alias Ecto.Multi
 
@@ -46,6 +46,44 @@ defmodule Ask.Runtime.SurveyAction do
       Logger.warn("Error when launching survey #{survey.id}. State is not ready ")
       {:error, %{survey: survey}}
     end
+  end
+
+  def stop(survey, conn \\ nil) do
+    survey = Repo.preload(survey, [:quota_buckets, :project])
+
+    case [survey.state, survey.locked] do
+      ["terminated", false] ->
+        # Cancelling a cancelled survey is idempotent.
+        # We must not error, because this can happen if a user has the survey
+        # UI open with the cancel button, and meanwhile the survey is cancelled
+        # from another tab.
+        # Cancelling a completed survey should have no effect.
+        # We must not error, because this can happen if a user has the survey
+        # UI open with the cancel button, and meanwhile the survey finished
+        {:ok, %{survey: survey}}
+      ["running", false] ->
+        changeset = Survey.changeset(survey, %{"state": "cancelling", "exit_code": 1, "exit_message": "Cancelled by user"})
+
+        multi = Multi.new
+        |> Multi.update(:survey, changeset)
+        |> Multi.insert(:log, ActivityLog.request_cancel(survey.project, conn, survey))
+        |> Repo.transaction
+
+        case multi do
+          {:ok, %{survey: survey}} ->
+            survey.project |> Project.touch!
+            cancellers_pids = SurveyCanceller.start_cancelling(survey.id).consumers_pids
+            {:ok, %{survey: survey, cancellers_pids: cancellers_pids}}
+          {:error, _, changeset, _} ->
+            Logger.warn "Error when stopping survey #{inspect survey}"
+            {:error, %{changeset: changeset}}
+        end
+      [_, _] ->
+        # Cancelling a pending survey, a survey in any other state or that it
+        # is locked, should result in an error.
+        Logger.warn "Error when stopping survey #{inspect survey}: Wrong state or locked"
+        {:error, %{survey: survey}}
+      end
   end
 
   def repeat(survey) do

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -72,8 +72,8 @@ defmodule Ask.Runtime.SurveyAction do
         case multi do
           {:ok, %{survey: survey}} ->
             survey.project |> Project.touch!
-            cancellers_pids = SurveyCanceller.start_cancelling(survey.id).consumers_pids
-            {:ok, %{survey: survey, cancellers_pids: cancellers_pids}}
+            %{consumers_pids: consumers_pids, processes: processes} = SurveyCanceller.start_cancelling(survey.id)
+            {:ok, %{survey: survey, cancellers_pids: consumers_pids, processes: processes}}
           {:error, _, changeset, _} ->
             Logger.warn "Error when stopping survey #{inspect survey}"
             {:error, %{changeset: changeset}}

--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -150,6 +150,7 @@
   "Editor": "",
   "Email": "",
   "Enabled <i>{{surveyName}}</i> {{reportType}} link": "",
+  "End date": "",
   "End section": "",
   "Enter a delay like 10m, 3h or 1d to express a time unit (default 1h, use values greater than 10m)": "",
   "Enter collaborator's email": "",

--- a/test/controllers/short_link_controller_test.exs
+++ b/test/controllers/short_link_controller_test.exs
@@ -22,7 +22,7 @@ defmodule Ask.ShortLinkControllerTest do
     conn = get conn, short_link_path(conn, :access, link.hash)
 
     assert json_response(conn, 200)["data"] == [
-      %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "down_channels" => [], "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "folder_id" => nil}
+      %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "end_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "down_channels" => [], "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "folder_id" => nil}
     ]
   end
 end

--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -37,7 +37,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id)
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => survey.description, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => started_at |> Timex.format!("%FT%T%:z", :strftime), "ended_at" => ended_at |> Timex.format!("%FT%T%:z", :strftime), "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => survey.description, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "end_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => started_at |> Timex.format!("%FT%T%:z", :strftime), "ended_at" => ended_at |> Timex.format!("%FT%T%:z", :strftime), "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
       ]
     end
 
@@ -50,7 +50,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id, state: "running")
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "running", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "running", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "end_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
       ]
     end
 
@@ -64,7 +64,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id)
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => survey.description, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => started_at |> Timex.format!("%FT%T%:z", :strftime), "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => folder.id}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => survey.description, "project_id" => project.id, "state" => "not_ready", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "end_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => started_at |> Timex.format!("%FT%T%:z", :strftime), "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => folder.id}
       ]
     end
 
@@ -77,7 +77,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id, state: "completed")
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "terminated", "locked" => false, "exit_code" => 0, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "terminated", "locked" => false, "exit_code" => 0, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "end_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
       ]
     end
 
@@ -90,7 +90,7 @@ defmodule Ask.SurveyControllerTest do
       conn = get conn, project_survey_path(conn, :index, project.id, %{"since" => Timex.format!(Timex.shift(Timex.now, hours: 2), "%FT%T%:z", :strftime)})
 
       assert json_response(conn, 200)["data"] == [
-        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "running", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
+        %{"cutoff" => survey.cutoff, "id" => survey.id, "mode" => survey.mode, "name" => survey.name, "description" => nil, "project_id" => project.id, "state" => "running", "locked" => false, "exit_code" => nil, "exit_message" => nil, "schedule" => %{"blocked_days" => [], "day_of_week" => %{"fri" => true, "mon" => true, "sat" => true, "sun" => true, "thu" => true, "tue" => true, "wed" => true}, "end_time" => "23:59:59", "start_time" => "00:00:00", "start_date" => nil, "end_date" => nil, "timezone" => "Etc/UTC"}, "next_schedule_time" => nil, "started_at" => nil, "ended_at" => nil, "updated_at" => DateTime.to_iso8601(survey.updated_at), "down_channels" => [], "folder_id" => nil}
       ]
     end
 
@@ -161,6 +161,7 @@ defmodule Ask.SurveyControllerTest do
           },
           "start_time" => "00:00:00",
           "start_date" => nil,
+          "end_date" => nil,
           "end_time" => "23:59:59",
           "timezone" => "Etc/UTC",
           "blocked_days" => []
@@ -238,6 +239,7 @@ defmodule Ask.SurveyControllerTest do
           },
           "start_time" => "00:00:00",
           "start_date" => nil,
+          "end_date" => nil,
           "end_time" => "23:59:59",
           "timezone" => "Etc/UTC",
           "blocked_days" => []
@@ -314,6 +316,7 @@ defmodule Ask.SurveyControllerTest do
           },
           "start_time" => "00:00:00",
           "start_date" => nil,
+          "end_date" => nil,
           "end_time" => "23:59:59",
           "timezone" => "Etc/UTC",
           "blocked_days" => []
@@ -386,6 +389,7 @@ defmodule Ask.SurveyControllerTest do
           },
           "start_time" => "00:00:00",
           "start_date" => nil,
+          "end_date" => nil,
           "end_time" => "23:59:59",
           "timezone" => "Etc/UTC",
           "blocked_days" => []

--- a/test/lib/ecto_types/schedule_test.exs
+++ b/test/lib/ecto_types/schedule_test.exs
@@ -32,21 +32,28 @@ defmodule Ask.ScheduleTest do
 
   describe "load:" do
     test "should load weekdays" do
-      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[18:00:00], blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[18:00:00], end_date: nil, blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
     end
 
     test "should load blocked_days" do
-      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[18:00:00], blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"]}")
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[18:00:00], end_date: nil, blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"]}")
     end
 
     test "should load without start_date for backward compatibility" do
-      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[18:00:00], blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[18:00:00], end_date: nil, blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
     end
 
     test "should load start_date" do
-      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: ~D[2016-01-01], end_time: ~T[18:00:00], blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":\"2016-01-01\",\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: ~D[2016-01-01], end_time: ~T[18:00:00], end_date: nil, blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":\"2016-01-01\",\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
     end
 
+    test "should load end_date" do
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: ~D[2016-01-01], end_time: ~T[18:00:00], end_date: ~D[2016-02-01], blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":\"2016-01-01\",\"end_time\":\"18:00:00\",\"end_date\":\"2016-02-01\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
+    end
+
+    test "should load without end_date for backward compatibility" do
+      assert {:ok, %Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true, sun: false, sat: false}, start_time: ~T[09:00:00], start_date: ~D[2016-01-01], end_time: ~T[18:00:00], end_date: nil, blocked_days: [], timezone: "America/Argentina/Buenos_Aires"}} == Schedule.load("{\"timezone\":\"America/Argentina/Buenos_Aires\",\"start_time\":\"09:00:00\",\"start_date\":\"2016-01-01\",\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}")
+    end
   end
   describe "cast:" do
     test "shuld cast to itself" do
@@ -69,25 +76,25 @@ defmodule Ask.ScheduleTest do
     test "should cast string times with string keys" do
       assert {
         :ok,
-        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[19:00:00], blocked_days: [], timezone: "Etc/UTC"}
-      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => "09:00:00", "start_date" => nil, "end_time" => "19:00:00", "timezone" => "Etc/UTC"})
+        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_date: nil, end_time: ~T[19:00:00], blocked_days: [], timezone: "Etc/UTC"}
+      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => "09:00:00", "start_date" => nil, "end_time" => "19:00:00", "end_date" => nil, "timezone" => "Etc/UTC"})
     end
 
     test "should cast string days with string keys" do
       assert {
         :ok,
-        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], end_time: ~T[19:00:00], blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "Etc/UTC"}
-      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => "09:00:00", "start_date" => nil, "end_time" => ~T[19:00:00], "timezone" => "Etc/UTC", "blocked_days" => ["2016-01-01", "2017-02-03"]})
+        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_date: nil, start_time: ~T[09:00:00], end_time: ~T[19:00:00], end_date: nil, blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "Etc/UTC"}
+      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => "09:00:00", "start_date" => nil, "end_time" => ~T[19:00:00], "end_date" => nil, "timezone" => "Etc/UTC", "blocked_days" => ["2016-01-01", "2017-02-03"]})
     end
 
-    test "shuld cast a struct with string keys" do
+    test "should cast a struct with string keys" do
       assert {
         :ok,
-        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], end_time: ~T[19:00:00], blocked_days: []}
-      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => ~T[09:00:00], "start_date" => nil, "end_time" => ~T[19:00:00]})
+        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_date: nil, start_time: ~T[09:00:00], end_time: ~T[19:00:00], end_date: nil, blocked_days: []}
+      } == Schedule.cast(%{"day_of_week" => %{"sun" => true, "mon" => true, "tue" => true, "wed" => true, "thu" => true, "fri" => false, "sat" => true}, "start_time" => ~T[09:00:00], "start_date" => nil, "end_time" => ~T[19:00:00], "end_date" => nil})
     end
 
-    test "shuld cast nil" do
+    test "should cast nil" do
       assert {:ok, @default_schedule} == Schedule.cast(nil)
     end
   end

--- a/test/lib/ecto_types/schedule_test.exs
+++ b/test/lib/ecto_types/schedule_test.exs
@@ -194,4 +194,52 @@ defmodule Ask.ScheduleTest do
       assert next_available_date_time == expected_next_available_date_time
     end
   end
+
+  describe "end date" do
+    setup do
+      {:ok, dt_not_passed, _} = DateTime.from_iso8601("2021-02-11T12:00:00Z")
+      {:ok, dt_today, _} = DateTime.from_iso8601("2021-02-19T19:00:00Z")
+      {:ok, dt_passed, _} = DateTime.from_iso8601("2021-02-25T12:00:00Z")
+
+      {
+        :ok,
+        end_date: ~D[2021-02-19],
+        dt_not_passed: dt_not_passed,
+        dt_today: dt_today,
+        dt_passed: dt_passed
+      }
+    end
+
+    test "end_date_passed? returns false when there's no end_date in the schedule" do
+      schedule = Schedule.always()
+
+      end_date_passed? = Schedule.end_date_passed?(schedule)
+
+      assert end_date_passed? == false
+    end
+
+    test "end_date_passed? returns false when the end_date didn't passed", %{end_date: end_date, dt_not_passed: dt_not_passed} do
+      schedule = %{Schedule.always() | end_date: end_date}
+
+      end_date_passed? = Schedule.end_date_passed?(schedule, dt_not_passed)
+
+      assert end_date_passed? == false
+    end
+
+    test "end_date_passed? returns true when end_date is today", %{end_date: end_date, dt_today: dt_today} do
+      schedule = %{Schedule.always() | end_date: end_date}
+
+      end_date_passed? = Schedule.end_date_passed?(schedule, dt_today)
+
+      assert end_date_passed? == true
+    end
+
+    test "end_date_passed? returns true when the end_date passed", %{end_date: end_date, dt_today: dt_passed} do
+      schedule = %{Schedule.always() | end_date: end_date}
+
+      end_date_passed? = Schedule.end_date_passed?(schedule, dt_passed)
+
+      assert end_date_passed? == true
+    end
+  end
 end

--- a/test/lib/ecto_types/schedule_test.exs
+++ b/test/lib/ecto_types/schedule_test.exs
@@ -14,19 +14,19 @@ defmodule Ask.ScheduleTest do
 
   describe "dump:" do
     test "should dump weekdays" do
-      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}"} == Schedule.dump(%Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], timezone: Schedule.default_timezone()})
+      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}"} == Schedule.dump(%Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], timezone: Schedule.default_timezone()})
     end
 
     test "should dump default" do
-      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[],\"blocked_days\":[]}"} == Schedule.dump(Schedule.default())
+      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[],\"blocked_days\":[]}"} == Schedule.dump(Schedule.default())
     end
 
     test "should dump always" do
-      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"00:00:00\",\"start_date\":null,\"end_time\":\"23:59:59\",\"day_of_week\":[\"sun\",\"mon\",\"tue\",\"wed\",\"thu\",\"fri\",\"sat\"],\"blocked_days\":[]}"} == Schedule.dump(Schedule.always())
+      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"00:00:00\",\"start_date\":null,\"end_time\":\"23:59:59\",\"end_date\":null,\"day_of_week\":[\"sun\",\"mon\",\"tue\",\"wed\",\"thu\",\"fri\",\"sat\"],\"blocked_days\":[]}"} == Schedule.dump(Schedule.always())
     end
 
     test "should dump blocked_days" do
-      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"]}"} == Schedule.dump(%Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], timezone: Schedule.default_timezone(), blocked_days: [~D[2016-01-01], ~D[2017-02-03]]})
+      assert {:ok, "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"]}"} == Schedule.dump(%Schedule{day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], timezone: Schedule.default_timezone(), blocked_days: [~D[2016-01-01], ~D[2017-02-03]]})
     end
   end
 
@@ -52,19 +52,18 @@ defmodule Ask.ScheduleTest do
     test "shuld cast to itself" do
       assert {:ok, %Schedule{day_of_week: %DayOfWeek{}, start_time: ~T[09:00:00], end_time: ~T[18:00:00], blocked_days: [], timezone: "Etc/UTC"}} == Schedule.cast(Schedule.default())
     end
-
     test "should cast string times" do
       assert {
         :ok,
-        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[19:00:00], blocked_days: [], timezone: "Etc/UTC"}
-      } == Schedule.cast(%{day_of_week: %{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: "09:00:00", start_date: nil, end_time: "19:00:00", timezone: "Etc/UTC", blocked_days: []})
+        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_date: nil, end_time: ~T[19:00:00], blocked_days: [], timezone: "Etc/UTC"}
+      } == Schedule.cast(%{day_of_week: %{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: "09:00:00", start_date: nil, end_date: nil, end_time: "19:00:00", timezone: "Etc/UTC", blocked_days: []})
     end
 
     test "should cast string days" do
       assert {
         :ok,
-        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_time: ~T[19:00:00], blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "Etc/UTC"}
-      } == Schedule.cast(%{day_of_week: %{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_time: "19:00:00", timezone: "Etc/UTC", blocked_days: ["2016-01-01", "2017-02-03"]})
+        %Schedule{day_of_week: %DayOfWeek{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_date: nil, end_time: ~T[19:00:00], blocked_days: [~D[2016-01-01], ~D[2017-02-03]], timezone: "Etc/UTC"}
+      } == Schedule.cast(%{day_of_week: %{sun: true, mon: true, tue: true, wed: true, thu: true, fri: false, sat: true}, start_time: ~T[09:00:00], start_date: nil, end_date: nil, end_time: "19:00:00", timezone: "Etc/UTC", blocked_days: ["2016-01-01", "2017-02-03"]})
     end
 
     test "should cast string times with string keys" do

--- a/web/static/js/actions/survey.js
+++ b/web/static/js/actions/survey.js
@@ -16,6 +16,7 @@ export const SET_SCHEDULE_TO = 'SURVEY_SET_SCHEDULE_TO'
 export const SET_SCHEDULE_FROM = 'SURVEY_SET_SCHEDULE_FROM'
 export const ADD_SCHEDULE_BLOCKED_DAY = 'SURVEY_ADD_SCHEDULE_BLOCKED_DAY'
 export const SELECT_SCHEDULE_START_DATE = 'SURVEY_SELECT_SCHEDULE_START_DATE'
+export const SELECT_SCHEDULE_END_DATE = 'SURVEY_SELECT_SCHEDULE_END_DATE'
 export const REMOVE_SCHEDULE_BLOCKED_DAY = 'SURVEY_REMOVE_SCHEDULE_BLOCKED_DAY'
 export const CLEAR_SCHEDULE_BLOCKED_DAYS = 'SURVEY_CLEAR_SCHEDULE_BLOCKED_DAYS'
 export const SELECT_MODE = 'SURVEY_SELECT_MODE'
@@ -219,6 +220,11 @@ export const clearBlockedDays = () => ({
 
 export const selectScheduleStartDate = (date: string) => ({
   type: SELECT_SCHEDULE_START_DATE,
+  date
+})
+
+export const selectScheduleEndDate = (date: string) => ({
+  type: SELECT_SCHEDULE_END_DATE,
   date
 })
 

--- a/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
+++ b/web/static/js/components/surveys/SurveyWizardScheduleStep.jsx
@@ -88,7 +88,7 @@ class SurveyWizardScheduleStep extends Component {
       return <div>{t('Loading...')}</div>
     }
 
-    const { startDate } = survey.schedule
+    const { startDate, endDate } = survey.schedule
 
     return (
       <div>
@@ -116,7 +116,7 @@ class SurveyWizardScheduleStep extends Component {
           <TimeDropdown label={t('To')} defaultValue={defaultTo} onChange={this.updateTo} readOnly={readOnly} min={defaultFrom} extraOption={{ at: 23, item: { label: '12:00 AM', value: '23:59:59' } }} />
         </div>
         <div className='row mb0'>
-          <div className='col s12'>
+          <div className='col s6'>
             <label className='grey-text'>{this.props.t('Start date')}</label>
             <input
               type='text'
@@ -129,6 +129,21 @@ class SurveyWizardScheduleStep extends Component {
               ? null
               : formattedDate
               dispatch(actions.selectScheduleStartDate(selectedDate))
+            }} />
+          </div>
+          <div className='col s6'>
+            <label className='grey-text'>{this.props.t('End date')}</label>
+            <input
+              type='text'
+              value={(endDate && this.formatDate(endDate)) || ''}
+              disabled={readOnly}
+            />
+            <SingleDatePicker readOnly={readOnly} selected={endDate} onSelect={date => {
+              const formattedDate = dateformat(date, 'yyyy-mm-dd')
+              const selectedDate = isEqual(formattedDate, endDate)
+              ? null
+              : formattedDate
+              dispatch(actions.selectScheduleEndDate(selectedDate))
             }} />
           </div>
         </div>

--- a/web/static/js/reducers/survey.js
+++ b/web/static/js/reducers/survey.js
@@ -32,6 +32,7 @@ export const dataReducer = (state: Survey, action: any): Survey => {
     case actions.SET_SCHEDULE_FROM: return setScheduleFrom(state, action)
     case actions.ADD_SCHEDULE_BLOCKED_DAY: return addScheduleBlockedDay(state, action)
     case actions.SELECT_SCHEDULE_START_DATE: return selectScheduleStartDate(state, action)
+    case actions.SELECT_SCHEDULE_END_DATE: return selectScheduleEndDate(state, action)
     case actions.REMOVE_SCHEDULE_BLOCKED_DAY: return removeScheduleBlockedDay(state, action)
     case actions.CLEAR_SCHEDULE_BLOCKED_DAYS: return clearScheduleBlockedDays(state, action)
     case actions.SELECT_MODE: return selectMode(state, action)
@@ -433,6 +434,16 @@ const selectScheduleStartDate = (state, action) => {
     schedule: {
       ...state.schedule,
       startDate: action.date
+    }
+  }
+}
+
+const selectScheduleEndDate = (state, action) => {
+  return {
+    ...state,
+    schedule: {
+      ...state.schedule,
+      endDate: action.date
     }
   }
 }


### PR DESCRIPTION
### Is this a draft ❓ 

No, it isn't. It's ready for review, but I keep it as a draft because before merging it #1850 has to be merged and after that the base branch has to be changed to master.

### What are we doing❓ 

We're adding `start_date` and `end_date` to the survey schedule.

#1850 adds the `start_date` field and this PR adds the `end_date` field.

When a survey is running and the end date is reached, it should stop automatically just as it does when the end-user stops a survey manually.

![end date](https://user-images.githubusercontent.com/39921597/110004399-29cc8380-7cf6-11eb-8ed5-df907e0b0824.png)

Fix #1838 