### PR TITLE
Fix: performance issue in RespondentGroupAction.remove_duplicates_with_respect_to/2

### DIFF
--- a/priv/repo/migrations/20211213094856_add_index_to_respondents_canonical_phone_numbers.exs
+++ b/priv/repo/migrations/20211213094856_add_index_to_respondents_canonical_phone_numbers.exs
@@ -1,0 +1,11 @@
+defmodule Ask.Repo.Migrations.AddIndexToRespondentsCanonicalPhoneNumbers do
+  use Ecto.Migration
+
+  def up do
+    create index(:respondents, :canonical_phone_number)
+  end
+
+  def down do
+    drop index(:respondents, :canonical_phone_number)
+  end
+end


### PR DESCRIPTION
Adds an index to respondents.canonical_phone_numbers because we use
it to determine possible duplicates, and the table being huge
(several gigabytes) it takes dozens of minutes to execute a request.

Splits the query in batches, because Ecto seems to generate a
prepared statement such as `IN (?, ?, ?, ...) which eventually
reaches the limit of how many placeholders are allowed (65535).

fixes #2021
fixes [SURVEDA-MUMBAI-1E](https://sentry.io/organizations/instedd/issues/2852043788/?project=1497371)