### PR TITLE
Avoid future behaviour misunderstanding

### DIFF
--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -36,12 +36,9 @@ defmodule Ask.Runtime.PanelSurvey do
       incentives_enabled: survey.incentives_enabled
     }
 
-    questionnaire_ids = Enum.map(survey.questionnaires, fn q -> q.id end)
-
     survey.project
     |> Ecto.build_assoc(:surveys)
     |> Survey.changeset(new_ocurrence)
-    |> Survey.update_questionnaires(questionnaire_ids)
   end
 
   def copy_respondents(current_occurrence, new_occurrence) do


### PR DESCRIPTION
Below I'll try to explain why IMHO the lines this commit removes can only lead to misunderstandings and the reasons to remove them.

In previous iterations of the panel survey development, the new wave took its questionnaires from the latest wave of its panel survey.

But currently, the end-user selects the questionnaire/s after the new wave is created.

Because of them, the new wave could wrongly appear (to future Devs or maintainers) to be associated with a questionnaire.

But that appearance is just that because the UI doesn't show the `wave -> questionnaires` created association/s to the end-user. Conversely, it forces them to select a new questionnaire before launching the new wave.