### PR TITLE
Fix the language selection step export

### DIFF
--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -204,6 +204,10 @@ defmodule Ask.Runtime.CleanI18n do
     forward_path = fn positions -> String.slice(path, positions..-1) end
 
     cond do
+      path == ".prompt" and language_selection_step?(entity) ->
+        # Don't clean the language selection step
+        entity
+
       # Base case
       path == "" ->
         clean_base_case(entity, filter_languages)
@@ -224,6 +228,9 @@ defmodule Ask.Runtime.CleanI18n do
         {:error, "Invalid path"}
     end
   end
+
+  defp language_selection_step?(%{"type" => "language-selection"} = _entity), do: true
+  defp language_selection_step?(_entity), do: false
 
   defp clean_key(entity, langs, path, forward_path) do
     key = String.split(path, ".") |> Enum.at(1)

--- a/test/lib/runtime/questionnaire_action_test.exs
+++ b/test/lib/runtime/questionnaire_action_test.exs
@@ -64,6 +64,25 @@ defmodule Ask.Runtime.QuestionnaireExportTest do
                build_expected_export(quiz, [@ivr_audio_id])
     end
 
+    test "IVR - exports a questionnaire with language selection step" do
+      quiz =
+        build_quiz(
+          @ivr_empty_quiz,
+          name: @quiz_title,
+          settings: @ivr_simple_quiz_settings,
+          steps: [
+            @ivr_language_selection_step
+          ]
+        )
+
+      export_result = modelize_quiz(quiz) |> QuestionnaireExport.export()
+
+      assert export_result ==
+               build_expected_export(quiz, [@ivr_audio_id])
+    end
+
+
+
     test "Mobile Web - exports a simple questionnaire" do
       quiz =
         build_quiz(
@@ -189,6 +208,17 @@ defmodule Ask.Runtime.QuestionnaireExportTest do
       clean = CleanI18n.clean(entity, ["baz"], ".foo")
 
       assert clean == %{"foo" => "bar"}
+    end
+
+    test "doesn't clean the language selection prompt" do
+      step = %{
+        "type" => "language-selection",
+        "prompt" => %{"foo" => "bar"}
+      }
+
+      clean = CleanI18n.clean(step, ["baz"], ".prompt")
+
+      assert clean == step
     end
 
     test "cleans choices (when the content of one of the requested keys isn't a map)" do

--- a/test/support/dummy_questionnaires.ex
+++ b/test/support/dummy_questionnaires.ex
@@ -267,6 +267,21 @@ defmodule Ask.DummyQuestionnaires do
                                      choices: []
                                    )
 
+      @ivr_language_selection_step %{
+        "type" => "language-selection",
+        "title" => "Language selection",
+        "store" => "language",
+        "prompt" => %{
+          "sms" => "",
+          "mobileweb" => "",
+          "ivr" => %{
+            "text" => "foo",
+            "audio_source" => "upload",
+            "audio_id" => @ivr_audio_id
+          }
+        }
+      }
+
       @ivr_simple_choice_step build_step(
                                 @simple_choice_step,
                                 prompt: @ivr_question_prompt,


### PR DESCRIPTION
The language selection step isn't being exported properly since #1832.

Avoid cleaning the language selection step prompt.
Because it's a singular step, treat it differently.

Fix #1894