### PR TITLE
Fix: optimize audios' uuid column

### DIFF
--- a/priv/repo/migrations/20211125141835_optimize_audios_uuid.exs
+++ b/priv/repo/migrations/20211125141835_optimize_audios_uuid.exs
@@ -1,0 +1,16 @@
+# Use 36 bytes of fixed storage for storing UUIDs instead of a dynamically
+# allocated storage of `1 + 36 * 3` bytes (109 bytes) with UTF8, without
+# changing the actual UUID format.
+defmodule Ask.Repo.Migrations.OptimizeAudiosUuid do
+  use Ecto.Migration
+
+  def up do
+    execute "ALTER TABLE audios MODIFY uuid CHAR(36) CHARACTER SET ascii"
+    create index(:audios, :uuid)
+  end
+
+  def down do
+    execute "ALTER TABLE audios MODIFY uuid VARCHAR(255) CHARACTER SET utf8"
+    drop index(:audios, :uuid)
+  end
+end

--- a/priv/repo/migrations/20211125141835_optimize_audios_uuid.exs
+++ b/priv/repo/migrations/20211125141835_optimize_audios_uuid.exs
@@ -10,7 +10,7 @@ defmodule Ask.Repo.Migrations.OptimizeAudiosUuid do
   end
 
   def down do
-    execute "ALTER TABLE audios MODIFY uuid VARCHAR(255) CHARACTER SET utf8"
     drop index(:audios, :uuid)
+    execute "ALTER TABLE audios MODIFY uuid VARCHAR(255) CHARACTER SET utf8"
   end
 end


### PR DESCRIPTION
The audios table was missing an index on the UUID column, which led to requests to fetch an audio file to take ~25s in staging, triggering timeout errors in different places (e.g. playing an audio file, exporting questionnaire, ...)

Also optimizes the storage a little by using a fixed size CHAR storage with ASCII character set (1 character = 1 byte) instead of UTF-8 (1 character = 3 bytes).

We could optimize further, by using a BLOB(16) instead, but that wouldn't require more changes (e.g. use `Ecto.UUID`), complicating manual SQL requests, ..., for little overall improvements —the table usually doesn't grow too big.

Fixes ASK-STG-QY
Fixes ASK-STG-R1