### PR TITLE
Create enums for Respondent state & disposition

### DIFF
--- a/lib/ask/ecto_types/steps.ex
+++ b/lib/ask/ecto_types/steps.ex
@@ -1,0 +1,45 @@
+defmodule Ask.Ecto.Type.Steps do
+  @moduledoc """
+  This Ecto type transforms the steps stored as JSON blob in the database to
+  the internal Elixir/Erlang representation (e.g. dispositions are atoms).
+  """
+  use Ecto.Type
+
+  def type, do: :longtext
+
+  def cast(any) do
+    {:ok, transform(any)}
+  end
+
+  def cast!(any) do
+    transform(any)
+  end
+
+  def load(string) when is_binary(string) do
+    case Poison.decode(string) do
+      {:ok, steps} -> {:ok, transform(steps)}
+      any -> any
+    end
+  end
+
+  def dump(json) do
+    Poison.encode(json)
+  end
+
+  defp transform(steps) when is_nil(steps), do: nil
+  defp transform(steps) do
+    steps |> Enum.map(fn (item) ->
+      case item["type"] do
+        "section" ->
+          %{ item | "steps" => Enum.map(item["steps"], &transform_one(&1)) }
+        _ ->
+          transform_one(item)
+      end
+    end)
+  end
+
+  defp transform_one(%{ "disposition" => disposition } = step) when is_binary(disposition) do
+    %{ step | "disposition" => String.to_existing_atom(disposition) }
+  end
+  defp transform_one(step), do: step
+end

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -69,7 +69,7 @@ defmodule Ask.Runtime.Broker do
   def configure_new_respondent(respondent, questionnaire_id, sequence_mode) do
     {primary_mode, _} = get_modes(sequence_mode)
     respondent
-    |> Respondent.changeset(%{questionnaire_id: questionnaire_id, mode: sequence_mode, disposition: "queued"})
+    |> Respondent.changeset(%{questionnaire_id: questionnaire_id, mode: sequence_mode, disposition: :queued})
     |> Repo.update!
     |> RespondentDispositionHistory.create(respondent.disposition, primary_mode)
   end

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -172,7 +172,7 @@ defmodule Ask.Runtime.Broker do
   end
 
   defp retry_respondents(now) do
-    Repo.all(from r in Respondent, select: r.id, where: r.state == "active" and r.timeout_at <= ^now, limit: ^batch_limit_per_minute())
+    Repo.all(from r in Respondent, select: r.id, where: r.state == :active and r.timeout_at <= ^now, limit: ^batch_limit_per_minute())
     |> Enum.each(fn respondent_id -> Respondent.with_lock(respondent_id, &retry_respondent(&1)) end)
   end
 
@@ -247,7 +247,7 @@ defmodule Ask.Runtime.Broker do
 
     (from r in assoc(survey, :respondents),
       select: r.id,
-      where: r.state == "pending",
+      where: r.state == :pending,
       limit: ^count)
     |> Repo.all
     |> Enum.each(fn respondent_id -> Respondent.with_lock(respondent_id, &start(survey, &1), &Repo.preload(&1, respondent_group: [respondent_group_channels: :channel])) end)

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -115,9 +115,9 @@ defmodule Ask.Runtime.Broker do
     try do
       by_state = Ask.RespondentStats.respondents_by_state(survey)
       %{
-        "active" => active,
-        "pending" => pending,
-        "completed" => completed,
+        active: active,
+        pending: pending,
+        completed: completed,
       } = by_state
 
       reached_quotas = reached_quotas?(survey)

--- a/lib/ask/runtime/nuntium_channel.ex
+++ b/lib/ask/runtime/nuntium_channel.ex
@@ -76,7 +76,7 @@ defmodule Ask.Runtime.NuntiumChannel do
 
     respondent_id = Repo.one(from r in Respondent,
       select: r.id,
-      where: r.sanitized_phone_number == ^phone_number and r.state == "active",
+      where: r.sanitized_phone_number == ^phone_number and r.state == :active,
       order_by: [desc: r.updated_at],
       limit: 1)
 

--- a/lib/ask/runtime/panel_survey.ex
+++ b/lib/ask/runtime/panel_survey.ex
@@ -54,8 +54,8 @@ defmodule Ask.Runtime.PanelSurvey do
         phone_numbers =
           from(r in Respondent,
             where:
-              r.respondent_group_id == ^respondent_group.id and r.disposition != "refused" and
-                r.disposition != "ineligible",
+              r.respondent_group_id == ^respondent_group.id and r.disposition != :refused and
+                r.disposition != :ineligible,
             select: r.phone_number
           )
           |> Repo.all()

--- a/lib/ask/runtime/questionnaire_simulator.ex
+++ b/lib/ask/runtime/questionnaire_simulator.ex
@@ -163,7 +163,7 @@ defmodule Ask.Runtime.QuestionnaireSimulator do
       survey: survey,
       questionnaire_id: questionnaire.id,
       mode: [mode],
-      disposition: "queued",
+      disposition: :queued,
       phone_number: "",
       canonical_phone_number: "",
       sanitized_phone_number: "",

--- a/lib/ask/runtime/respondent_group_action.ex
+++ b/lib/ask/runtime/respondent_group_action.ex
@@ -166,7 +166,7 @@ defmodule Ask.Runtime.RespondentGroupAction do
         respondent_group_id: respondent_group.id,
         hashed_number:
           Respondent.hash_phone_number(phone_number, respondent_group.survey.project.salt),
-        disposition: "registered",
+        disposition: :registered,
         stats: %Stats{},
         user_stopped: false,
         inserted_at: DateTime.utc_now() |> DateTime.truncate(:second),

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -136,9 +136,9 @@ defmodule Ask.Runtime.Session do
         # the user asked for stopping receiving messages
         session
       response == Flow.Message.answer ->
-        update_respondent_disposition(session, "contacted", current_mode, persist)
+        update_respondent_disposition(session, :contacted, current_mode, persist)
       true ->
-        update_respondent_disposition(session, "started", current_mode, persist)
+        update_respondent_disposition(session, :started, current_mode, persist)
     end
     respondent = session.respondent
     step_answer = Flow.step(session.flow, current_mode |> SessionMode.visitor, response, SessionMode.mode(current_mode), respondent.disposition)
@@ -177,7 +177,7 @@ defmodule Ask.Runtime.Session do
 
   def log_disposition_changed(respondent, channel, mode, previous_disposition, new_disposition, persist \\ true) do
     if persist do
-      SurveyLogger.log(respondent.survey_id, mode, respondent.id, respondent.hashed_number, channel.id, previous_disposition, "disposition changed", String.capitalize(new_disposition))
+      SurveyLogger.log(respondent.survey_id, mode, respondent.id, respondent.hashed_number, channel.id, previous_disposition, "disposition changed", new_disposition |> to_string() |> String.capitalize())
     end
   end
 
@@ -241,7 +241,7 @@ defmodule Ask.Runtime.Session do
 
   def delivery_confirm(session, title, current_mode, persist) do
     if persist, do: log_confirmation(title, session.respondent.disposition, current_mode.channel, session.flow.mode, session.respondent)
-    update_respondent_disposition(session, "contacted", current_mode, persist)
+    update_respondent_disposition(session, :contacted, current_mode, persist)
   end
 
   def cancel(session) do
@@ -392,11 +392,11 @@ defmodule Ask.Runtime.Session do
   # If the respondent has answered at least `min_relevant_steps` relevant steps
   # and the reply doesn't defines already a disposition
   # then, 'interim partial' disposition is returned in reply
-  defp relevant_interim_partial_step({:ok, flow, %{disposition: nil} = reply} = step_answer, %{disposition: "started"} = respondent, persist) do
+  defp relevant_interim_partial_step({:ok, flow, %{disposition: nil} = reply} = step_answer, %{disposition: :started} = respondent, persist) do
     new_step_answer = if Flow.interim_partial_by_relevant_steps?(flow) do # Filtered here to avoid fetching the responses unnecessarily
       valid_relevant_responses = all_responses(respondent, reply, persist) |> Enum.count(&Flow.relevant_response?(flow, &1))
       if valid_relevant_responses >= Flow.min_relevant_steps(flow) do
-        {:ok, flow, %{reply | disposition: "interim partial"}}
+        {:ok, flow, %{reply | disposition: :"interim partial"}}
       end
     end
 
@@ -583,7 +583,7 @@ defmodule Ask.Runtime.Session do
            session.count_partial_results
          ) do
       true ->
-        session = update_respondent_disposition(session, "rejected", current_mode)
+        session = update_respondent_disposition(session, :rejected, current_mode)
 
         if flow.questionnaire.quota_completed_steps && length(flow.questionnaire.quota_completed_steps) > 0 do
           flow = %{flow | current_step: nil, in_quota_completed_steps: true}

--- a/lib/ask/runtime/survey.ex
+++ b/lib/ask/runtime/survey.ex
@@ -92,7 +92,7 @@ defmodule Ask.Runtime.Survey do
 
     new_disposition = old_disposition
                       |> Flow.resulting_disposition(reply_disposition)
-                      |> Flow.resulting_disposition("completed")
+                      |> Flow.resulting_disposition(:completed)
 
     updated_respondent = respondent_updates(:end, respondent, new_disposition, persist)
                          |> disposition_changed(session, old_disposition, persist)

--- a/lib/ask/runtime/survey_logger.ex
+++ b/lib/ask/runtime/survey_logger.ex
@@ -34,7 +34,7 @@ defmodule Ask.Runtime.SurveyLogger do
       respondent_id: respondent_id,
       respondent_hashed_number: respondent_hash,
       channel_id: channel_id,
-      disposition: disposition,
+      disposition: to_string(disposition),
       action_type: action_type,
       action_data: action_data,
       timestamp: DateTime.truncate(timestamp, :second)

--- a/priv/repo/migrations/20170412201505_migrate_session_to_current_mode.exs
+++ b/priv/repo/migrations/20170412201505_migrate_session_to_current_mode.exs
@@ -137,7 +137,7 @@ defmodule Ask.Repo.Migrations.MigrateSessionToCurrentMode do
   end
 
   defp change_respondents(change_function) do
