### PR TITLE
Fix: cache-control header for AudioController and AudioDeliveryController

### DIFF
--- a/test/controllers/audio_controller_test.exs
+++ b/test/controllers/audio_controller_test.exs
@@ -90,27 +90,20 @@ defmodule Ask.AudioControllerTest do
   end
 
   describe "show" do
-
-    test "when the UUID exists it returns 200", %{conn: conn} do
+    test "returns the file with long cache expiry", %{conn: conn} do
       audio = insert(:audio)
       conn = get conn, audio_path(conn, :show, audio.uuid)
 
       assert conn.status == 200
-    end
-
-    test "when the UUID exists it returns the file", %{conn: conn} do
-      audio = insert(:audio)
-      conn = get conn, audio_path(conn, :show, audio.uuid)
-
       assert conn.resp_body == File.read!("test/fixtures/audio.mp3")
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31556926, immutable"]
     end
 
-    test "when the doesn't exist UUID it returns a 404", %{conn: conn} do
+    test "returns 404 when the file doesn't exist", %{conn: conn} do
       assert_error_sent 404, fn ->
         get conn, audio_path(conn, :show, 1234)
       end
     end
-
   end
 
   describe "tts" do
@@ -118,7 +111,8 @@ defmodule Ask.AudioControllerTest do
       conn = get conn, audio_path(conn, :tts, text: "lorem ipsum")
 
       assert conn.status == 200
-      assert ["audio/x-wav"] = get_resp_header(conn, "content-type")
+      assert get_resp_header(conn, "content-type") == ["audio/x-wav"]
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31556926, immutable"]
       assert byte_size(conn.resp_body) > 0
     end
   end

--- a/test/controllers/audio_delivery_controller_test.exs
+++ b/test/controllers/audio_delivery_controller_test.exs
@@ -1,0 +1,29 @@
+defmodule Ask.AudioDeliveryControllerTest do
+  use Ask.ConnCase
+
+  setup %{conn: conn} do
+    user = insert(:user)
+    conn = conn
+      |> put_private(:test_user, user)
+      |> put_req_header("accept", "application/json")
+
+    {:ok, conn: conn, user: user}
+  end
+
+  describe "show" do
+    test "returns the audio file with long cache expiry", %{conn: conn} do
+      audio = insert(:audio)
+      conn = get conn, audio_path(conn, :show, audio.uuid)
+
+      assert conn.status == 200
+      assert conn.resp_body == File.read!("test/fixtures/audio.mp3")
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=31556926, immutable"]
+    end
+
+    test "returns 404 when the file doesn't exist", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        get conn, audio_path(conn, :show, 1234)
+      end
+    end
+  end
+end

--- a/web/controllers/audio_controller.ex
+++ b/web/controllers/audio_controller.ex
@@ -34,8 +34,7 @@ defmodule Ask.AudioController do
     # can be downloaded, be careful to use a valid filename
     # (one that doesn't have commas or strange characters)
     conn
-    # Expires in one year ( recommended by RFC 2616: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21 )
-    |> put_resp_header("cache-control", "max-age=31556926")
+    |> put_cache_headers()
     |> send_resp(200, audio.data)
   end
 
@@ -48,8 +47,8 @@ defmodule Ask.AudioController do
       System.cmd("/usr/bin/text2wave", ["-o", output, input], parallelism: true)
 
       conn
-      |> put_resp_header("cache-control", "max-age=31556926")
       |> put_resp_header("content-type", "audio/x-wav")
+      |> put_cache_headers()
       |> send_file(200, output)
     after
       File.rm(input)

--- a/web/controllers/audio_delivery_controller.ex
+++ b/web/controllers/audio_delivery_controller.ex
@@ -9,6 +9,7 @@ defmodule Ask.AudioDeliveryController do
     conn
     |> put_resp_header("content-type", Audio.mime_type(audio))
     |> put_resp_header("content-disposition", "attachment; filename=#{audio.filename}")
+    |> put_cache_headers()
     |> send_resp(200, audio.data)
   end
 end

--- a/web/web.ex
+++ b/web/web.ex
@@ -46,6 +46,13 @@ defmodule Ask.Web do
       import CSV.Helper
       import Pagination.Helper
       import Changeset.Helper
+
+      # Sets HTTP headers to cache the response for 1 year, as recommended by
+      # [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21).
+      def put_cache_headers(conn) do
+        conn
+        |> put_resp_header("cache-control", "public, max-age=31556926, immutable")
+      end
     end
   end
 


### PR DESCRIPTION
The former did set the cache-control header properly, but the latter didn't, leading to poor performance with Twilio.

There were no tests for AudioDeliveryController either, or for the cache-control header being set in AudioController. This is now tested.