### PR TITLE
Avoid replicating `end_date` on survey repetition

### DIFF
--- a/lib/ask/ecto_types/schedule.ex
+++ b/lib/ask/ecto_types/schedule.ex
@@ -186,6 +186,10 @@ defmodule Ask.Schedule do
     Map.put(schedule, :start_date, nil)
   end
 
+  def remove_end_date(schedule) do
+    Map.put(schedule, :end_date, nil)
+  end
+
   def end_date_passed?(schedule, date_time \\ DateTime.utc_now())
 
   def end_date_passed?(%{end_date: nil} = _schedule, _date_time) do

--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -11,6 +11,11 @@ defmodule Ask.Runtime.PanelSurvey do
       survey
       |> Repo.preload([:project])
 
+    schedule =
+      survey.schedule
+      |> Schedule.remove_start_date()
+      |> Schedule.remove_end_date()
+
     new_ocurrence = %{
       # basic settings
       project_id: survey.project_id,
@@ -25,7 +30,7 @@ defmodule Ask.Runtime.PanelSurvey do
       # advanced settings
       cutoff: survey.cutoff,
       count_partial_results: survey.count_partial_results,
-      schedule: Schedule.remove_start_date(survey.schedule),
+      schedule: schedule,
       sms_retry_configuration: survey.sms_retry_configuration,
       ivr_retry_configuration: survey.ivr_retry_configuration,
       mobileweb_retry_configuration: survey.mobileweb_retry_configuration,

--- a/test/lib/runtime/survey_action_test.exs
+++ b/test/lib/runtime/survey_action_test.exs
@@ -38,19 +38,24 @@ defmodule Ask.SurveyActionTest do
       refute incentives_enabled
     end
 
-    test "removes the start date of the schedule" do
+    test "removes start_date and end_date of the schedule" do
       survey = completed_panel_survey()
       start_date = ~D[2016-01-01]
-      survey = set_start_date(survey, start_date)
+      end_date = ~D[2016-02-01]
+      schedule = set_start_date(survey.schedule, start_date)
+      |> set_end_date(end_date)
+      survey = set_schedule(survey, schedule)
 
       {result, data} = SurveyAction.repeat(survey)
       assert result == :ok
       assert survey.schedule
       assert survey.schedule.start_date == start_date
+      assert survey.schedule.end_date == end_date
       new_occurrence = Map.get(data, :survey)
       assert new_occurrence
       assert new_occurrence.schedule
       refute new_occurrence.schedule.start_date
+      refute new_occurrence.schedule.end_date
     end
 
     test "doesn't repeat a regular survey" do
@@ -204,11 +209,17 @@ defmodule Ask.SurveyActionTest do
     }
   end
 
-  defp set_start_date(survey, start_date) do
-    schedule = Map.put(survey.schedule, :start_date, start_date)
-
+  defp set_schedule(survey, schedule) do
     Survey.changeset(survey, %{schedule: schedule})
     |> Repo.update!()
+  end
+
+  defp set_start_date(schedule, start_date) do
+    Map.put(schedule, :start_date, start_date)
+  end
+
+  defp set_end_date(schedule, end_date) do
+    Map.put(schedule, :end_date, end_date)
   end
 
   defp repeated_survey() do


### PR DESCRIPTION
We don't want to replicate `start_date` nor `end_date` on survey repetition. It doesn't make sense to do it.

This PR avoids replicating `end_date` on survey repetition using the same logic we already used to avoid replicating `start_date` on survey repetition.

Fix #1839