-    Repo.all(from r in Respondent, where: r.state == "active") |> Enum.each(fn respondent ->
+    Repo.all(from r in Respondent, where: r.state == :active) |> Enum.each(fn respondent ->
       respondent
       |> Respondent.changeset(%{
           session: change_function.(respondent.session)

--- a/priv/repo/migrations/20200408144038_remove_respondent_stalled_state.exs
+++ b/priv/repo/migrations/20200408144038_remove_respondent_stalled_state.exs
@@ -44,7 +44,7 @@ defmodule Ask.Repo.Migrations.RemoveRespondentStalledState do
   end
 
   def up do
-    Repo.all(from r in Respondent, where: r.state == "stalled")
+    Repo.all(from r in Respondent, where: r.state == :stalled)
     |> Enum.each(fn respondent -> Respondent.update_stalled_to_failed(respondent) end)
   end
 

--- a/test/controllers/mobile_survey_controller_test.exs
+++ b/test/controllers/mobile_survey_controller_test.exs
@@ -151,7 +151,7 @@ defmodule Ask.MobileSurveyControllerTest do
 
     # Check before flag step
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "started"
+    assert respondent.disposition == :started
 
     conn = post conn, mobile_survey_path(conn, :send_reply, respondent.id, %{token: token, value: "Yes", step_id: "s2"})
     json = json_response(conn, 200)
@@ -165,7 +165,7 @@ defmodule Ask.MobileSurveyControllerTest do
 
     # Check after flag step
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "interim partial"
+    assert respondent.disposition == :"interim partial"
 
     conn = post conn, mobile_survey_path(conn, :send_reply, respondent.id, %{token: token, value: "Yes", step_id: "s4"})
     json = json_response(conn, 200)
@@ -342,7 +342,7 @@ defmodule Ask.MobileSurveyControllerTest do
     post conn, mobile_survey_path(conn, :send_reply, respondent.id, %{token: token, value: "", step_id: "s1"})
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "refused"
+    assert respondent.disposition == :refused
 
     :ok = broker |> GenServer.stop
   end

--- a/test/controllers/mobile_survey_controller_test.exs
+++ b/test/controllers/mobile_survey_controller_test.exs
@@ -69,7 +69,7 @@ defmodule Ask.MobileSurveyControllerTest do
     assert survey.state == "running"
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     # mobile_survey_send_reply_path
 
     # Check that get_step without token gives error
@@ -211,7 +211,7 @@ defmodule Ask.MobileSurveyControllerTest do
     interval = Interval.new(from: Timex.shift(now, seconds: -5), until: Timex.shift(now, seconds: 5), step: [seconds: 1])
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "completed"
+    assert respondent.state == :completed
     assert respondent.session == nil
     assert respondent.completed_at in interval
 
@@ -325,7 +325,7 @@ defmodule Ask.MobileSurveyControllerTest do
     assert survey.state == "running"
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     # mobile_survey_send_reply_path
 
     conn = get conn, mobile_survey_path(conn, :get_step, respondent.id, %{token: token})

--- a/test/controllers/oauth_client_controller_test.exs
+++ b/test/controllers/oauth_client_controller_test.exs
@@ -112,7 +112,7 @@ defmodule Ask.OAuthClientControllerTest do
     assert survey.exit_message == "Channel '#{channel.name}' no longer exists"
 
     respondent = Repo.get!(Ask.Respondent, respondent.id)
-    assert respondent.state == "cancelled"
+    assert respondent.state == :cancelled
 
     refute Ask.Channel |> Repo.get(channel.id)
   end

--- a/test/controllers/respondent_group_controller_test.exs
+++ b/test/controllers/respondent_group_controller_test.exs
@@ -68,7 +68,7 @@ defmodule Ask.RespondentGroupControllerTest do
 
       assert length(respondents) == 14
 
-      assert hd(respondents).disposition == "registered"
+      assert hd(respondents).disposition == :registered
 
       assert group
       assert group.name == "phone_numbers.csv"
@@ -350,7 +350,7 @@ defmodule Ask.RespondentGroupControllerTest do
       entries = File.stream!("test/fixtures/respondent_phone_numbers.csv") |>
       CSV.decode(separator: ?\t) |>
       Enum.map(fn row ->
-        %{phone_number: Enum.at(row, 0), survey_id: survey.id, respondent_group_id: group.id, inserted_at: local_time, updated_at: local_time, disposition: "registered", stats: %Stats{}, user_stopped: false}
+        %{phone_number: Enum.at(row, 0), survey_id: survey.id, respondent_group_id: group.id, inserted_at: local_time, updated_at: local_time, disposition: :registered, stats: %Stats{}, user_stopped: false}
       end)
 
       {respondents_count, _ } = Repo.insert_all(Respondent, entries)
@@ -377,7 +377,7 @@ defmodule Ask.RespondentGroupControllerTest do
       entries = File.stream!("test/fixtures/respondent_phone_numbers.csv") |>
       CSV.decode(separator: ?\t) |>
       Enum.map(fn row ->
-        %{phone_number: Enum.at(row, 0), survey_id: survey.id, respondent_group_id: group.id, inserted_at: local_time, updated_at: local_time, disposition: "registered", stats: %Stats{}, user_stopped: false}
+        %{phone_number: Enum.at(row, 0), survey_id: survey.id, respondent_group_id: group.id, inserted_at: local_time, updated_at: local_time, disposition: :registered, stats: %Stats{}, user_stopped: false}
       end)
 
       {respondents_count, _ } = Repo.insert_all(Respondent, entries)

--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -1958,7 +1958,7 @@ defmodule Ask.SurveyControllerTest do
       assert json_response(conn, 200)
       survey = Repo.get(Survey, survey.id)
       assert Survey.cancelled?(survey)
-      assert length(Repo.all(from(r in Ask.Respondent, where: (r.state == "cancelled" and is_nil(r.session) and is_nil(r.timeout_at))))) == 4
+      assert length(Repo.all(from(r in Ask.Respondent, where: (r.state == :cancelled and is_nil(r.session) and is_nil(r.timeout_at))))) == 4
       assert_receive [:cancel_message, ^test_channel, ^channel_state]
 
     end
@@ -1991,7 +1991,7 @@ defmodule Ask.SurveyControllerTest do
 
       assert json_response(conn, 200)
       assert Repo.get(Survey, survey2.id).state == "running"
-      assert length(Repo.all(from(r in Ask.Respondent, where: r.state == "active"))) == 6
+      assert length(Repo.all(from(r in Ask.Respondent, where: r.state == :active))) == 6
       assert_receive [:cancel_message, ^test_channel, ^channel_state]
     end
 

--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -597,7 +597,7 @@ defmodule Ask.SurveyControllerTest do
 
     test "additional respondents equals needed to complete - respondents in non final dispositions", %{conn: conn, user: user} do
       non_final_dispositions = Respondent.metrics_non_final_dispositions()
-      respondents = [%{disposition: "completed"}] ++ Enum.map(non_final_dispositions, fn disposition -> %{disposition: disposition} end)
+      respondents = [%{disposition: :completed}] ++ Enum.map(non_final_dispositions, fn disposition -> %{disposition: disposition} end)
       %{"needed_to_complete" => 100, "additional_respondents" => additional_respondents} = testing_survey(%{user: user, respondents: respondents, attrs: %{cutoff: 101}})
         |> get_stats(conn)
       assert additional_respondents == 100 - Enum.count(non_final_dispositions)

--- a/test/lib/runtime/broker_test.exs
+++ b/test/lib/runtime/broker_test.exs
@@ -838,7 +838,7 @@ defmodule Ask.Runtime.BrokerTest do
       assert survey.state == "running"
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :active
-      assert respondent.disposition == "queued"
+      assert respondent.disposition == :queued
 
       now = Timex.now
 
@@ -849,7 +849,7 @@ defmodule Ask.Runtime.BrokerTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :failed
-      assert respondent.disposition == "failed"
+      assert respondent.disposition == :failed
 
       last_entry = ((respondent |> Repo.preload(:survey_log_entries)).survey_log_entries |> Enum.at(-1))
       assert last_entry.survey_id == survey.id
@@ -872,12 +872,12 @@ defmodule Ask.Runtime.BrokerTest do
       assert survey.state == "running"
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :active
-      assert respondent.disposition == "queued"
+      assert respondent.disposition == :queued
 
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you smoke?")
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "contacted"
+      assert respondent.disposition == :contacted
 
       now = Timex.now
 
@@ -887,7 +887,7 @@ defmodule Ask.Runtime.BrokerTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :failed
-      assert respondent.disposition == "unresponsive"
+      assert respondent.disposition == :unresponsive
 
       last_entry = ((respondent |> Repo.preload(:survey_log_entries)).survey_log_entries |> Enum.at(-1))
       assert last_entry.survey_id == survey.id
@@ -910,20 +910,20 @@ defmodule Ask.Runtime.BrokerTest do
       assert survey.state == "running"
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :active
-      assert respondent.disposition == "queued"
+      assert respondent.disposition == :queued
 
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you smoke?")
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :active
-      assert respondent.disposition == "contacted"
+      assert respondent.disposition == :contacted
 
       respondent = Repo.get(Respondent, respondent.id)
       Ask.Runtime.Survey.sync_step(respondent, Flow.Message.reply("yes"))
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :active
-      assert respondent.disposition == "started"
+      assert respondent.disposition == :started
 
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you exercise?")
 
@@ -935,7 +935,7 @@ defmodule Ask.Runtime.BrokerTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :failed
-      assert respondent.disposition == "breakoff"
+      assert respondent.disposition == :breakoff
 
       last_entry = ((respondent |> Repo.preload(:survey_log_entries)).survey_log_entries) |> Enum.at(-1)
       assert last_entry.survey_id == survey.id
@@ -953,20 +953,20 @@ defmodule Ask.Runtime.BrokerTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :active
-      assert respondent.disposition == "queued"
+      assert respondent.disposition == :queued
 
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you smoke?")
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :active
-      assert respondent.disposition == "contacted"
+      assert respondent.disposition == :contacted
 
       respondent = Repo.get(Respondent, respondent.id)
       Ask.Runtime.Survey.sync_step(respondent, Flow.Message.reply("Yes"))
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :active
-      assert respondent.disposition == "interim partial"
+      assert respondent.disposition == :"interim partial"
 
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you exercise?")
 
@@ -978,7 +978,7 @@ defmodule Ask.Runtime.BrokerTest do
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :failed
-      assert respondent.disposition == "partial"
+      assert respondent.disposition == :partial
 
       last_entry = ((respondent |> Repo.preload(:survey_log_entries)).survey_log_entries |> Enum.at(-1))
       assert last_entry.survey_id == survey.id
@@ -996,7 +996,7 @@ defmodule Ask.Runtime.BrokerTest do
       Broker.handle_info(:poll, nil)
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
     end
 
     test "set the respondent as complete (disposition) if disposition is interim partial" do
@@ -1005,7 +1005,7 @@ defmodule Ask.Runtime.BrokerTest do
       Broker.handle_info(:poll, nil)
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
     end
 
     test "set the respondent from registered to queued" do
@@ -1016,7 +1016,7 @@ defmodule Ask.Runtime.BrokerTest do
       survey = Repo.get(Ask.Survey, survey.id)
       assert survey.state == "running"
       updated_respondent = Repo.get(Respondent, respondent.id)
-      assert updated_respondent.disposition == "queued"
+      assert updated_respondent.disposition == :queued
     end
 
     test "don't set the respondent as completed (disposition) if disposition is ineligible" do
@@ -1025,7 +1025,7 @@ defmodule Ask.Runtime.BrokerTest do
       Broker.handle_info(:poll, nil)
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "ineligible"
+      assert respondent.disposition == :ineligible
     end
 
     test "don't set the respondent as completed (disposition) if disposition is refused" do
@@ -1034,7 +1034,7 @@ defmodule Ask.Runtime.BrokerTest do
       Broker.handle_info(:poll, nil)
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "refused"
+      assert respondent.disposition == :refused
     end
 
     test "don't set the respondent as partial (disposition) if disposition is ineligible" do
@@ -1043,7 +1043,7 @@ defmodule Ask.Runtime.BrokerTest do
       Broker.handle_info(:poll, nil)
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "ineligible"
+      assert respondent.disposition == :ineligible
     end
 
     test "don't set the respondent as partial (disposition) if disposition is refused" do
@@ -1052,7 +1052,7 @@ defmodule Ask.Runtime.BrokerTest do
       Broker.handle_info(:poll, nil)
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "refused"
+      assert respondent.disposition == :refused
     end
 
     test "don't set the respondent as ineligible (disposition) if disposition is completed" do
@@ -1061,7 +1061,7 @@ defmodule Ask.Runtime.BrokerTest do
       Broker.handle_info(:poll, nil)
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
     end
   end
 
@@ -1223,7 +1223,7 @@ defmodule Ask.Runtime.BrokerTest do
     Broker.handle_info(:poll, nil)
     assert_respondents_by_state(survey, 1, 10)
 
-    mark_n_active_respondents_as("completed", 1)
+    mark_n_active_respondents_as(:completed, 1)
 
     Broker.handle_info(:poll, nil)
     assert_respondents_by_state(survey, 1, 9)
@@ -1238,14 +1238,14 @@ defmodule Ask.Runtime.BrokerTest do
     Broker.handle_info(:poll, nil)
     assert_respondents_by_state(survey, 50, 151)
 
-    mark_n_active_respondents_as("failed", 20)
-    mark_n_active_respondents_as("completed", 30)
+    mark_n_active_respondents_as(:failed, 20)
+    mark_n_active_respondents_as(:completed, 30)
     Broker.handle_info(:poll, nil)
     assert_respondents_by_state(survey, 20, 131)
 
     # since all the previous ones failed the success rate decreases
     # and the batch size increases
-    mark_n_active_respondents_as("failed", 26)
+    mark_n_active_respondents_as(:failed, 26)
     Broker.handle_info(:poll, nil)
     assert_respondents_by_state(survey, 20, 111)
   end
@@ -1256,7 +1256,7 @@ defmodule Ask.Runtime.BrokerTest do
     Broker.poll
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "queued"
+    assert respondent.disposition == :queued
 
     # Set for immediate timeout
     Respondent.changeset(respondent, %{timeout_at: Timex.now |> Timex.shift(minutes: -1)}) |> Repo.update
@@ -1264,7 +1264,7 @@ defmodule Ask.Runtime.BrokerTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :failed
-    assert respondent.disposition == "failed"
+    assert respondent.disposition == :failed
 
     :ok = broker |> GenServer.stop
   end

--- a/test/lib/runtime/flow_test.exs
+++ b/test/lib/runtime/flow_test.exs
@@ -1287,7 +1287,7 @@ defmodule Ask.FlowTest do
       |> test_step(mode)
 
   defp test_step(flow, mode), do:
-    Flow.step(flow, test_visitor(mode), :answer, "contacted")
+    Flow.step(flow, test_visitor(mode), :answer, :contacted)
 
   defp test_reply(flow, mode, nil), do:
     Flow.step(flow, test_visitor(mode), Flow.Message.no_reply, :contacted)

--- a/test/lib/runtime/flow_test.exs
+++ b/test/lib/runtime/flow_test.exs
@@ -247,7 +247,7 @@ defmodule Ask.FlowTest do
     disposition = Reply.disposition(reply)
 
     assert prompts == []
-    assert disposition == "refused"
+    assert disposition == :refused
   end
 
   test "retry step (sms mode)" do
@@ -1192,7 +1192,7 @@ defmodule Ask.FlowTest do
 
   describe "flag steps" do
     test "flag steps and send prompts" do
-      quiz = build(:questionnaire, steps: @flag_steps)
+      quiz = build(:questionnaire, steps: Ask.Ecto.Type.Steps.cast!(@flag_steps))
       flow = Flow.start(quiz, "sms")
       flow_state = flow |> test_step("sms")
 
@@ -1201,16 +1201,16 @@ defmodule Ask.FlowTest do
       disposition = Reply.disposition(reply)
 
       assert prompts == ["Do you exercise? Reply 1 for YES, 2 for NO"]
-      assert disposition == "interim partial"
+      assert disposition == :"interim partial"
       assert flow.current_step == 1
     end
 
     test "ending keeps the last flag" do
-      quiz = build(:questionnaire, steps: @partial_step)
+      quiz = build(:questionnaire, steps: Ask.Ecto.Type.Steps.cast!(@partial_step))
       flow = Flow.start(quiz, "sms")
       flow_state = flow |> test_step("sms")
       assert {:end, _, reply} = flow_state
-      assert Reply.disposition(reply) == "interim partial"
+      assert Reply.disposition(reply) == :"interim partial"
     end
 
     test "two consecutive flag steps: ineligible, completed" do
@@ -1230,12 +1230,12 @@ defmodule Ask.FlowTest do
         flag_step(
           id: "bbb",
           title: "b",
-          disposition: "ineligible"
+          disposition: :ineligible
         ),
         flag_step(
           id: "ccc",
           title: "c",
-          disposition: "completed"
+          disposition: :completed
         ),
       ]
 
@@ -1244,7 +1244,7 @@ defmodule Ask.FlowTest do
         |> Flow.start("sms")
         |> test_step("sms")
       assert {:end, _, reply} = flow |> reply_sms("1")
-      assert Reply.disposition(reply) == "ineligible"
+      assert Reply.disposition(reply) == :ineligible
     end
 
     test "two consecutive flag steps: refused, completed" do
@@ -1264,12 +1264,12 @@ defmodule Ask.FlowTest do
         flag_step(
           id: "bbb",
           title: "b",
-          disposition: "refused"
+          disposition: :refused
         ),
         flag_step(
           id: "ccc",
           title: "c",
-          disposition: "completed"
+          disposition: :completed
         ),
       ]
 
@@ -1278,7 +1278,7 @@ defmodule Ask.FlowTest do
         |> Flow.start("sms")
         |> test_step("sms")
       assert {:end, _, reply} = flow |> reply_sms("1")
-      assert Reply.disposition(reply) == "refused"
+      assert Reply.disposition(reply) == :refused
     end
   end
 
@@ -1287,10 +1287,10 @@ defmodule Ask.FlowTest do
       |> test_step(mode)
 
   defp test_step(flow, mode), do:
-    Flow.step(flow, test_visitor(mode), :answer, "any_disposition")
+    Flow.step(flow, test_visitor(mode), :answer, "contacted")
 
   defp test_reply(flow, mode, nil), do:
-    Flow.step(flow, test_visitor(mode), Flow.Message.no_reply, "any_disposition")
+    Flow.step(flow, test_visitor(mode), Flow.Message.no_reply, :contacted)
 
   defp reply_sms(flow, reply), do: test_reply(flow, "sms", reply)
 
@@ -1304,7 +1304,7 @@ defmodule Ask.FlowTest do
 
   defp reply_ivr(flow, reply), do: test_reply(flow, "ivr", reply)
 
-  defp test_reply(flow, mode, reply, old_disposition \\ "any_disposition"), do:
+  defp test_reply(flow, mode, reply, old_disposition \\ :contacted), do:
     Flow.step(flow, test_visitor(mode), Flow.Message.reply(reply), old_disposition)
 
   defp test_visitor(mode) do

--- a/test/lib/runtime/questionnaire_simulator_test.exs
+++ b/test/lib/runtime/questionnaire_simulator_test.exs
@@ -95,20 +95,20 @@ defmodule QuestionnaireSimulatorTest do
         simulation = start_contacted(start_simulation, quiz, mode)
 
         %{respondent_id: respondent_id, disposition: disposition, simulation_status: status} = simulation
-        assert "contacted" == disposition
+        assert :contacted == disposition
         on_sms_assert_last_message(simulation, "Do you smoke? Reply 1 for YES, 2 for NO", mode)
         assert Simulation.Status.active == status
 
         %{disposition: disposition} = simulation = process_respondent_response(respondent_id, "No", mode)
-        assert "started" == disposition
+        assert :started == disposition
         on_sms_assert_last_message(simulation, "Do you exercise? Reply 1 for YES, 2 for NO", mode)
 
         %{disposition: disposition} = simulation = process_respondent_response(respondent_id, "Yes", mode)
-        assert "interim partial" == disposition
+        assert :"interim partial" == disposition
         on_sms_assert_last_message(simulation, "Is this the last question?", mode)
 
         %{disposition: disposition, simulation_status: status} = simulation = process_respondent_response(respondent_id, "Yes", mode)
-        assert "completed" == disposition
+        assert :completed == disposition
         on_sms_assert_last_message(simulation, "Thanks for completing this survey", mode)
         assert Simulation.Status.ended == status
       end)
@@ -323,12 +323,12 @@ defmodule QuestionnaireSimulatorTest do
     test "if stop message on contacted disposition, then final disposition is 'refused'", %{start_simulation: start_simulation} do
       quiz = questionnaire_with_steps(@dummy_steps)
       %{respondent_id: respondent_id, disposition: starting_disposition} = start_simulation.(quiz, "sms")
-      assert "contacted" == starting_disposition
+      assert :contacted == starting_disposition
 
       %{simulation_status: status, disposition: disposition} = process_respondent_response(respondent_id, "Stop", "sms")
 
       assert Simulation.Status.ended == status
-      assert "refused" == disposition
+      assert :refused == disposition
     end
 
     test "if stop message on started disposition, then final disposition is 'breakoff'", %{start_simulation: start_simulation} do
@@ -336,12 +336,12 @@ defmodule QuestionnaireSimulatorTest do
       %{respondent_id: respondent_id} = start_simulation.(quiz, "sms")
       %{disposition: previous_disposition} = process_respondent_response(respondent_id, "No", "sms")
 
-      assert "started" == previous_disposition
+      assert :started == previous_disposition
 
       %{simulation_status: status, disposition: disposition} = process_respondent_response(respondent_id, "Stop", "sms")
 
       assert Simulation.Status.ended == status
-      assert "breakoff" == disposition
+      assert :breakoff == disposition
     end
 
     test "if stop message on interim-partial disposition, then final disposition is 'breakoff'", %{start_simulation: start_simulation} do
@@ -350,12 +350,12 @@ defmodule QuestionnaireSimulatorTest do
       process_respondent_response(respondent_id, "No", "sms")
       %{disposition: previous_disposition} = process_respondent_response(respondent_id, "Yes", "sms")
 
-      assert "interim partial" == previous_disposition
+      assert :"interim partial" == previous_disposition
 
       %{simulation_status: status, disposition: disposition} = process_respondent_response(respondent_id, "Stop", "sms")
 
       assert Simulation.Status.ended == status
-      assert "partial" == disposition
+      assert :partial == disposition
     end
   end
 
@@ -368,13 +368,13 @@ defmodule QuestionnaireSimulatorTest do
         simulation = start_contacted(start_simulation, quiz, mode)
 
         %{respondent_id: respondent_id, disposition: disposition} = simulation
-        assert "contacted" == disposition
+        assert :contacted == disposition
 
         %{disposition: disposition} = process_respondent_response(respondent_id, "No", mode)
-        assert "started" == disposition
+        assert :started == disposition
 
         %{disposition: disposition} = process_respondent_response(respondent_id, "Yes", mode)
-        assert "interim partial" == disposition
+        assert :"interim partial" == disposition
       end)
     end
 
