### PR TITLE
Fix export when choices responses

### DIFF
--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -227,4 +227,6 @@ defmodule Ask.Runtime.CleanI18n do
       Map.delete(entity_acc, lang)
     end)
   end
+
+  defp clean_base_case(entity, _langs), do: entity
 end

--- a/test/lib/runtime/questionnaire_action_test.exs
+++ b/test/lib/runtime/questionnaire_action_test.exs
@@ -20,8 +20,8 @@ defmodule Ask.Runtime.QuestionnaireExportTest do
     end
   end
 
-  describe "CleanI18n" do
-    test "base case" do
+  describe "CleanI18n.clean/3" do
+    test "cleans a base case" do
       entity = %{"en" => "foo", "es" => "bar"}
 
       clean = CleanI18n.clean(entity, ["en"], "")
@@ -29,7 +29,7 @@ defmodule Ask.Runtime.QuestionnaireExportTest do
       assert clean == %{"en" => "foo"}
     end
 
-    test "clean every map element" do
+    test "cleans every map element" do
       entity = %{"bar" => %{"en" => "foo", "es" => "bar"}}
 
       clean = CleanI18n.clean(entity, ["en"], ".[]")
@@ -37,7 +37,7 @@ defmodule Ask.Runtime.QuestionnaireExportTest do
       assert clean == %{"bar" => %{"en" => "foo"}}
     end
 
-    test "clean every list element" do
+    test "cleans every list element" do
       entity = [%{"en" => "foo", "es" => "bar"}]
 
       clean = CleanI18n.clean(entity, ["en"], ".[]")
@@ -45,12 +45,45 @@ defmodule Ask.Runtime.QuestionnaireExportTest do
       assert clean == [%{"en" => "foo"}]
     end
 
-    test "clean the requested key of a map" do
+    test "cleans the requested key of a map" do
       entity = %{"a" => %{"en" => "foo", "es" => "bar"}, "b" => %{"en" => "foo", "es" => "bar"}}
 
       clean = CleanI18n.clean(entity, ["en"], ".a")
 
       assert clean == %{"a" => %{"en" => "foo"}, "b" => %{"en" => "foo", "es" => "bar"}}
+    end
+
+    test "doesn't crash when the content of the requested key isn't a map" do
+      # A real case that was making it crash:
+      # entity = [
+      #   %{
+      #     "choices" => [
+      #       %{
+      #         "responses" => %{"ivr" => [], "mobileweb" => %{"en" => ""}, "sms" => %{"en" => []}},
+      #         "skip_logic" => nil,
+      #         "value" => ""
+      #       }
+      #     ],
+      #     "id" => "caad462b-afa4-4c9c-839d-c9e3e7ee4dc1",
+      #     "prompt" => %{
+      #       "en" => %{
+      #         "ivr" => %{"audio_source" => "tts", "text" => ""},
+      #         "mobileweb" => "",
+      #         "sms" => ""
+      #       }
+      #     },
+      #     "store" => "",
+      #     "title" => "",
+      #     "type" => "multiple-choice"
+      #   }
+      # ]
+      # clean = CleanI18n.clean(entity, ["en"], ".[].choices.[].responses.[]")
+
+      entity = %{"foo" => "bar"}
+
+      clean = CleanI18n.clean(entity, ["baz"], ".foo")
+
+      assert clean == %{"foo" => "bar"}
     end
   end
 end

--- a/test/lib/runtime/questionnaire_action_test.exs
+++ b/test/lib/runtime/questionnaire_action_test.exs
@@ -54,36 +54,37 @@ defmodule Ask.Runtime.QuestionnaireExportTest do
     end
 
     test "doesn't crash when the content of the requested key isn't a map" do
-      # A real case that was making it crash:
-      # entity = [
-      #   %{
-      #     "choices" => [
-      #       %{
-      #         "responses" => %{"ivr" => [], "mobileweb" => %{"en" => ""}, "sms" => %{"en" => []}},
-      #         "skip_logic" => nil,
-      #         "value" => ""
-      #       }
-      #     ],
-      #     "id" => "caad462b-afa4-4c9c-839d-c9e3e7ee4dc1",
-      #     "prompt" => %{
-      #       "en" => %{
-      #         "ivr" => %{"audio_source" => "tts", "text" => ""},
-      #         "mobileweb" => "",
-      #         "sms" => ""
-      #       }
-      #     },
-      #     "store" => "",
-      #     "title" => "",
-      #     "type" => "multiple-choice"
-      #   }
-      # ]
-      # clean = CleanI18n.clean(entity, ["en"], ".[].choices.[].responses.[]")
-
       entity = %{"foo" => "bar"}
 
       clean = CleanI18n.clean(entity, ["baz"], ".foo")
 
       assert clean == %{"foo" => "bar"}
+    end
+
+    test "cleans choices (when the content of one of the requested keys isn't a map)" do
+      # A real case cut that was making it crash.
+      # What was making it crash: `"ivr" => []`. Because [] isn't a map.
+      entity = [
+        %{
+          "choices" => [
+            %{
+              "responses" => %{"ivr" => [], "mobileweb" => %{"en" => "foo", "es" => "bar"}}
+            }
+          ]
+        }
+      ]
+
+      clean = CleanI18n.clean(entity, ["en"], ".[].choices.[].responses.[]")
+
+      assert clean == [
+               %{
+                 "choices" => [
+                   %{
+                     "responses" => %{"ivr" => [], "mobileweb" => %{"en" => "foo"}}
+                   }
+                 ]
+               }
+             ]
     end
   end
 end


### PR DESCRIPTION
Under certain conditions, it crashes.

Because of a bug in the clean algorithm when the content of the requested key isn't a map.

Fix #1868