### PR TITLE
Fix questionnaire download filenames

### DIFF
--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -269,10 +269,13 @@ defmodule Ask.QuestionnaireController do
     questionnaire = load_questionnaire_not_snapshot(project.id, id)
 
     zip_file = QuestionnaireAction.export_and_zip(questionnaire)
+    underscored_name = questionnaire.name
+      |> String.split # remove continuos spaces
+      |> Enum.join("_") # replace space with _
 
     conn = conn
            |> put_resp_content_type("application/octet-stream")
-           |> put_resp_header("content-disposition", "attachment; filename=#{questionnaire.id}.zip")
+           |> put_resp_header("content-disposition", "attachment; filename=#{questionnaire.id}-#{underscored_name}.zip")
            |> send_chunked(200)
 
     zip_file

--- a/web/static/js/reducers/questionnaire.js
+++ b/web/static/js/reducers/questionnaire.js
@@ -1574,8 +1574,8 @@ const addMessageToCsvForTranslation = (m, defaultLang, context) => {
 }
 
 export const csvTranslationFilename = (questionnaire: Questionnaire): string => {
-  const filename = (questionnaire.name || '').replace(/\W/g, '')
-  return filename + '_translations.csv'
+  const filename = (questionnaire.name || '').replace(/\s+/g, '_')
+  return `${questionnaire.id}-${filename}_translations.csv`
 }
 
 const addToCsvForTranslation = (text, context, func) => {


### PR DESCRIPTION
Related #2024 

For a questionnaire with the name "Example questionnaire", the following download-filenames are generated:

- `42-Example_questionnaire.zip` (when Export questionnaire)
- `42-Example_questionnaire_translations.csv` (when Download contents as csv)