@@ -386,19 +386,19 @@ defmodule QuestionnaireSimulatorTest do
         simulation = start_contacted(start_simulation, quiz, mode)
 
         %{respondent_id: respondent_id, disposition: disposition} = simulation
-        assert "contacted" == disposition
+        assert :contacted == disposition
 
         %{disposition: disposition} = process_respondent_response(respondent_id, "No", mode)
-        assert "started" == disposition
+        assert :started == disposition
 
         %{disposition: disposition} = process_respondent_response(respondent_id, "Yes", mode)
-        assert "interim partial" == disposition
+        assert :"interim partial" == disposition
 
         %{disposition: disposition} = process_respondent_response(respondent_id, "7", mode)
-        assert "interim partial" == disposition
+        assert :"interim partial" == disposition
 
         %{disposition: disposition, simulation_status: status} = process_respondent_response(respondent_id, "4", mode)
-        assert "completed" == disposition
+        assert :completed == disposition
         assert Simulation.Status.ended == status
       end)
     end
@@ -411,16 +411,16 @@ defmodule QuestionnaireSimulatorTest do
         simulation = start_contacted(start_simulation, quiz, mode)
 
         %{respondent_id: respondent_id, disposition: disposition} = simulation
-        assert "contacted" == disposition
+        assert :contacted == disposition
 
         %{disposition: disposition} = process_respondent_response(respondent_id, "No", mode) # First relevant
