### PR TITLE
Fix: can't export some questionnaires as CSV

### DIFF
--- a/web/static/js/components/questionnaires/QuestionnaireMenu.jsx
+++ b/web/static/js/components/questionnaires/QuestionnaireMenu.jsx
@@ -29,14 +29,9 @@ class QuestionnaireMenu extends Component {
   }
 
   buildCsvLink() {
-    const { questionnaire } = this.props
-
-    const data = csvForTranslation(questionnaire)
-    let csvContent = 'data:text/csv;charset=utf-8,'
-    csvContent += csvString.stringify(data)
-    const encodedUri = encodeURI(csvContent)
-
-    return encodedUri
+    const data = csvForTranslation(this.props.questionnaire)
+    const csvData = csvString.stringify(data)
+    return 'data:text/csv;charset=utf-8,' + encodeURIComponent(csvData)
   }
 
   openUploadCsvDialog(e) {


### PR DESCRIPTION
- [x] Special characters (such as `#`) break the export.
- [ ] ~~SMS prompts with split parts will only export the first part, skip the n+1 parts.~~ Errata: they're actually joined with a special character (`\u001E`)

fixes #1995