### PR TITLE
Cleanup expired Let's Encrypt CA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM elixir:1.5.3
 
+# Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-client inotify-tools sox libsox-fmt-mp3 && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,8 @@
 FROM elixir:1.5.3
 
+# Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-client inotify-tools sox libsox-fmt-mp3 vim && \

--- a/Dockerfile.webpack
+++ b/Dockerfile.webpack
@@ -1,5 +1,8 @@
 FROM node:10.15.3
 
+# Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y libelf1 && \


### PR DESCRIPTION
Let's Encrypt old Certificate Authority expired on Sept 30, 2021.

Most of InSTEDD's infra uses those certificates, so this patch makes new certificates work again.