-        assert "started" == disposition
+        assert :started == disposition
 
         %{disposition: disposition} = process_respondent_response(respondent_id, "5", mode)
-        assert "started" == disposition
+        assert :started == disposition
 
         %{disposition: disposition} = process_respondent_response(respondent_id, "No", mode) # Second relevant, in different section
-        assert "interim partial" == disposition
+        assert :"interim partial" == disposition
       end)
     end
   end
@@ -489,28 +489,28 @@ defmodule QuestionnaireSimulatorTest do
 
     %{respondent_id: respondent_id, disposition: disposition, simulation_status: status, current_step: current_step} = simulation
     [first, second, third, fourth] = quiz |> Questionnaire.all_steps|> Enum.map(fn step -> step["id"] end)
-    assert "contacted" == disposition
+    assert :contacted == disposition
     on_sms_assert_last_message(simulation, "Do you smoke? Reply 1 for YES, 2 for NO", mode)
     assert current_step == first
     assert Ask.Simulation.Status.active == status
 
     %{disposition: disposition, current_step: current_step} = simulation = process_respondent_response(respondent_id, "No", mode)
-    assert "started" == disposition
+    assert :started == disposition
     on_sms_assert_last_message(simulation, "Do you exercise? Reply 1 for YES, 2 for NO", mode)
     assert current_step == second
 
     %{disposition: disposition, current_step: current_step} = simulation = process_respondent_response(respondent_id, "Yes", mode)
-    assert "started" == disposition
+    assert :started == disposition
     on_sms_assert_last_message(simulation, "Which is the second perfect number??", mode)
     assert current_step == third
 
     %{disposition: disposition, current_step: current_step} = simulation = process_respondent_response(respondent_id, "7", mode)
-    assert "started" == disposition
+    assert :started == disposition
     on_sms_assert_last_message(simulation, "What's the number of this question??", mode)
     assert current_step == fourth
 
     %{disposition: disposition, simulation_status: status, current_step: current_step} = simulation = process_respondent_response(respondent_id, "4", mode)
-    assert "completed" == disposition
+    assert :completed == disposition
     on_sms_assert_last_message(simulation, "Thanks for completing this survey", mode)
     assert current_step == nil
     assert Ask.Simulation.Status.ended == status

--- a/test/lib/runtime/session_test.exs
+++ b/test/lib/runtime/session_test.exs
@@ -696,7 +696,7 @@ defmodule Ask.SessionTest do
 
     # The session won't update the respondent, the broker will
     respondent = Respondent |> Repo.get(respondent.id)
-    assert respondent.state == "pending"
+    assert respondent.state == :pending
     assert respondent.disposition == "registered"
     assert 1 == respondent.stats |> Stats.attempts(:sms)
   end

--- a/test/lib/runtime/session_test.exs
+++ b/test/lib/runtime/session_test.exs
@@ -697,7 +697,7 @@ defmodule Ask.SessionTest do
     # The session won't update the respondent, the broker will
     respondent = Respondent |> Repo.get(respondent.id)
     assert respondent.state == :pending
-    assert respondent.disposition == "registered"
+    assert respondent.disposition == :registered
     assert 1 == respondent.stats |> Stats.attempts(:sms)
   end
 
@@ -1031,14 +1031,14 @@ defmodule Ask.SessionTest do
     quiz = insert(:questionnaire, steps: @flag_steps)
     {:ok, _, %{disposition: disposition}, _} = Session.start(quiz, respondent, channel, "sms", Schedule.always())
 
-    assert disposition == "interim partial"
+    assert disposition == :"interim partial"
   end
 
   test "flag and end", %{respondent: respondent, channel: channel} do
-    quiz = build(:questionnaire, steps: @partial_step)
+    quiz = insert(:questionnaire, steps: @partial_step)
     {:end, %{disposition: disposition}, respondent} = Session.start(quiz, respondent, channel, "sms", Schedule.always())
 
-    assert disposition == "interim partial"
+    assert disposition == :"interim partial"
     assert 1 == respondent.stats |> Stats.attempts(:sms)
   end
 
@@ -1047,8 +1047,8 @@ defmodule Ask.SessionTest do
       {:ok, survey_logger} = SurveyLogger.start_link
       quiz = insert(:questionnaire, steps: @flag_step_after_multiple_choice)
       ivr_channel = insert(:channel, settings: TestChannel.new |> TestChannel.settings, type: "ivr")
-      # respondent is updated to "queued" in order to ensure a valid disposition transition "queued" -> "interim partial"
-      respondent = respondent |> Respondent.changeset(%{disposition: "started"}) |> Repo.update!
+      # respondent is updated to "queued" in order to ensure a valid disposition transition :"queued" -> :"interim partial"
+      respondent = respondent |> Respondent.changeset(%{disposition: :started}) |> Repo.update!
       {:ok, session, _, _} = Session.start(quiz, respondent, ivr_channel, "ivr", Schedule.always())
       Session.sync_step(session, Flow.Message.reply("1"))
 
@@ -1076,9 +1076,9 @@ defmodule Ask.SessionTest do
       {:ok, survey_logger} = SurveyLogger.start_link
       quiz = insert(:questionnaire, steps: @flag_step_after_multiple_choice)
       ivr_channel = insert(:channel, settings: TestChannel.new |> TestChannel.settings, type: "ivr")
-      # respondent disposition is updated to "queued",
+      # respondent disposition is updated to :queued,
       # representing a respondent that has already been started.
-      respondent = respondent |> Respondent.changeset(%{disposition: "queued"}) |> Repo.update!
+      respondent = respondent |> Respondent.changeset(%{disposition: :queued}) |> Repo.update!
       {:ok, session, _, _} = Session.start(quiz, respondent, ivr_channel, "ivr", Schedule.always())
 
       Session.sync_step(session, Flow.Message.answer())
@@ -1110,7 +1110,7 @@ defmodule Ask.SessionTest do
       assert nil == reply.disposition
 
       {:ok, _session, reply, _timeout} = Session.sync_step(updated_session(respondent.id, session), Flow.Message.reply("Yes"))
-      assert "interim partial" == reply.disposition
+      assert :"interim partial" == reply.disposition
     end
 
     test "indicates 'interim partial' disposition if respondent answers the min_relevant_steps and the quiz has sections", %{quiz: quiz, respondent: respondent, channel: channel} do
@@ -1122,7 +1122,7 @@ defmodule Ask.SessionTest do
       assert nil == reply.disposition
 
       {:ok, _session, reply, _timeout} = Session.sync_step(updated_session(respondent.id, session), Flow.Message.reply("Yes"))
-      assert "interim partial" == reply.disposition
+      assert :"interim partial" == reply.disposition
     end
 
     test "indicates 'interim partial' disposition if respondent answers the min_relevant_steps even if are not followed",
@@ -1139,7 +1139,7 @@ defmodule Ask.SessionTest do
       assert nil == reply.disposition # second response but this is not a relevant question
 
       {:ok, _session, reply, _timeout} = Session.sync_step(updated_session(respondent.id, session), Flow.Message.reply("3"))
-      assert "interim partial" == reply.disposition # third response, but second relevant response
+      assert :"interim partial" == reply.disposition # third response, but second relevant response
     end
 
     test "indicates 'interim partial' disposition if respondent answers the min_relevant_steps even if are in different sections",
@@ -1156,7 +1156,7 @@ defmodule Ask.SessionTest do
       assert nil == reply.disposition # second response but this is not a relevant question
 
       {:ok, _session, reply, _timeout} = Session.sync_step(updated_session(respondent.id, session), Flow.Message.reply("Yes"))
-      assert "interim partial" == reply.disposition # third response, but second relevant response
+      assert :"interim partial" == reply.disposition # third response, but second relevant response
     end
 
     test "does not indicates 'interim partial' disposition if respondent answers the min_relevant_steps but one is ignored answer (numeric refusal)",
@@ -1195,10 +1195,10 @@ defmodule Ask.SessionTest do
       steps = QuestionnaireRelevantSteps.odd_relevant_steps()
       quiz = quiz |> Questionnaire.changeset(%{partial_relevant_config: %{"enabled" => true, "min_relevant_steps" => 1}, steps: steps}) |> Repo.update!
       session = start_session(respondent, quiz, channel)
-      assert "contacted" == session.respondent.disposition
+      assert :contacted == session.respondent.disposition
 
       {:ok, _session, reply, _timeout} = Session.sync_step(session, Flow.Message.reply("Yes"))
-      assert "interim partial" == reply.disposition
+      assert :"interim partial" == reply.disposition
       histories = Ask.RespondentDispositionHistory |> Repo.all |> Enum.map(fn hist -> hist.disposition end)
       assert ["queued", "contacted", "started"] == histories, "Although is never \"seen\", respondent passed through started disposition and must be logged"
     end
@@ -1215,7 +1215,7 @@ defmodule Ask.SessionTest do
       assert nil == reply.disposition # second response but this is not a relevant question
 
       {:ok, _session, reply, _timeout} = Session.sync_step(updated_session(respondent.id, session), Flow.Message.reply("#")) # refuse response
-      assert "interim partial" == reply.disposition # third response, second relevant response, but ignored value since is refusal response
+      assert :"interim partial" == reply.disposition # third response, second relevant response, but ignored value since is refusal response
     end
 
     test "if questionnaire hasn't got partial_relevant_config, no response should trigger an 'interim partial' disposition even if all steps are relevant",
@@ -1291,7 +1291,7 @@ defmodule Ask.SessionTest do
       assert nil == reply.disposition
 
       {:ok, session, reply, _timeout} = Session.sync_step(updated_session(respondent.id, session), Flow.Message.reply("Yes"))
-      assert "interim partial" == reply.disposition
+      assert :"interim partial" == reply.disposition
 
       # update respondent with new disposition
       Respondent |> Repo.get(respondent.id) |> Respondent.changeset(%{disposition: reply.disposition}) |> Repo.update!
@@ -1312,7 +1312,7 @@ defmodule Ask.SessionTest do
       assert nil == reply.disposition
 
       {:stopped, reply, _respondent} = Session.sync_step(updated_session(respondent.id, session), Flow.Message.reply("stop"))
-      assert "breakoff" == reply.disposition
+      assert :breakoff == reply.disposition
     end
 
     defp start_session(respondent, quiz, channel) do

--- a/test/lib/runtime/survey_test.exs
+++ b/test/lib/runtime/survey_test.exs
@@ -32,7 +32,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       Survey.delivery_confirm(respondent, "Do you smoke?")
 
@@ -72,7 +72,7 @@ defmodule Ask.Runtime.SurveyTest do
       interval = Interval.new(from: Timex.shift(SystemTime.time.now, seconds: -5), until: Timex.shift(SystemTime.time.now, seconds: 5), step: [seconds: 1])
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "completed"
+      assert respondent.state == :completed
       assert respondent.session == nil
       assert respondent.completed_at in interval
 
