### PR TITLE
Fix: IVR crash on quex step with refusal disabled

### DIFF
--- a/lib/ask/runtime/step.ex
+++ b/lib/ask/runtime/step.ex
@@ -139,7 +139,7 @@ defmodule Ask.Runtime.Step do
     end
   end
 
-  def fetch(:num_digits, step, "ivr", _language) do
+  def fetch(:num_digits, step, "ivr", language) do
     case step["type"] do
       "language-selection" ->
         # If we have 9 choices (1..9) then we can set numDigits to 1,
@@ -165,18 +165,12 @@ defmodule Ask.Runtime.Step do
       "numeric" ->
         # Only send numDigits if the min and max values have the same string length,
         # also taking into account the values of refusal responses
-        refusal = step["refusal"]
-
-        values = if refusal do
-          refusal["responses"]["ivr"]
-        else
-          []
-        end
-
         min_value = step["min_value"]
         max_value = step["max_value"]
+        refusal_values = fetch(:refusal, step, "ivr", language) || []
+
         if min_value && max_value do
-          values = [min_value, max_value | values]
+          values = [min_value, max_value | refusal_values]
           |> Enum.map(fn v -> v |> to_string |> String.length end)
           |> Enum.uniq
 

--- a/test/lib/runtime/flow_test.exs
+++ b/test/lib/runtime/flow_test.exs
@@ -202,6 +202,7 @@ defmodule Ask.FlowTest do
         skip_logic: numeric_skip_logic(min_value: 12345, max_value: 56789, ranges_delimiters: "25,75", ranges: []),
         alphabetical_answers: false,
         refusal: %{
+          "enabled" => true,
           "responses" => %{
             "ivr" => ["#", "12"]
           }
@@ -211,6 +212,31 @@ defmodule Ask.FlowTest do
     step = start_ivr(quiz)
     assert {:ok, %Flow{}, reply} = step
     assert Reply.num_digits(reply) == nil
+  end
+
+  test "first step (ivr mode) for num digits, with disabled refusal" do
+    steps = [
+      numeric_step(
+        id: Ecto.UUID.generate,
+        title: "Which is the second perfect number?",
+        prompt: prompt(
+          sms: sms_prompt("Which is the second perfect number??"),
+          ivr: tts_prompt("Which is the second perfect number")
+          ),
+        store: "Perfect Number",
+        skip_logic: numeric_skip_logic(min_value: 12345, max_value: 56789, ranges_delimiters: "25,75", ranges: []),
+        alphabetical_answers: false,
+        refusal: %{
+          "enabled" => false,
+          "responses" => %{
+            "ivr" => ["#", "12"]
+          }
+        }
+      )]
+    quiz = build(:questionnaire, steps: steps)
+    step = start_ivr(quiz)
+    assert {:ok, %Flow{}, reply} = step
+    assert Reply.num_digits(reply) == 5
   end
 
   test "retry step" do


### PR DESCRIPTION
There was a bug in `Ask.Runtime.Step` that considered refusal values for a step where refusal had been disabled. The list of values was empty, so this ended up introducing a `nil` value in the list, and an eventual internal crash.

fixes #2017 