### PR TITLE
Code refactor PanelSurvey

### DIFF
--- a/lib/ask/runtime/respondent_group_action.ex
+++ b/lib/ask/runtime/respondent_group_action.ex
@@ -137,8 +137,9 @@ defmodule Ask.Runtime.RespondentGroupAction do
     Enum.map(loaded_entries, fn %{phone_number: phone_number} -> phone_number end)
   end
 
-  def loaded_phone_numbers(phone_numbers),
-    do: Enum.map(phone_numbers, fn phone_number -> %{phone_number: phone_number} end)
+  def loaded_phone_numbers(phone_numbers) do
+    Enum.map(phone_numbers, fn phone_number -> %{phone_number: phone_number} end)
+  end
 
   def merge_sample(old_sample, loaded_entries) do
     new_sample = old_sample ++ entries_for_sample(loaded_entries)

--- a/lib/ask/runtime/respondent_group_action.ex
+++ b/lib/ask/runtime/respondent_group_action.ex
@@ -324,10 +324,9 @@ defmodule Ask.Runtime.RespondentGroupAction do
   end
 
   # For each existing group a new respondent group with the same name is created.
-  # Each respondent group has a copy of every respondent (except refused)
-  # and channel association.
+  # Each respondent group has a copy of every respondent (except refused and
+  # ineligible) and channel association.
   def clone_respondents_groups_into(respondent_groups, survey) do
-
     groups_phone_numbers = phone_numbers_by_group_id(respondent_groups)
 
     Enum.map(respondent_groups, fn group ->

--- a/lib/ask/runtime/respondent_group_action.ex
+++ b/lib/ask/runtime/respondent_group_action.ex
@@ -322,4 +322,59 @@ defmodule Ask.Runtime.RespondentGroupAction do
       }
     end)
   end
+
+  # For each existing group a new respondent group with the same name is created.
+  # Each respondent group has a copy of every respondent (except refused)
+  # and channel association.
+  def clone_respondents_groups_into(respondent_groups, survey) do
+
+    groups_phone_numbers = phone_numbers_by_group_id(respondent_groups)
+
+    Enum.map(respondent_groups, fn group ->
+      loaded_phone_numbers = groups_phone_numbers
+        |> Map.get(group.id)
+        |> loaded_phone_numbers()
+
+      new_group = create(group.name, loaded_phone_numbers, survey)
+      copy_respondent_group_channels(group, new_group)
+
+      new_group
+    end)
+  end
+
+  defp phone_numbers_by_group_id(respondent_groups) do
+    groups_ids = respondent_groups |> Enum.map(& &1.id)
+
+    (from r in Respondent,
+      where:
+        r.respondent_group_id in ^groups_ids and
+        r.disposition != :refused and
+        r.disposition != :ineligible,
+      select: [r.respondent_group_id, r.phone_number])
+      |> Repo.all()
+      |> Enum.group_by(&List.first/1, &List.last/1) # group phone_numbers by respondent_group_id
+  end
+
+  defp copy_respondent_group_channels(respondent_group, new_respondent_group) do
+    respondent_group =
+      respondent_group
+      |> Repo.preload(:respondent_group_channels)
+
+    Repo.transaction(fn ->
+      Enum.each(
+        respondent_group.respondent_group_channels,
+        fn respondent_group_channel ->
+          RespondentGroupChannel.changeset(
+            %RespondentGroupChannel{},
+            %{
+              respondent_group_id: new_respondent_group.id,
+              channel_id: respondent_group_channel.channel_id,
+              mode: respondent_group_channel.mode
+            }
+          )
+          |> Repo.insert!()
+        end
+      )
+    end)
+  end
 end

--- a/test/lib/runtime/panel_survey_test.exs
+++ b/test/lib/runtime/panel_survey_test.exs
@@ -254,10 +254,7 @@ defmodule Ask.Runtime.PanelSurveyTest do
       survey
       |> Repo.preload(respondents: [respondent_group: [respondent_group_channels: :channel]])
 
-    Enum.map(survey.respondents, fn %{
-                                      hashed_number: hashed_number,
-                                      respondent_group: respondent_group
-                                    } ->
+    respondent_channels = Enum.map(survey.respondents, fn %{ hashed_number: hashed_number, respondent_group: respondent_group } ->
       respondent_group_channels =
         Enum.map(respondent_group.respondent_group_channels, fn %{channel: channel, mode: mode} ->
           %{channel_id: channel.id, mode: mode}
@@ -265,6 +262,9 @@ defmodule Ask.Runtime.PanelSurveyTest do
 
       %{hashed_number: hashed_number, respondent_group_channels: respondent_group_channels}
     end)
+
+    # order response by hashed_number so it can be used to compare lists in tests using ==
+    respondent_channels
   end
 
   defp assert_incentives_enabled(survey) do

--- a/test/lib/runtime/panel_survey_test.exs
+++ b/test/lib/runtime/panel_survey_test.exs
@@ -260,11 +260,12 @@ defmodule Ask.Runtime.PanelSurveyTest do
           %{channel_id: channel.id, mode: mode}
         end)
 
-      %{hashed_number: hashed_number, respondent_group_channels: respondent_group_channels}
+      { hashed_number, respondent_group_channels }
     end)
 
-    # order response by hashed_number so it can be used to compare lists in tests using ==
-    respondent_channels
+    # We sort the response by hashed_number so that the function
+    # is deterministic enough to be used to compare lists using ==
+    List.keysort(respondent_channels, 0)
   end
 
   defp assert_incentives_enabled(survey) do


### PR DESCRIPTION
Code refactor PanelSurvey's `copy_respondents`, following ToDo comment.

New `RespondentGroupAction` functions:
- `clone_respondents_groups_into` (protocol message)
- `phone_numbers_by_group_id` (private)

Code refactor's goal was:
- more clarity while reading the code 
- extract `Repo`'s query from `Enum.map` (replace n queries with 1 unique query)

Code refactor impact on dependencies:
- Remove `Ecto.Query` from `Ask.Runtime.PanelSurvey`