@@ -154,7 +154,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       reply = Survey.sync_step(respondent, Flow.Message.answer())
       assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
@@ -179,7 +179,7 @@ defmodule Ask.Runtime.SurveyTest do
       interval = Interval.new(from: Timex.shift(now, seconds: -5), until: Timex.shift(now, seconds: 5), step: [seconds: 1])
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "completed"
+      assert respondent.state == :completed
       assert respondent.session == nil
       assert respondent.completed_at in interval
 
@@ -274,7 +274,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       reply = Survey.sync_step(respondent, Flow.Message.answer())
       assert {:reply, ReplyHelper.simple("Let there be rock", "Welcome to the survey!"), _} = reply
@@ -309,7 +309,7 @@ defmodule Ask.Runtime.SurveyTest do
       interval = Interval.new(from: Timex.shift(now, seconds: -5), until: Timex.shift(now, seconds: 5), step: [seconds: 1])
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "completed"
+      assert respondent.state == :completed
       assert respondent.session == nil
       assert respondent.completed_at in interval
 
@@ -363,7 +363,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       Survey.delivery_confirm(respondent, "Do you smoke?")
 
@@ -392,7 +392,7 @@ defmodule Ask.Runtime.SurveyTest do
       interval = Interval.new(from: Timex.shift(now, seconds: -5), until: Timex.shift(now, seconds: 5), step: [seconds: 1])
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "completed"
+      assert respondent.state == :completed
       assert respondent.session == nil
       assert respondent.completed_at in interval
 
@@ -507,7 +507,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       Survey.delivery_confirm(respondent, "Do you smoke?")
 
@@ -536,7 +536,7 @@ defmodule Ask.Runtime.SurveyTest do
       interval = Interval.new(from: Timex.shift(now, seconds: -5), until: Timex.shift(now, seconds: 5), step: [seconds: 1])
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "completed"
+      assert respondent.state == :completed
       assert respondent.session == nil
       assert respondent.completed_at in interval
 
@@ -643,7 +643,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       reply = Survey.sync_step(respondent, Flow.Message.answer())
       assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
@@ -668,7 +668,7 @@ defmodule Ask.Runtime.SurveyTest do
       interval = Interval.new(from: Timex.shift(now, seconds: -5), until: Timex.shift(now, seconds: 5), step: [seconds: 1])
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "completed"
+      assert respondent.state == :completed
       assert respondent.session == nil
       assert respondent.completed_at in interval
 
@@ -851,7 +851,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
       reply = Survey.sync_step(respondent, Flow.Message.reply("Foo"))
       assert {:reply, ReplyHelper.error("Wrong answer", "Do you smoke?", "Do you smoke? Reply 1 for YES, 2 for NO"), _} = reply
 
@@ -990,7 +990,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       reply = Survey.sync_step(respondent, Flow.Message.answer())
       assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
@@ -1489,7 +1489,7 @@ defmodule Ask.Runtime.SurveyTest do
     Survey.delivery_confirm(respondent, "Do you smoke?")
 
     updated_respondent = Repo.get(Respondent, respondent.id)
-    assert updated_respondent.state == "active"
+    assert updated_respondent.state == :active
     assert updated_respondent.disposition == "contacted"
 
     :ok = broker |> GenServer.stop
@@ -1508,7 +1508,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
 
     updated_respondent = Repo.get(Respondent, respondent.id)
-    assert updated_respondent.state == "active"
+    assert updated_respondent.state == :active
     assert updated_respondent.disposition == "contacted"
 
     :ok = broker |> GenServer.stop
@@ -1528,13 +1528,13 @@ defmodule Ask.Runtime.SurveyTest do
     Survey.delivery_confirm(respondent, "Do you smoke?")
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "contacted"
 
     Survey.sync_step(respondent, Flow.Message.reply("Yes"))
 
     updated_respondent = Repo.get(Respondent, respondent.id)
-    assert updated_respondent.state == "active"
+    assert updated_respondent.state == :active
     assert updated_respondent.disposition == "started"
 
     :ok = broker |> GenServer.stop
@@ -1554,7 +1554,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert 1 == %{survey_id: survey.id} |> RetryStat.stats() |> RetryStat.count(%{attempt: 1, retry_time: RetryStat.retry_time(respondent.timeout_at), ivr_active: false, mode: respondent.mode})
 
     updated_respondent = Repo.get(Respondent, respondent.id)
-    assert updated_respondent.state == "active"
+    assert updated_respondent.state == :active
 
     now = Timex.now
     interval = Interval.new(from: Timex.shift(now, minutes: 1), until: Timex.shift(now, minutes: 3), step: [seconds: 1])
@@ -1574,7 +1574,7 @@ defmodule Ask.Runtime.SurveyTest do
     Survey.sync_step(respondent, Flow.Message.reply("Yes"))
 
     updated_respondent = Repo.get(Respondent, respondent.id)
-    assert updated_respondent.state == "active"
+    assert updated_respondent.state == :active
 
     {erl_date, _} = Timex.now |> Timex.shift(days: 2) |> Timex.to_erl
     time = Timex.Timezone.resolve("Etc/UTC", {erl_date, {0, 0, 0}})
@@ -1596,12 +1596,12 @@ defmodule Ask.Runtime.SurveyTest do
     assert survey.state == "running"
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
 
     Survey.delivery_confirm(respondent, "Do you exercise?")
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "interim partial"
     survey = Repo.get(Ask.Survey, survey.id)
     assert survey.state == "running"
@@ -1646,7 +1646,7 @@ defmodule Ask.Runtime.SurveyTest do
     Survey.sync_step(respondent, Flow.Message.reply("Yes"))
 
     respondent = Repo.get!(Respondent, respondent.id)
-    assert respondent.state == "completed"
+    assert respondent.state == :completed
     assert respondent.disposition == "ineligible"
 
     histories = RespondentDispositionHistory |> Repo.all
@@ -1672,7 +1672,7 @@ defmodule Ask.Runtime.SurveyTest do
     Survey.sync_step(respondent, Flow.Message.reply("Yes"))
 
     respondent = Repo.get!(Respondent, respondent.id)
-    assert respondent.state == "completed"
+    assert respondent.state == :completed
     assert respondent.disposition == "refused"
 
     histories = RespondentDispositionHistory |> Repo.all
@@ -1724,14 +1724,14 @@ defmodule Ask.Runtime.SurveyTest do
 
     test "base scenario (previous to the STOP MO message)" do
       confirm_delivery("Do you exercise?")
-      assert_respondent(%{current_state: "active", previous_disposition: "queued", current_disposition: "contacted", user_stopped: false})
+      assert_respondent(%{current_state: :active, previous_disposition: "queued", current_disposition: "contacted", user_stopped: false})
     end
 
     test "contacted -> refused" do
       confirm_delivery("Do you exercise?")
       respondent_sends_stop()
 
-      assert_respondent(%{current_state: "failed", previous_disposition: "contacted", current_disposition: "refused", user_stopped: true})
+      assert_respondent(%{current_state: :failed, previous_disposition: "contacted", current_disposition: "refused", user_stopped: true})
     end
 
     test "started -> breakoff" do
@@ -1739,7 +1739,7 @@ defmodule Ask.Runtime.SurveyTest do
       respondent_answers("Any thing")
       respondent_sends_stop()
 
-      assert_respondent(%{current_state: "failed", previous_disposition: "started", current_disposition: "breakoff", user_stopped: true})
+      assert_respondent(%{current_state: :failed, previous_disposition: "started", current_disposition: "breakoff", user_stopped: true})
     end
 
     test "queued -> refused" do
@@ -1747,7 +1747,7 @@ defmodule Ask.Runtime.SurveyTest do
       #     It's expected that a "queued" respondent isn't yet contacted.
       respondent_sends_stop()
 
-      assert_respondent(%{current_state: "failed", previous_disposition: "queued", current_disposition: "refused", user_stopped: true})
+      assert_respondent(%{current_state: :failed, previous_disposition: "queued", current_disposition: "refused", user_stopped: true})
     end
   end
 
@@ -1766,7 +1766,7 @@ defmodule Ask.Runtime.SurveyTest do
     Survey.sync_step(respondent, Flow.Message.reply("Yes"))
 
     respondent = Repo.get!(Respondent, respondent.id)
-    assert respondent.state == "completed"
+    assert respondent.state == :completed
     assert respondent.disposition == "completed"
 
     histories = RespondentDispositionHistory |> Repo.all
@@ -1788,7 +1788,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert_received [:ask, ^test_channel, ^respondent, ^token, ReplyHelper.simple("Do you exercise?", "Do you exercise? Reply 1 for YES, 2 for NO")]
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "interim partial"
     survey = Repo.get(Ask.Survey, survey.id)
     assert survey.state == "running"
@@ -1799,7 +1799,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id) |> Repo.preload(:responses)
     assert survey.state == "running"
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "interim partial"
     assert hd(respondent.responses).value == "Yes"
   end
@@ -1830,14 +1830,14 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
 
-    assert respondent.state       == "active"
+    assert respondent.state       == :active
     assert respondent.disposition == "started"
 
     Survey.sync_step(respondent, Flow.Message.no_reply)
 
     respondent = Repo.get(Respondent, respondent.id)
 
-    assert respondent.state       == "active"
+    assert respondent.state       == :active
     assert respondent.disposition == "started"
 
     now = Timex.now
@@ -1878,7 +1878,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
 
-    assert respondent.state       == "active"
+    assert respondent.state       == :active
     assert respondent.disposition == "started"
 
     now = Timex.now
@@ -1896,7 +1896,7 @@ defmodule Ask.Runtime.SurveyTest do
     Broker.poll
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "queued"
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
@@ -1907,14 +1907,14 @@ defmodule Ask.Runtime.SurveyTest do
     assert {:reply, ReplyHelper.ivr("Do you exercise", "Do you exercise? Press 1 for YES, 2 for NO"), _} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "started"
 
     Respondent.changeset(respondent, %{timeout_at: Timex.now |> Timex.shift(minutes: -1)}) |> Repo.update
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "failed"
+    assert respondent.state == :failed
     assert respondent.disposition == "breakoff"
 
     :ok = logger |> GenServer.stop
@@ -1937,7 +1937,7 @@ defmodule Ask.Runtime.SurveyTest do
     Broker.poll
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "queued"
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
@@ -1948,14 +1948,14 @@ defmodule Ask.Runtime.SurveyTest do
     assert {:reply, ReplyHelper.ivr("Do you exercise", "Do you exercise? Press 1 for YES, 2 for NO"), _} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "interim partial"
 
     Respondent.changeset(respondent, %{timeout_at: Timex.now |> Timex.shift(minutes: -1)}) |> Repo.update
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "failed"
+    assert respondent.state == :failed
     assert respondent.disposition == "partial"
 
     :ok = logger |> GenServer.stop
@@ -1976,7 +1976,7 @@ defmodule Ask.Runtime.SurveyTest do
     Broker.poll
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "queued"
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
@@ -1987,20 +1987,20 @@ defmodule Ask.Runtime.SurveyTest do
     assert {:reply, ReplyHelper.ivr("Do you exercise", "Do you exercise? Press 1 for YES, 2 for NO"), _} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "interim partial"
 
     _reply = Survey.sync_step(respondent, Flow.Message.reply("1"))
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "completed"
 
     Respondent.changeset(respondent, %{timeout_at: Timex.now |> Timex.shift(minutes: -1)}) |> Repo.update
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "failed"
+    assert respondent.state == :failed
     assert respondent.disposition == "completed"
 
     :ok = broker |> GenServer.stop
