### PR TITLE
Fix: report crashed process exceptions to Sentry

### DIFF
--- a/lib/ask.ex
+++ b/lib/ask.ex
@@ -42,6 +42,8 @@ defmodule Ask do
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Ask.Supervisor]
+    :ok = :error_logger.add_report_handler(Sentry.Logger)
+
     supervisor_result = Supervisor.start_link(children, opts)
     survey_canceller_children = if Mix.env != :test && !IEx.started? do
       # Start cancelling with survey_id = nil to check all surveys that must be cancelled

--- a/lib/ask/endpoint.ex
+++ b/lib/ask/endpoint.ex
@@ -1,5 +1,6 @@
 defmodule Ask.Endpoint do
   use Phoenix.Endpoint, otp_app: :ask
+  use Sentry.Phoenix.Endpoint
 
   socket "/socket", Ask.UserSocket
 


### PR DESCRIPTION
Relies on :error_logger to log exceptions happening in processes that live outside Plug.

See https://github.com/getsentry/sentry-elixir/tree/6.4.2#capture-crashed-process-exceptions