@@ -2014,21 +2014,21 @@ defmodule Ask.Runtime.SurveyTest do
     Broker.poll
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "queued"
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "contacted"
 
     Respondent.changeset(respondent, %{timeout_at: Timex.now |> Timex.shift(minutes: -1)}) |> Repo.update
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "failed"
+    assert respondent.state == :failed
     assert respondent.disposition == "unresponsive"
 
     :ok = logger |> GenServer.stop
@@ -2080,7 +2080,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "contacted"
 
     respondent
@@ -2093,7 +2093,7 @@ defmodule Ask.Runtime.SurveyTest do
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "failed"
+    assert respondent.state == :failed
     assert respondent.disposition == "partial"
 
     :ok = broker |> GenServer.stop
@@ -2134,7 +2134,7 @@ defmodule Ask.Runtime.SurveyTest do
     reply = Survey.sync_step(respondent, Flow.Message.reply("Yes"))
     assert {:end, _} = reply
     updated_respondent = Repo.get(Respondent, respondent.id)
-    assert updated_respondent.state == "rejected"
+    assert updated_respondent.state == :rejected
     assert updated_respondent.disposition == "rejected"
 
     selected_bucket = QuotaBucket |> Repo.get(selected_bucket.id)
@@ -2177,7 +2177,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert survey.state == "running"
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "failed"
+    assert respondent.state == :failed
 
     :ok = broker |> GenServer.stop
   end
@@ -2196,7 +2196,7 @@ defmodule Ask.Runtime.SurveyTest do
     Survey.sync_step_internal(session, Flow.Message.reply("Yes"))
 
     updated_respondent = Repo.get(Respondent, respondent.id)
-    assert updated_respondent.state == "active"
+    assert updated_respondent.state == :active
 
     now = Timex.now
     interval = Interval.new(from: Timex.shift(now, minutes: 1), until: Timex.shift(now, minutes: 3), step: [seconds: 1])
@@ -2213,7 +2213,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert survey.state == "running"
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
@@ -2231,7 +2231,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert {:end, _} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "failed"
+    assert respondent.state == :failed
     assert respondent.disposition == "breakoff"
 
     :ok = broker |> GenServer.stop
@@ -2248,7 +2248,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert survey.state == "running"
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
@@ -2266,7 +2266,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert {:end, _} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
     assert respondent.disposition == "started"
 
     :ok = broker |> GenServer.stop
@@ -2334,7 +2334,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert survey.state == "running"
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == "active"
+    assert respondent.state == :active
 
     respondent = Repo.get(Respondent, respondent.id)
     assert {:end, ^respondent} = Survey.sync_step(respondent, Flow.Message.reply("Yes"), "sms")

--- a/test/lib/runtime/survey_test.exs
+++ b/test/lib/runtime/survey_test.exs
@@ -1105,7 +1105,7 @@ defmodule Ask.Runtime.SurveyTest do
              |> Enum.filter( fn (b) -> b.id != selected_bucket.id end)
              |> Enum.all?( fn (b) -> b.count == 0 end)
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       :ok = broker |> GenServer.stop
     end
@@ -1142,7 +1142,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert {:end, {:reply, ReplyHelper.simple("Thank you", "Thanks for completing this survey")}, _} = reply
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
       selected_bucket = QuotaBucket |> Repo.get(selected_bucket.id)
       assert selected_bucket.count == 1
       assert QuotaBucket
@@ -1173,7 +1173,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert {:reply, ReplyHelper.simple("Do you exercise", "Do you exercise? Reply 1 for YES, 2 for NO"), _} = reply
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "interim partial"
+      assert respondent.disposition == :"interim partial"
 
       respondent = Repo.get(Respondent, respondent.id)
       reply = Survey.sync_step(respondent, Flow.Message.reply("Yes"))
@@ -1186,7 +1186,7 @@ defmodule Ask.Runtime.SurveyTest do
              |> Enum.filter( fn (b) -> b.id != selected_bucket.id end)
              |> Enum.all?( fn (b) -> b.count == 0 end)
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       respondent = Repo.get(Respondent, respondent.id)
       reply = Survey.sync_step(respondent, Flow.Message.reply("99"))
@@ -1199,7 +1199,7 @@ defmodule Ask.Runtime.SurveyTest do
              |> Enum.filter( fn (b) -> b.id != selected_bucket.id end)
              |> Enum.all?( fn (b) -> b.count == 0 end)
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       respondent = Repo.get(Respondent, respondent.id)
       reply = Survey.sync_step(respondent, Flow.Message.reply("11"))
@@ -1212,7 +1212,7 @@ defmodule Ask.Runtime.SurveyTest do
              |> Enum.filter( fn (b) -> b.id != selected_bucket.id end)
              |> Enum.all?( fn (b) -> b.count == 0 end)
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       :ok = broker |> GenServer.stop
     end
@@ -1249,7 +1249,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert {:end, {:reply, ReplyHelper.simple("Thank you", "Thanks for completing this survey")}, _} = reply
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
       selected_bucket = QuotaBucket |> Repo.get(selected_bucket.id)
       assert selected_bucket.count == 1
       assert QuotaBucket
@@ -1290,7 +1290,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert {:reply, ReplyHelper.simple("Do you exercise", "Do you exercise? Reply 1 for YES, 2 for NO"), _} = reply
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "interim partial"
+      assert respondent.disposition == :"interim partial"
 
       selected_bucket = QuotaBucket |> Repo.get(selected_bucket.id)
       assert selected_bucket.count == 1
@@ -1304,7 +1304,7 @@ defmodule Ask.Runtime.SurveyTest do
       assert {:reply, ReplyHelper.simple("Which is the second perfect number?", "Which is the second perfect number??"), _} = reply
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       respondent = Repo.get(Respondent, respondent.id)
       reply = Survey.sync_step(respondent, Flow.Message.reply("99"))
@@ -1317,7 +1317,7 @@ defmodule Ask.Runtime.SurveyTest do
              |> Enum.filter( fn (b) -> b.id != selected_bucket.id end)
              |> Enum.all?( fn (b) -> b.count == 0 end)
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       respondent = Repo.get(Respondent, respondent.id)
       reply = Survey.sync_step(respondent, Flow.Message.reply("11"))
@@ -1330,7 +1330,7 @@ defmodule Ask.Runtime.SurveyTest do
              |> Enum.filter( fn (b) -> b.id != selected_bucket.id end)
              |> Enum.all?( fn (b) -> b.count == 0 end)
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       :ok = broker |> GenServer.stop
     end
@@ -1363,7 +1363,7 @@ defmodule Ask.Runtime.SurveyTest do
 
       assert {:reply, ReplyHelper.simple("Do you exercise", "Do you exercise? Reply 1 for YES, 2 for NO"), _} = reply
 
-      assert respondent.disposition == "interim partial"
+      assert respondent.disposition == :"interim partial"
 
       reply = Survey.sync_step(respondent, Flow.Message.reply("Yes"))
 
@@ -1376,7 +1376,7 @@ defmodule Ask.Runtime.SurveyTest do
              |> Repo.all
              |> Enum.filter( fn (b) -> b.id != selected_bucket.id end)
              |> Enum.all?( fn (b) -> b.count == 0 end)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       respondent = Repo.get(Respondent, respondent.id)
       reply = Survey.sync_step(respondent, Flow.Message.reply("99"))
@@ -1389,7 +1389,7 @@ defmodule Ask.Runtime.SurveyTest do
              |> Enum.filter( fn (b) -> b.id != selected_bucket.id end)
              |> Enum.all?( fn (b) -> b.count == 0 end)
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       respondent = Repo.get(Respondent, respondent.id)
       reply = Survey.sync_step(respondent, Flow.Message.reply("11"))
@@ -1402,7 +1402,7 @@ defmodule Ask.Runtime.SurveyTest do
              |> Enum.filter( fn (b) -> b.id != selected_bucket.id end)
              |> Enum.all?( fn (b) -> b.count == 0 end)
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == "completed"
+      assert respondent.disposition == :completed
 
       :ok = broker |> GenServer.stop
     end
@@ -1465,13 +1465,13 @@ defmodule Ask.Runtime.SurveyTest do
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "interim partial"
+    assert respondent.disposition == :"interim partial"
 
     reply = Survey.sync_step(respondent, Flow.Message.reply("Yes"))
     assert {:reply, ReplyHelper.simple("Is this the last question?"), _} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "interim partial"
+    assert respondent.disposition == :"interim partial"
     assert respondent.effective_modes == ["sms"]
   end
 
@@ -1484,13 +1484,13 @@ defmodule Ask.Runtime.SurveyTest do
     assert_received [:ask, ^test_channel, %Respondent{sanitized_phone_number: ^phone_number}, _, ReplyHelper.simple("Do you smoke?", "Do you smoke? Reply 1 for YES, 2 for NO")]
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "queued"
+    assert respondent.disposition == :queued
 
     Survey.delivery_confirm(respondent, "Do you smoke?")
 
     updated_respondent = Repo.get(Respondent, respondent.id)
     assert updated_respondent.state == :active
-    assert updated_respondent.disposition == "contacted"
+    assert updated_respondent.disposition == :contacted
 
     :ok = broker |> GenServer.stop
   end
@@ -1502,14 +1502,14 @@ defmodule Ask.Runtime.SurveyTest do
     Broker.poll
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "queued"
+    assert respondent.disposition == :queued
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
 
     updated_respondent = Repo.get(Respondent, respondent.id)
     assert updated_respondent.state == :active
-    assert updated_respondent.disposition == "contacted"
+    assert updated_respondent.disposition == :contacted
 
     :ok = broker |> GenServer.stop
   end
@@ -1523,19 +1523,19 @@ defmodule Ask.Runtime.SurveyTest do
     assert_received [:ask, ^test_channel, %Respondent{sanitized_phone_number: ^phone_number}, _, ReplyHelper.simple("Do you smoke?", "Do you smoke? Reply 1 for YES, 2 for NO")]
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "queued"
+    assert respondent.disposition == :queued
 
     Survey.delivery_confirm(respondent, "Do you smoke?")
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "contacted"
+    assert respondent.disposition == :contacted
 
     Survey.sync_step(respondent, Flow.Message.reply("Yes"))
 
     updated_respondent = Repo.get(Respondent, respondent.id)
     assert updated_respondent.state == :active
-    assert updated_respondent.disposition == "started"
+    assert updated_respondent.disposition == :started
 
     :ok = broker |> GenServer.stop
   end
@@ -1602,7 +1602,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "interim partial"
+    assert respondent.disposition == :"interim partial"
     survey = Repo.get(Ask.Survey, survey.id)
     assert survey.state == "running"
 
@@ -1647,7 +1647,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get!(Respondent, respondent.id)
     assert respondent.state == :completed
-    assert respondent.disposition == "ineligible"
+    assert respondent.disposition == :ineligible
 
     histories = RespondentDispositionHistory |> Repo.all
     assert length(histories) == 4
@@ -1673,7 +1673,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get!(Respondent, respondent.id)
     assert respondent.state == :completed
-    assert respondent.disposition == "refused"
+    assert respondent.disposition == :refused
 
     histories = RespondentDispositionHistory |> Repo.all
     assert length(histories) == 3
@@ -1724,14 +1724,14 @@ defmodule Ask.Runtime.SurveyTest do
 
     test "base scenario (previous to the STOP MO message)" do
       confirm_delivery("Do you exercise?")
-      assert_respondent(%{current_state: :active, previous_disposition: "queued", current_disposition: "contacted", user_stopped: false})
+      assert_respondent(%{current_state: :active, previous_disposition: :queued, current_disposition: :contacted, user_stopped: false})
     end
 
     test "contacted -> refused" do
       confirm_delivery("Do you exercise?")
       respondent_sends_stop()
 
-      assert_respondent(%{current_state: :failed, previous_disposition: "contacted", current_disposition: "refused", user_stopped: true})
+      assert_respondent(%{current_state: :failed, previous_disposition: :contacted, current_disposition: :refused, user_stopped: true})
     end
 
     test "started -> breakoff" do
@@ -1739,7 +1739,7 @@ defmodule Ask.Runtime.SurveyTest do
       respondent_answers("Any thing")
       respondent_sends_stop()
 
-      assert_respondent(%{current_state: :failed, previous_disposition: "started", current_disposition: "breakoff", user_stopped: true})
+      assert_respondent(%{current_state: :failed, previous_disposition: :started, current_disposition: :breakoff, user_stopped: true})
     end
 
     test "queued -> refused" do
@@ -1747,7 +1747,7 @@ defmodule Ask.Runtime.SurveyTest do
       #     It's expected that a "queued" respondent isn't yet contacted.
       respondent_sends_stop()
 
-      assert_respondent(%{current_state: :failed, previous_disposition: "queued", current_disposition: "refused", user_stopped: true})
+      assert_respondent(%{current_state: :failed, previous_disposition: :queued, current_disposition: :refused, user_stopped: true})
     end
   end
 
@@ -1767,7 +1767,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get!(Respondent, respondent.id)
     assert respondent.state == :completed
-    assert respondent.disposition == "completed"
+    assert respondent.disposition == :completed
 
     histories = RespondentDispositionHistory |> Repo.all
     assert length(histories) == 3
@@ -1789,7 +1789,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "interim partial"
+    assert respondent.disposition == :"interim partial"
     survey = Repo.get(Ask.Survey, survey.id)
     assert survey.state == "running"
 
@@ -1800,7 +1800,7 @@ defmodule Ask.Runtime.SurveyTest do
     respondent = Repo.get(Respondent, respondent.id) |> Repo.preload(:responses)
     assert survey.state == "running"
     assert respondent.state == :active
-    assert respondent.disposition == "interim partial"
+    assert respondent.disposition == :"interim partial"
     assert hd(respondent.responses).value == "Yes"
   end
 
@@ -1831,14 +1831,14 @@ defmodule Ask.Runtime.SurveyTest do
     respondent = Repo.get(Respondent, respondent.id)
 
     assert respondent.state       == :active
-    assert respondent.disposition == "started"
+    assert respondent.disposition == :started
 
     Survey.sync_step(respondent, Flow.Message.no_reply)
 
     respondent = Repo.get(Respondent, respondent.id)
 
     assert respondent.state       == :active
-    assert respondent.disposition == "started"
+    assert respondent.disposition == :started
 
     now = Timex.now
     interval = Interval.new(from: Timex.shift(now, minutes: 9), until: Timex.shift(now, minutes: 11), step: [seconds: 1])
@@ -1879,7 +1879,7 @@ defmodule Ask.Runtime.SurveyTest do
     respondent = Repo.get(Respondent, respondent.id)
 
     assert respondent.state       == :active
-    assert respondent.disposition == "started"
+    assert respondent.disposition == :started
 
     now = Timex.now
     interval = Interval.new(from: Timex.shift(now, minutes: 9), until: Timex.shift(now, minutes: 11), step: [seconds: 1])
@@ -1897,7 +1897,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "queued"
+    assert respondent.disposition == :queued
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
@@ -1908,14 +1908,14 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "started"
+    assert respondent.disposition == :started
 
     Respondent.changeset(respondent, %{timeout_at: Timex.now |> Timex.shift(minutes: -1)}) |> Repo.update
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :failed
-    assert respondent.disposition == "breakoff"
+    assert respondent.disposition == :breakoff
 
     :ok = logger |> GenServer.stop
 
@@ -1938,7 +1938,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "queued"
+    assert respondent.disposition == :queued
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
@@ -1949,14 +1949,14 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "interim partial"
+    assert respondent.disposition == :"interim partial"
 
     Respondent.changeset(respondent, %{timeout_at: Timex.now |> Timex.shift(minutes: -1)}) |> Repo.update
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :failed
-    assert respondent.disposition == "partial"
+    assert respondent.disposition == :partial
 
     :ok = logger |> GenServer.stop
     last_entry = ((respondent |> Repo.preload(:survey_log_entries)).survey_log_entries |> Enum.at(-1))
@@ -1977,7 +1977,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "queued"
+    assert respondent.disposition == :queued
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
@@ -1988,20 +1988,20 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "interim partial"
+    assert respondent.disposition == :"interim partial"
 
     _reply = Survey.sync_step(respondent, Flow.Message.reply("1"))
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "completed"
+    assert respondent.disposition == :completed
 
     Respondent.changeset(respondent, %{timeout_at: Timex.now |> Timex.shift(minutes: -1)}) |> Repo.update
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :failed
-    assert respondent.disposition == "completed"
+    assert respondent.disposition == :completed
 
     :ok = broker |> GenServer.stop
   end
@@ -2015,21 +2015,21 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "queued"
+    assert respondent.disposition == :queued
 
     reply = Survey.sync_step(respondent, Flow.Message.answer())
     assert {:reply, ReplyHelper.ivr("Do you smoke?", "Do you smoke? Press 8 for YES, 9 for NO"), _} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "contacted"
+    assert respondent.disposition == :contacted
 
     Respondent.changeset(respondent, %{timeout_at: Timex.now |> Timex.shift(minutes: -1)}) |> Repo.update
     Broker.handle_info(:poll, nil)
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :failed
-    assert respondent.disposition == "unresponsive"
+    assert respondent.disposition == :unresponsive
 
     :ok = logger |> GenServer.stop
     last_entry = ((respondent |> Repo.preload(:survey_log_entries)).survey_log_entries |> Enum.at(-1))
@@ -2081,11 +2081,11 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "contacted"
+    assert respondent.disposition == :contacted
 
     respondent
     |> Respondent.changeset(%{
-      disposition: "interim partial",
+      disposition: :"interim partial",
       timeout_at: Timex.now |> Timex.shift(minutes: -1)
     })
     |> Repo.update!
@@ -2094,7 +2094,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :failed
-    assert respondent.disposition == "partial"
+    assert respondent.disposition == :partial
 
     :ok = broker |> GenServer.stop
   end
@@ -2110,7 +2110,7 @@ defmodule Ask.Runtime.SurveyTest do
     Survey.sync_step(respondent, Flow.Message.no_reply)
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "queued"
+    assert respondent.disposition == :queued
   end
 
   test "marks the respondent as rejected when the bucket is completed" do
@@ -2135,7 +2135,7 @@ defmodule Ask.Runtime.SurveyTest do
     assert {:end, _} = reply
     updated_respondent = Repo.get(Respondent, respondent.id)
     assert updated_respondent.state == :rejected
-    assert updated_respondent.disposition == "rejected"
+    assert updated_respondent.disposition == :rejected
 
     selected_bucket = QuotaBucket |> Repo.get(selected_bucket.id)
     assert selected_bucket.count == 1
@@ -2232,7 +2232,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :failed
-    assert respondent.disposition == "breakoff"
+    assert respondent.disposition == :breakoff
 
     :ok = broker |> GenServer.stop
   end
@@ -2267,7 +2267,7 @@ defmodule Ask.Runtime.SurveyTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     assert respondent.state == :active
-    assert respondent.disposition == "started"
+    assert respondent.disposition == :started
 
     :ok = broker |> GenServer.stop
   end
@@ -2354,7 +2354,7 @@ defmodule Ask.Runtime.SurveyTest do
     Survey.delivery_confirm(respondent, "Contact", "sms")
 
     respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == "contacted"
+    assert respondent.disposition == :contacted
   end
 
   test "it doesn't crash on channel_failed when there's no session" do
@@ -2553,19 +2553,20 @@ defmodule Ask.Runtime.SurveyTest do
     last_entry = SurveyLogEntry |> Repo.all |> take_last
 
     assert last_entry.action_type == "disposition changed"
-    assert last_entry.disposition == old_disposition
+    assert last_entry.disposition == to_string(old_disposition)
     assert last_entry.action_data == upcaseFirst(new_disposition)
   end
 
   defp assert_last_history_disposition_is(disposition) do
     last_history = RespondentDispositionHistory |> Repo.all |> take_last
 
-    assert last_history.disposition == disposition
+    assert last_history.disposition == to_string(disposition)
   end
 
   defp take_last(records), do:
     records |> Enum.take(-1) |> hd
 
+  defp upcaseFirst(value) when is_atom(value), do: to_string(value) |> upcaseFirst
   defp upcaseFirst(<<first::utf8, rest::binary>>), do: String.upcase(<<first::utf8>>) <> rest
 
 end

--- a/test/lib/runtime/verboice_channel_test.exs
+++ b/test/lib/runtime/verboice_channel_test.exs
@@ -200,7 +200,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "10", "CallSid" => "6B8F5B7B-E412-46D3-96E1-688215F43CC3", "CallStatusReason" => "some random reason", "CallStatusCode" => "42"})
 
@@ -251,7 +251,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "11", "CallSid" => "some-id", "CallStatusCode" => "42"})
 
@@ -282,7 +282,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "12", "CallSid" => "id with spaces", "CallStatusReason" => "some random reason"})
 
@@ -313,7 +313,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "failed", "CallDuration" => "13", "CallSid" => "12345"})
 
@@ -344,7 +344,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "no-answer", "CallDuration" => "14", "CallSid" => "1515", "CallStatusReason" => "another reason", "CallStatusCode" => "foo"})
 
@@ -375,7 +375,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert survey.state == "running"
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       VerboiceChannel.callback(conn, %{"path" => ["status", respondent.id, "token"], "CallStatus" => "busy", "CallDuration" => "15", "CallSid" => "1", "CallStatusReason" => "yet another reason", "CallStatusCode" => "bar"})
 
@@ -405,7 +405,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert survey.state == "running"
 
       %Respondent{mode: mode} = respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       assert 1 == %{survey_id: survey.id} |> RetryStat.stats() |> RetryStat.count(%{attempt: 1, ivr_active: true, mode: mode})
 
@@ -474,7 +474,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       Broker.poll
 
       respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == "active"
+      assert respondent.state == :active
 
       {:ok, %{conn: conn, respondent: respondent, logger: logger, broker: broker}}
     end
@@ -500,7 +500,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       logger |> GenServer.stop
       broker |> GenServer.stop
     end
-    
+
     test "counts attempt upon respondent interaction callback", %{conn: conn, respondent: respondent, logger: logger, broker: broker} do
       assert Stats.attempts(respondent.stats, :ivr) == 0
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -105,7 +105,7 @@ defmodule Ask.TestHelpers do
                      from r in assoc(survey, :respondents),
                      group_by: :state,
                      select: {r.state, count("*")}) |> Enum.into(%{})
-        [by_state["active"] || 0, by_state["pending"] || 0]
+        [by_state[:active] || 0, by_state[:pending] || 0]
       end
 
       # Format a timestamp without microseconds the same way the controller does.

--- a/test/survey_canceller/survey_canceller_test.exs
+++ b/test/survey_canceller/survey_canceller_test.exs
@@ -23,7 +23,7 @@ defmodule Ask.SurveyCancellerTest do
                Repo.all(
                  from(
                    r in Ask.Respondent,
-                   where: (r.state == "cancelled" and is_nil(r.session) and is_nil(r.timeout_at))
+                   where: (r.state == :cancelled and is_nil(r.session) and is_nil(r.timeout_at))
                  )
                )
              ) == 0
@@ -69,7 +69,7 @@ defmodule Ask.SurveyCancellerTest do
                Repo.all(
                  from(
                    r in Ask.Respondent,
-                   where: (r.state == "cancelled" and is_nil(r.session) and is_nil(r.timeout_at))
+                   where: (r.state == :cancelled and is_nil(r.session) and is_nil(r.timeout_at))
                  )
                )
              ) == 4
@@ -120,7 +120,7 @@ defmodule Ask.SurveyCancellerTest do
                Repo.all(
                  from(
                    r in Ask.Respondent,
-                   where: (r.state == "cancelled" and is_nil(r.session) and is_nil(r.timeout_at))
+                   where: (r.state == :cancelled and is_nil(r.session) and is_nil(r.timeout_at))
                  )
                )
              ) == 7
@@ -178,7 +178,7 @@ defmodule Ask.SurveyCancellerTest do
                Repo.all(
                  from(
                    r in Ask.Respondent,
-                   where: (r.state == "cancelled" and is_nil(r.session) and is_nil(r.timeout_at))
+                   where: (r.state == :cancelled and is_nil(r.session) and is_nil(r.timeout_at))
                  )
                )
              ) == 11

--- a/web/controllers/mobile_survey_controller.ex
+++ b/web/controllers/mobile_survey_controller.ex
@@ -79,7 +79,7 @@ defmodule Ask.MobileSurveyController do
           questionnaire = Enum.random(questionnaires)
           msg = questionnaire.settings["mobile_web_survey_is_over_message"] || "The survey is over"
           {end_step(msg), end_progress(), nil}
-        respondent.state in ["pending", "active", "rejected"] ->
+        respondent.state in [:pending, :active, :rejected] ->
           case Survey.sync_step(respondent, value, "mobileweb") do
             {:reply, reply, _} ->
               {Reply.first_step(reply), Reply.progress(reply), reply.error_message}

--- a/web/controllers/respondent_controller.ex
+++ b/web/controllers/respondent_controller.ex
@@ -217,11 +217,11 @@ defmodule Ask.RespondentController do
     target = target(survey, buckets, total_respondents)
 
     total_respondents_by_disposition =
-      Ask.RespondentStats.respondent_count(survey_id: ^survey.id, by: :disposition)
+      Ask.RespondentStats.respondents_by_disposition(survey)
 
     # Completion percentage
     attempted_respondents = total_respondents_by_disposition
-      |> Enum.filter(fn {d, _} -> d not in ["queued", "registered"] end)
+      |> Enum.filter(fn {d, _} -> d not in [:queued, :registered] end)
       |> Enum.map(fn {_, c} -> c end)
       |> Enum.sum
 
@@ -875,7 +875,7 @@ defmodule Ask.RespondentController do
     |> Repo.get!(survey_id)
 
     csv_rows = (from r in Respondent,
-      where: r.survey_id == ^survey.id and r.disposition == "completed" and not is_nil(r.questionnaire_id),
+      where: r.survey_id == ^survey.id and r.disposition == :completed and not is_nil(r.questionnaire_id),
       order_by: r.id)
     |> Repo.stream
     |> Repo.stream_preload(:questionnaire)

--- a/web/controllers/survey_respondents_canceller.ex
+++ b/web/controllers/survey_respondents_canceller.ex
@@ -67,7 +67,7 @@ defmodule Ask.RespondentsCancellerProducer do
       r in Respondent,
       select: r.id,
       where: (
-        r.state == "active" and (r.survey_id in ^state.survey_ids) and (
+        r.state == :active and (r.survey_id in ^state.survey_ids) and (
           r.id > ^state.last_updated_respondent_id)),
       limit: 100,
       order_by: [

--- a/web/models/questionnaire.ex
+++ b/web/models/questionnaire.ex
@@ -9,8 +9,8 @@ defmodule Ask.Questionnaire do
     field :name, :string
     field :description, :string
     field :modes, Ask.Ecto.Type.StringList
-    field :steps, JSON
-    field :quota_completed_steps, JSON
+    field :steps, Ask.Ecto.Type.Steps
+    field :quota_completed_steps, Ask.Ecto.Type.Steps
     field :settings, JSON
     field :languages, JSON
     field :default_language, :string

--- a/web/models/respondent.ex
+++ b/web/models/respondent.ex
@@ -10,15 +10,14 @@ defmodule Ask.Respondent do
     field :hashed_number, :string
     field :section_order, JSON
 
-    # Valid states are:
-    # * pending: the initial state of a respondent, before communication starts
-    # * active: a communication is being held with the respondent
-    # * completed: the communication finished succesfully (it reached the end)
-    # * failed: communication couldn't be established or was cut
-    # * rejected: communication ended because the respondent fell in a full quota bucket
-    # * cancelled: when the survey is stopped and has "terminated" state, all the active
-    #     respondents will be updated with this state.
-    field :state, :string, default: "pending"
+    field :state, Ecto.Enum, values: [
+      :pending,   # the initial state of a respondent, before communication starts
+      :active,    # a communication is being held with the respondent
+      :completed, # the communication finished succesfully (it reached the end)
+      :failed,    # communication couldn't be established or was cut
+      :rejected,  # communication ended because the respondent fell in a full quota bucket
+      :cancelled, # when the survey is stopped and has :terminated state, all the active respondents will be updated with this state.
+    ], default: :pending
 
     # Valid dispositions are:
     # https://cloud.githubusercontent.com/assets/22697/25618659/3126839e-2f1e-11e7-8a3a-7908f8cd1749.png
@@ -36,7 +35,7 @@ defmodule Ask.Respondent do
     # - completed: through flag step from started or partial / survey finished with the respondent on started or partial disposition
     field :disposition, :string, default: "registered"
 
-    field :completed_at, :utc_datetime # only when state=="pending"
+    field :completed_at, :utc_datetime # only when state==:pending
     field :timeout_at, :utc_datetime
     field :session, JSON
     # In Respondent model, "mode" field name should change in the future.
@@ -76,7 +75,7 @@ defmodule Ask.Respondent do
     |> cast(params, [:phone_number, :sanitized_phone_number, :canonical_phone_number, :state, :session, :quota_bucket_id, :completed_at, :timeout_at, :questionnaire_id, :mode, :disposition, :mobile_web_cookie_code, :language, :effective_modes, :stats, :section_order, :retry_stat_id, :user_stopped])
     |> validate_required([:phone_number, :state, :user_stopped])
     |> validate_inclusion(:disposition, ["registered", "queued", "contacted", "failed", "unresponsive", "started", "ineligible", "rejected", "breakoff", "refused", "partial", "interim partial", "completed"])
-    |> validate_inclusion(:state, ["pending", "active", "completed", "failed", "rejected", "cancelled"])
+    |> validate_inclusion(:state, Ecto.Enum.values(Ask.Respondent, :state))
     |> Ecto.Changeset.optimistic_lock(:lock_version)
   end
 

--- a/web/models/respondent_disposition_history.ex
+++ b/web/models/respondent_disposition_history.ex
@@ -25,7 +25,7 @@ defmodule Ask.RespondentDispositionHistory do
     if respondent.disposition && respondent.disposition != old_disposition do
       %RespondentDispositionHistory{
         respondent: respondent,
-        disposition: respondent.disposition,
+        disposition: respondent.disposition |> to_string(),
         mode: mode,
         survey_id: respondent.survey_id,
         respondent_hashed_number: respondent.hashed_number

--- a/web/models/respondent_stats.ex
+++ b/web/models/respondent_stats.ex
@@ -114,6 +114,6 @@ defmodule Ask.RespondentStats do
 
   def respondents_by_disposition(survey) do
     respondent_count(survey_id: ^survey.id, by: :disposition)
-    |> Enum.into(%{})
+    |> Enum.into(%{}, fn ({k, v}) -> {String.to_existing_atom(k), v} end)
   end
 end

--- a/web/models/respondent_stats.ex
+++ b/web/models/respondent_stats.ex
@@ -100,20 +100,17 @@ defmodule Ask.RespondentStats do
   end
 
   def respondents_by_state(survey) do
-    by_state_defaults = %{
-      active: 0,
-      pending: 0,
-      completed: 0,
-      rejected: 0,
-      failed: 0,
-    }
+    by_state_defaults = Ecto.Enum.values(Ask.Respondent, :state)
+    |> Map.new(fn (state) -> {state, 0} end)
 
-    respondent_count(survey_id: ^survey.id, by: :state)
-    |> Enum.into(by_state_defaults, fn ({k, v}) -> {String.to_existing_atom(k), v} end)
+    by_state = respondent_count(survey_id: ^survey.id, by: :state)
+    |> Map.new(fn ({k, v}) -> {String.to_existing_atom(k), v} end)
+
+    Map.merge(by_state_defaults, by_state)
   end
 
   def respondents_by_disposition(survey) do
     respondent_count(survey_id: ^survey.id, by: :disposition)
-    |> Enum.into(%{}, fn ({k, v}) -> {String.to_existing_atom(k), v} end)
+    |> Map.new(fn ({k, v}) -> {String.to_existing_atom(k), v} end)
   end
 end

--- a/web/models/respondent_stats.ex
+++ b/web/models/respondent_stats.ex
@@ -101,15 +101,15 @@ defmodule Ask.RespondentStats do
 
   def respondents_by_state(survey) do
     by_state_defaults = %{
-      "active" => 0,
-      "pending" => 0,
-      "completed" => 0,
-      "rejected" => 0,
-      "failed" => 0,
+      active: 0,
+      pending: 0,
+      completed: 0,
+      rejected: 0,
+      failed: 0,
     }
 
     respondent_count(survey_id: ^survey.id, by: :state)
-    |> Enum.into(by_state_defaults)
+    |> Enum.into(by_state_defaults, fn ({k, v}) -> {String.to_existing_atom(k), v} end)
   end
 
   def respondents_by_disposition(survey) do

--- a/web/models/survey.ex
+++ b/web/models/survey.ex
@@ -398,7 +398,7 @@ defmodule Ask.Survey do
   end
 
   def cancel_respondents(survey) do
-    from(r in Respondent, where: ((r.state == "active") and (r.survey_id == ^survey.id)))
+    from(r in Respondent, where: ((r.state == :active) and (r.survey_id == ^survey.id)))
     |> Repo.update_all(set: [state: "cancelled", session: nil, timeout_at: nil])
   end
 

--- a/web/models/survey.ex
+++ b/web/models/survey.ex
@@ -592,7 +592,7 @@ defmodule Ask.Survey do
     )
 
     case quota_completed do
-      nil -> respondents_by_state["completed"]
+      nil -> respondents_by_state[:completed]
       value -> value |> Decimal.to_integer
     end
   end


### PR DESCRIPTION
Leverages Ecto.Enum to validate respondent state/disposition values and raise errors when trying to use invalid values (e.g. typos, mixed up state vs disposition vs survey state, ...).

- [x] Respondent state enum (see f026354)
- [x] Respondent disposition enum (see b1ac21a)

requires #1986 (Ecto 3.5+)
closes #1975 