### PR TITLE
Add move PanelSurveys to a folder

### DIFF
--- a/web/controllers/panel_survey_controller.ex
+++ b/web/controllers/panel_survey_controller.ex
@@ -80,4 +80,8 @@ defmodule Ask.PanelSurveyController do
       render(conn, "show.json", panel_survey: panel_survey)
     end
   end
+
+  def set_folder_id(conn, %{"project_id" => project_id, "panel_survey_id" => id, "folder_id" => folder_id}) do
+    send_resp(conn, :no_content, "")
+  end
 end

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -182,7 +182,9 @@ defmodule Ask.SurveyController do
       |> assoc(:surveys)
       |> Repo.get!(survey_id)
 
-    # Panel surveys can belong to a folder, but their occurences don't.
+    # Occurrences cannot change its folder.
+    # Although it's allowed when changing the Panel Survey's folder
+    # they belong to.
     if Survey.belongs_to_panel_survey?(survey), do: raise ConflictError
 
     old_folder_name = if survey.folder_id, do: Repo.get(Folder, survey.folder_id).name, else: "No Folder"
@@ -205,7 +207,6 @@ defmodule Ask.SurveyController do
         |> render(Ask.ChangesetView, "error.json", changeset: changeset)
     end
   end
-
 
   def set_name(conn, %{"project_id" => project_id, "survey_id" => survey_id, "name" => name}) do
     project =

--- a/web/models/activity_log.ex
+++ b/web/models/activity_log.ex
@@ -1,7 +1,14 @@
 defmodule Ask.ActivityLog do
   use Ask.Web, :model
   import User.Helper
-  alias Ask.{ActivityLog, Project, Survey, Questionnaire, Folder}
+  alias Ask.{
+    ActivityLog,
+    Folder,
+    PanelSurvey,
+    Project,
+    Questionnaire,
+    Survey
+  }
 
   schema "activity_log" do
     belongs_to :project, Ask.Project
@@ -21,6 +28,9 @@ defmodule Ask.ActivityLog do
   def valid_actions("survey"), do:
     ["create", "edit", "rename", "change_description", "lock", "unlock", "delete", "start", "repeat", "request_cancel", "completed_cancel", "download", "enable_public_link", "regenerate_public_link", "disable_public_link", "change_folder", "add_respondents"]
 
+  def valid_actions("panel_survey"), do:
+    ["panel_survey_change_folder"]
+
   def valid_actions("questionnaire"), do:
     ["create", "edit", "rename", "delete", "add_mode", "remove_mode", "add_language", "remove_language", "create_step", "delete_step", "rename_step", "edit_step", "edit_settings", "create_section", "rename_section", "delete_section", "edit_section", "archive", "unarchive"]
 
@@ -38,6 +48,7 @@ defmodule Ask.ActivityLog do
 
   defp typeof(%Project{}), do: "project"
   defp typeof(%Survey{}), do: "survey"
+  defp typeof(%PanelSurvey{}), do: "panel_survey"
   defp typeof(%Questionnaire{}), do: "questionnaire"
   defp typeof(%Folder{}), do: "folder"
 
@@ -301,5 +312,13 @@ defmodule Ask.ActivityLog do
   def update_archived_status(project, conn, questionnaire, archived) do
     action = if archived, do: "archive", else: "unarchive"
     create(action, project, conn, questionnaire, %{questionnaire_name: questionnaire.name})
+  end
+
+  def panel_survey_change_folder(project, conn, panel_survey, old_folder_name, new_folder_name) do
+    create("panel_survey_change_folder", project, conn, panel_survey, %{
+      panel_survey_name: panel_survey.name,
+      old_folder_name: old_folder_name,
+      new_folder_name: new_folder_name
+    })
   end
 end

--- a/web/models/survey.ex
+++ b/web/models/survey.ex
@@ -689,7 +689,9 @@ defmodule Ask.Survey do
 
   # Regular survey can always change its folder
   def movable?(%{panel_survey_id: nil} = _survey), do: true
-  # Panel survey occurrences can't change its folder (because they don't belong to folders)
+  # Panel survey occurrences can't change its folder by its own
+  # Changing a Panel Survey's folder, triggers
+  # the folder change for each of its occurrences
   def movable?(_survey), do: false
 
   defp only_occurrence_of_panel_survey?(%{panel_survey_id: nil} = _survey), do: false

--- a/web/router.ex
+++ b/web/router.ex
@@ -76,6 +76,7 @@ defmodule Ask.Router do
         end
         resources "/panel_surveys", PanelSurveyController, except: [:new, :edit] do
           post "/new_occurrence/", PanelSurveyController, :new_occurrence
+          post "/set_folder_id", PanelSurveyController, :set_folder_id
         end
         delete "/memberships/remove", MembershipController, :remove, as: :membership_remove
         put "/memberships/update", MembershipController, :update, as: :membership_update

--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -375,7 +375,7 @@ path.respondentsData.referenceStrokeColor15 { stroke: var(--reference-color15); 
     }
   }
   .dropdown-content {
-    min-width: 120px;
+    min-width: 150px;
   }
 
   .card-title {

--- a/web/static/js/actions/panelSurvey.js
+++ b/web/static/js/actions/panelSurvey.js
@@ -1,5 +1,6 @@
 // @flow
 import * as api from '../api'
+import * as panelSurveysActions from '../actions/panelSurveys'
 
 export const FETCH = 'PANEL_SURVEY_FETCH'
 export const RECEIVE = 'PANEL_SURVEY_RECEIVE'
@@ -33,3 +34,8 @@ export const receive = (panelSurvey: PanelSurvey) => ({
   type: RECEIVE,
   data: panelSurvey
 })
+
+export const changeFolder = (panelSurvey: PanelSurvey, folderId: number) => (dispatch: Function, getState: () => Store) => {
+  return api.panelSurveySetFolderId(panelSurvey.projectId, panelSurvey.id, folderId)
+    .then(() => dispatch(panelSurveysActions.folderChanged(panelSurvey.id, folderId)))
+}

--- a/web/static/js/actions/panelSurveys.js
+++ b/web/static/js/actions/panelSurveys.js
@@ -3,6 +3,7 @@ import * as panelSurveyActions from './panelSurvey'
 
 export const FETCH = 'PANEL_SURVEYS_FETCH'
 export const RECEIVE = 'PANEL_SURVEYS_RECEIVE'
+export const FOLDER_CHANGED = 'PANEL_SURVEY_FOLDER_CHANGED'
 
 export const fetchPanelSurveys = (projectId: number) => (dispatch: Function, getState: () => Store): Promise<?SurveyList> => {
   const state = getState()
@@ -32,4 +33,10 @@ export const receivePanelSurveys = (projectId: number, items: IndexedList<PanelS
   type: RECEIVE,
   projectId,
   items
+})
+
+export const folderChanged = (panelSurveyId: number, folderId: number) => ({
+  type: FOLDER_CHANGED,
+  panelSurveyId,
+  folderId
 })

--- a/web/static/js/actions/survey.js
+++ b/web/static/js/actions/survey.js
@@ -179,8 +179,7 @@ export const changeName = (newName: string) => (dispatch: Function, getState: ()
 
 export const changeFolder = (survey: Survey, folderId: number) => (dispatch: Function, getState: () => Store) => {
   return api.setFolderId(survey.projectId, survey.id, folderId)
-    .then(() => dispatch(surveysActions.folderChanged(survey.id, folderId))
-  )
+    .then(() => dispatch(surveysActions.folderChanged(survey.id, folderId)))
 }
 
 export const changeDescription = (newDescription: string) => (dispatch: Function, getState: () => Store) => {

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -288,8 +288,15 @@ export const updateSurvey = (projectId, survey) => {
 export const setSurveyName = (projectId, surveyId, name) => {
   return apiPostJSON(`projects/${projectId}/surveys/${surveyId}/set_name`, null, { name })
 }
+
 export const setFolderId = (projectId, surveyId, folderId) => {
   return apiPostJSON(`projects/${projectId}/surveys/${surveyId}/set_folder_id`, null, { folderId: folderId || null })
+}
+
+export const panelSurveySetFolderId = (projectId, panelSurveyId, folderId) => {
+  console.log("panelSurveySetFolderId")
+  console.log({projectId, panelSurveyId, folderId})
+  return apiPostJSON(`projects/${projectId}/panel_surveys/${panelSurveyId}/set_folder_id`, null, { folderId: folderId || null })
 }
 
 export const setSurveyDescription = (projectId, surveyId, description) => {

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -294,8 +294,6 @@ export const setFolderId = (projectId, surveyId, folderId) => {
 }
 
 export const panelSurveySetFolderId = (projectId, panelSurveyId, folderId) => {
-  console.log("panelSurveySetFolderId")
-  console.log({projectId, panelSurveyId, folderId})
   return apiPostJSON(`projects/${projectId}/panel_surveys/${panelSurveyId}/set_folder_id`, null, { folderId: folderId || null })
 }
 

--- a/web/static/js/components/folders/FolderShow.jsx
+++ b/web/static/js/components/folders/FolderShow.jsx
@@ -13,7 +13,6 @@ import { MainAction, Action, EmptyPage, ConfirmationModal, PagingFooter } from '
 import { SurveyCard, PanelSurveyCard } from '../surveys/SurveyCard'
 import * as routes from '../../routes'
 import { translate } from 'react-i18next'
-// import { surveyIndexProps } from '../surveys/SurveyIndex'
 
 class FolderShow extends Component<any, any> {
   state = {}
@@ -21,20 +20,24 @@ class FolderShow extends Component<any, any> {
     t: PropTypes.func,
     dispatch: PropTypes.func,
     router: PropTypes.object,
+    params: PropTypes.object,
+
     projectId: PropTypes.any.isRequired,
     project: PropTypes.object,
+
+    folderId: PropTypes.number,
+    folder: PropTypes.object,
     surveys: PropTypes.array,
+    panelSurveys: PropTypes.array,
+    surveysAndPanelSurveys: PropTypes.array,
+
     startIndex: PropTypes.number.isRequired,
     endIndex: PropTypes.number.isRequired,
     totalCount: PropTypes.number.isRequired,
-    params: PropTypes.object,
-    folderId: PropTypes.number,
-    // name: PropTypes.string,
+
     loadingFolder: PropTypes.bool,
     loadingSurveys: PropTypes.bool,
-    panelSurveys: PropTypes.array,
     loadingPanelSurveys: PropTypes.bool,
-    surveysAndPanelSurveys: PropTypes.array,
   }
 
   componentWillMount() {
@@ -246,6 +249,7 @@ const mapStateToProps = (state, ownProps) => {
     projectId,
     project: state.project.data,
 
+    folderId,
     folder,
     surveys,
     panelSurveys,

--- a/web/static/js/components/folders/FolderShow.jsx
+++ b/web/static/js/components/folders/FolderShow.jsx
@@ -112,7 +112,7 @@ class FolderShow extends Component<any, any> {
           <Action text={t('Panel Survey')} icon='repeat' onClick={() => this.newPanelSurvey()} />
         </MainActions>
 
-        <Title project={project} projectId={projectId} folder={folder}/>
+        <Title projectId={projectId} folder={folder}/>
 
         <MainView isReadOnly={readOnly}
                   isEmpty={isEmptyView}
@@ -120,7 +120,8 @@ class FolderShow extends Component<any, any> {
                   t={t}>
 
           <SurveysGrid surveysAndPanelSurveys={surveysAndPanelSurveys}
-                       isReadOnly={readOnly} />
+                       isReadOnly={readOnly}
+                       t={t} />
 
           <PagingFooter {...{ startIndex, endIndex, totalCount }}
                         onPreviousPage={() => this.previousPage()}
@@ -134,7 +135,7 @@ class FolderShow extends Component<any, any> {
 }
 
 const Title = (props) => {
-  const { project, projectId, folder } = props
+  const { projectId, folder } = props
 
   return folder.name
     ? (
@@ -173,54 +174,22 @@ const EmptyView = (props) => {
 }
 
 const SurveysGrid = (props) => {
-  const { surveysAndPanelSurveys, isReadOnly } = props
+  const { surveysAndPanelSurveys, isReadOnly, t } = props
 
   const isPanelSurvey = function (survey) {
     return survey.hasOwnProperty('occurrences')
   }
 
-  console.log("SurveysGrid")
-  console.log(surveysAndPanelSurveys)
-
   return (
     <div className='survey-index-grid'>
       {surveysAndPanelSurveys.map(survey => {
         return isPanelSurvey(survey)
-          ? <PanelSurveyCard panelSurvey={survey} key={`panelsurvey-${survey.id}`} readOnly={isReadOnly} />
-          : <SurveyCard survey={survey} key={`survey-${survey.id}`} readOnly={isReadOnly} />
+          ? <PanelSurveyCard panelSurvey={survey} key={`panelsurvey-${survey.id}`} readOnly={isReadOnly} t={t} />
+          : <SurveyCard survey={survey} key={`survey-${survey.id}`} readOnly={isReadOnly} t={t} />
       })}
     </div>
   )
 }
-
-// const mapStateToProps = (state, ownProps) => {
-//   const { params, t } = ownProps
-
-//   const folderId = params.folderId && parseInt(params.folderId)
-//   if (!folderId) throw new Error(t('Missing param: folderId'))
-//   const { surveys, startIndex, endIndex, totalCount } = surveyIndexProps(state, {
-//     folderId: folderId,
-//     panelSurveyId: null
-//   })
-//   const folders = state.folder && state.folder.folders
-//   const folder = folders && folders[folderId]
-//   // const name = folder && folder.name
-
-//   return {
-//     projectId: ownProps.params.projectId,
-//     folder,
-//     project: state.project.data,
-//     surveys,
-//     startIndex,
-//     endIndex,
-//     totalCount,
-//     loadingSurveys: state.surveys.fetching,
-//     loadingFolder: state.panelSurvey.loading || state.folder.loading,
-//     // name,
-//     panelSurveys: state.panelSurveys.items && Object.values(state.panelSurveys.items),
-//     loadingPanelSurveys: state.panelSurveys.fetching
-//   }
-// }
 
 const mapStateToSurveys = (state) => {
   let { items } = state.surveys
@@ -234,7 +203,7 @@ const mapStateToPanelSurveys = (state) => {
 
 const mapStateToProps = (state, ownProps) => {
   const { params, t } = ownProps
-  const { folderId } = params
+  const { projectId, folderId } = params
 
   let surveys = mapStateToSurveys(state)
   let panelSurveys = mapStateToPanelSurveys(state)
@@ -274,7 +243,7 @@ const mapStateToProps = (state, ownProps) => {
                  state.folder.folders[folderId]
 
   return {
-    projectId: ownProps.params.projectId,
+    projectId,
     project: state.project.data,
 
     folder,

--- a/web/static/js/components/surveys/PanelSurveyShow.jsx
+++ b/web/static/js/components/surveys/PanelSurveyShow.jsx
@@ -20,20 +20,22 @@ class PanelSurveyShow extends Component<any, any> {
     t: PropTypes.func,
     dispatch: PropTypes.func,
     router: PropTypes.object,
+    params: PropTypes.object,
+
     projectId: PropTypes.any.isRequired,
     project: PropTypes.object,
+
+    panelSurveyId: PropTypes.number.isRequired,
+    panelSurvey: PropTypes.object,
+
     surveys: PropTypes.array,
+
     startIndex: PropTypes.number.isRequired,
     endIndex: PropTypes.number.isRequired,
     totalCount: PropTypes.number.isRequired,
-    params: PropTypes.object,
-    panelSurveyId: PropTypes.number.isRequired,
-    name: PropTypes.string,
+
     loadingPanelSurvey: PropTypes.bool,
-    loadingSurveys: PropTypes.bool,
-    panelSurvey: PropTypes.object,
-    panelSurveys: PropTypes.array,
-    loadingPanelSurveys: PropTypes.bool
+    loadingSurveys: PropTypes.bool
   }
 
   componentWillMount() {
@@ -43,7 +45,7 @@ class PanelSurveyShow extends Component<any, any> {
 
     dispatch(actions.fetchSurveys(projectId))
     dispatch(folderActions.fetchFolders(projectId))
-    dispatch(panelSurveysActions.fetchPanelSurveys(projectId))
+    dispatch(panelSurveysActions.fetchPanelSurveys(projectId)) // TODO: check if necessary
     if (!panelSurvey) {
       dispatch(panelSurveyActions.fetchPanelSurvey(projectId, panelSurveyId))
     }
@@ -73,17 +75,6 @@ class PanelSurveyShow extends Component<any, any> {
     dispatch(actions.previousSurveysPage())
   }
 
-  // loadingMessage() {
-  //   const { loadingSurveys, t, panelSurvey } = this.props
-
-  //   if (!panelSurvey) {
-  //     return t('Loading panel survey...')
-  //   } else if (loadingSurveys) {
-  //     return t('Loading surveys...')
-  //   }
-  //   return null
-  // }
-
   render() {
     const {
       projectId,
@@ -98,10 +89,6 @@ class PanelSurveyShow extends Component<any, any> {
       totalCount,
       t
     } = this.props
-
-
-    console.log(panelSurvey)
-    console.log(loadingPanelSurvey)
 
     const isLoading = (!panelSurvey && loadingPanelSurvey) ||
                       (!surveys && loadingSurveys)
@@ -216,8 +203,8 @@ const mapStateToProps = (state, ownProps) => {
     projectId: projectId,
     project: state.project.data,
 
-    panelSurvey,
     panelSurveyId,
+    panelSurvey,
 
     surveys,
 
@@ -229,49 +216,5 @@ const mapStateToProps = (state, ownProps) => {
     loadingSurveys: state.surveys.fetching
   }
 }
-
-// const mapStateToProps = (state, ownProps) => {
-//   const { params, t } = ownProps
-//   const { projectId, panelSurveyId } = params
-
-//   const panelSurveyId = params.panelSurveyId && parseInt(params.panelSurveyId)
-//   if (!panelSurveyId) throw new Error(t('Missing param: panelSurveyId'))
-
-//   let panelSurvey = null
-//   if (state.panelSurvey.data && state.panelSurvey.data.id == panelSurveyId) {
-//     panelSurvey = state.panelSurvey.data
-//   }
-//   const name = panelSurvey && panelSurvey.name || t('Untitled panel survey')
-
-//   const occurrences = panelSurvey ? panelSurvey.occurrences : null
-
-//   // NOTE: we fake pagination (backend doesn't paginate, yet)
-//   let totalCount = occurrences ? occurrences.length : 0
-//   const pageIndex = 0
-//   const pageSize = totalCount
-//   const startIndex = Math.min(totalCount, pageIndex + 1)
-//   const endIndex = Math.min(pageIndex + pageSize, totalCount)
-
-//   return {
-//     projectId: projectId,
-//     project: state.project.data,
-
-//     panelSurvey,
-//     panelSurveyId,
-
-//     surveys: occurrences,
-
-//     startIndex,
-//     endIndex,
-//     totalCount,
-
-//     loadingPanelSurvey: state.panelSurvey.loading || state.folder.loading,
-//     loadingSurveys: state.surveys.fetching,
-
-//     // name,
-//     // panelSurveys: state.panelSurveys.items && Object.values(state.panelSurveys.items),
-//     // loadingPanelSurveys: state.panelSurveys.fetching
-//   }
-// }
 
 export default translate()(withRouter(connect(mapStateToProps)(PanelSurveyShow)))

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -164,12 +164,12 @@ class SurveyCard extends Component<any> {
         {
           showAsPanelSurveyCard
           ? <div className='panel-survey-card-0'>
-            <div className='panel-survey-card-1'>
-              <div className='panel-survey-card-2'>
-                { surveyCard }
+              <div className='panel-survey-card-1'>
+                <div className='panel-survey-card-2'>
+                  { surveyCard }
+                </div>
               </div>
             </div>
-          </div>
           : surveyCard
         }
         <ConfirmationModal modalId='survey_index_move_survey' ref='moveSurveyConfirmationModal' confirmationText={t('Move')} header={t('Move survey')} showCancel />

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -4,6 +4,7 @@ import { translate, Trans } from 'react-i18next'
 import { Link } from 'react-router'
 import * as routes from '../../routes'
 import * as surveyActions from '../../actions/survey'
+import * as panelSurveyActions from '../../actions/panelSurvey'
 import { fetchRespondentsStats } from '../../actions/respondents'
 import { untitledSurveyTitle } from './SurveyTitle'
 import { Card, UntitledIfEmpty, Dropdown, DropdownItem, ConfirmationModal } from '../ui'
@@ -146,11 +147,7 @@ class _PanelSurveyCard extends Component<any> {
       onConfirm: () => {
         const { dispatch } = this.props
         const { folderId } = this.state
-
-        console.log("HEEEEEY MOVE THE PANEL!!")
-        console.log(folderId)
-
-        // dispatch(surveyActions.changeFolder(survey, folderId))
+        dispatch(panelSurveyActions.changeFolder(panelSurvey, folderId))
       }
     })
   }
@@ -179,8 +176,6 @@ class _PanelSurveyCard extends Component<any> {
 
   // The option Delete on the PanelSurveyCard means:
   // delete the last wave in the PanelSurvey
-  // TODO: we cannot delete all the waves!
-  // (ie leave the PanelSurvey without any waves)
   deletable() {
     const { readOnly } = this.props
     const survey = this.lastWave()

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -133,21 +133,26 @@ class _PanelSurveyCard extends Component<any> {
     return [...panelSurvey.occurrences].pop() // TODO
   }
 
-
-  // changeFolder = (folderId) => this.setState({ folderId })
+  changeFolder(folderId) {
+    this.setState({ folderId })
+  }
 
   moveSurvey = () => {
-    // const moveSurveyConfirmationModal: ConfirmationModal = this.refs.moveSurveyConfirmationModal
-    // const { survey } = this.props
-    // const modalText = <MoveSurveyForm defaultFolderId={survey.folderId} onChangeFolderId={folderId => this.changeFolder(folderId)} />
-    // moveSurveyConfirmationModal.open({
-    //   modalText: modalText,
-    //   onConfirm: () => {
-    //     const { dispatch } = this.props
-    //     const { folderId } = this.state
-    //     dispatch(surveyActions.changeFolder(survey, folderId))
-    //   }
-    // })
+    const { panelSurvey } = this.props
+
+    const moveSurveyConfirmationModal: ConfirmationModal = this.refs.moveSurveyConfirmationModal
+    moveSurveyConfirmationModal.open({
+      modalText: <MoveSurveyForm defaultFolderId={panelSurvey.folderId} onChangeFolderId={folderId => this.changeFolder(folderId)} />,
+      onConfirm: () => {
+        const { dispatch } = this.props
+        const { folderId } = this.state
+
+        console.log("HEEEEEY MOVE THE PANEL!!")
+        console.log(folderId)
+
+        // dispatch(surveyActions.changeFolder(survey, folderId))
+      }
+    })
   }
 
   deleteSurvey = () => {
@@ -172,13 +177,20 @@ class _PanelSurveyCard extends Component<any> {
     })
   }
 
+  // The option Delete on the PanelSurveyCard means:
+  // delete the last wave in the PanelSurvey
+  // TODO: we cannot delete all the waves!
+  // (ie leave the PanelSurvey without any waves)
   deletable() {
     const { readOnly } = this.props
-    return !readOnly
+    const survey = this.lastWave()
+
+    return !readOnly && survey.isDeletable
   }
 
   movable() {
-    return false
+    const { readOnly } = this.props
+    return !readOnly
   }
 
   actionable() {

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -32,10 +32,6 @@ class _SurveyCard extends Component<any> {
 
   componentDidMount() {
     const { survey, dispatch } = this.props
-
-    console.log("SurveyCard")
-    console.log(dispatch)
-
     if (survey.state != 'not_ready') {
       fetchRespondentsStats(survey.projectId, survey.id)(dispatch)
     }

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -13,15 +13,12 @@ import MoveSurveyForm from './MoveSurveyForm'
 
 import { connect } from 'react-redux'
 
-class SurveyCard extends Component<any> {
+class _SurveyCard extends Component<any> {
   props: {
     t: Function,
     dispatch: Function,
-    respondentsStats: ?Object,
     survey: Survey,
-    onDelete: (survey: Survey) => void,
-    readOnly: boolean,
-    panelSurveyId: ?number
+    readOnly: boolean
   };
 
   constructor(props) {
@@ -34,6 +31,9 @@ class SurveyCard extends Component<any> {
 
   componentDidMount() {
     const { survey, dispatch } = this.props
+
+    console.log("SurveyCard")
+    console.log(dispatch)
 
     if (survey.state != 'not_ready') {
       fetchRespondentsStats(survey.projectId, survey.id)(dispatch)
@@ -77,14 +77,12 @@ class SurveyCard extends Component<any> {
 
   deletable() {
     const { survey, readOnly } = this.props
-    if (readOnly) return false
-    return survey.isDeletable
+    return !readOnly && survey.isDeletable
   }
 
   movable() {
     const { survey, readOnly } = this.props
-    if (readOnly) return false
-    return survey.isMovable
+    return !readOnly && survey.isMovable
   }
 
   actionable() {
@@ -92,86 +90,123 @@ class SurveyCard extends Component<any> {
   }
 
   render() {
-    const { survey, respondentsStats, t, panelSurveyId } = this.props
+    const { survey, t, dispatch } = this.props
     const { panelSurvey } = survey
 
-    let cumulativePercentages = respondentsStats ? (respondentsStats['cumulativePercentages'] || {}) : {}
-    let completionPercentage = respondentsStats ? (respondentsStats['completionPercentage'] || 0) : 0
-
-    let description = <div className='grey-text card-description'>
-      {survey.description}
-    </div>
-
-    const redirectTo = panelSurvey
-    ? routes.panelSurvey(panelSurvey.projectId, panelSurvey.id)
-    : routes.showOrEditSurvey(survey)
-
-    const name = panelSurvey ? panelSurvey.name : survey.name
-
-    const actionMenu = (
-      <Dropdown className='options' dataBelowOrigin={false} label={<i className='material-icons'>more_vert</i>}>
-        <DropdownItem className='dots'>
-          <i className='material-icons'>more_vert</i>
-        </DropdownItem>
-        {
-          this.movable()
-          ? <DropdownItem>
-            <a onClick={e => this.moveSurvey()}><i className='material-icons'>folder</i>{t('Move to')}</a>
-          </DropdownItem>
-          : null
-        }
-        {
-          this.deletable()
-            ? <DropdownItem>
-              <a onClick={e => this.deleteSurvey()}><i className='material-icons'>delete</i>{t('Delete')}</a>
-            </DropdownItem>
-            : null
-        }
-      </Dropdown>
-    )
-
-    const surveyCard = <div className='survey-card'>
-      <Card>
-        <div className='card-content'>
-          <div className='survey-card-status'>
-            <Link className='grey-text' to={redirectTo}>
-              {t('{{percentage}}% of target completed', {percentage: String(Math.round(completionPercentage))})}
-            </Link>
-            { this.actionable() ? actionMenu : null }
-          </div>
-          <div className='card-chart'>
-            <RespondentsChart cumulativePercentages={cumulativePercentages} />
-          </div>
-          <div className='card-status'>
-            <Link className='card-title black-text truncate' title={name} to={redirectTo}>
-              <UntitledIfEmpty text={name} emptyText={untitledSurveyTitle(survey, t)} />
-            </Link>
-            <Link to={redirectTo}>
-              {description}
-              <SurveyStatus survey={survey} short />
-            </Link>
-          </div>
-        </div>
-      </Card>
-    </div>
-
-    const inPanelSurveyIndex = !!panelSurveyId
-    const isWaveOfPanelSurvey = panelSurvey || survey.generatesPanelSurvey
-    const showAsPanelSurveyCard = !inPanelSurveyIndex && isWaveOfPanelSurvey
+    let actions = []
+    if (this.movable()) actions.push({ name: t('Move to'), func: this.moveSurvey })
+    if (this.deletable()) actions.push({ name: t('Delete'), func: this.deleteSurvey })
 
     return (
       <div className='col s12 m6 l4'>
-        {
-          showAsPanelSurveyCard
-          ? <div className='panel-survey-card-0'>
-              <div className='panel-survey-card-1'>
-                <div className='panel-survey-card-2'>
-                  { surveyCard }
-                </div>
-              </div>
+        <InnerSurveyCard survey={survey}
+                         actions={actions}
+                         onClickRoute={routes.showOrEditSurvey(survey)}
+                         t={t}
+                         dispatch={dispatch}/>
+
+        <ConfirmationModal modalId='survey_index_move_survey' ref='moveSurveyConfirmationModal' confirmationText={t('Move')} header={t('Move survey')} showCancel />
+        <ConfirmationModal modalId='survey_index_delete' ref='deleteConfirmationModal' confirmationText={t('Delete')} header={t('Delete survey')} showCancel />
+      </div>
+    )
+  }
+}
+class _PanelSurveyCard extends Component<any> {
+  props: {
+    t: Function,
+    dispatch: Function,
+    panelSurvey: Survey,
+    readOnly: boolean,
+  };
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      folderId: props.panelSurvey.folderId || ''
+    }
+  }
+
+  lastWave() {
+    const { panelSurvey } = this.props
+
+    return [...panelSurvey.occurrences].pop() // TODO
+  }
+
+
+  // changeFolder = (folderId) => this.setState({ folderId })
+
+  moveSurvey = () => {
+    // const moveSurveyConfirmationModal: ConfirmationModal = this.refs.moveSurveyConfirmationModal
+    // const { survey } = this.props
+    // const modalText = <MoveSurveyForm defaultFolderId={survey.folderId} onChangeFolderId={folderId => this.changeFolder(folderId)} />
+    // moveSurveyConfirmationModal.open({
+    //   modalText: modalText,
+    //   onConfirm: () => {
+    //     const { dispatch } = this.props
+    //     const { folderId } = this.state
+    //     dispatch(surveyActions.changeFolder(survey, folderId))
+    //   }
+    // })
+  }
+
+  deleteSurvey = () => {
+    const deleteConfirmationModal: ConfirmationModal = this.refs.deleteConfirmationModal
+    const { t, panelSurvey } = this.props
+
+    const survey = this.lastWave()
+
+    deleteConfirmationModal.open({
+      modalText: <span>
+        <p>
+          <Trans>
+            Are you sure you want to delete the last wave <b><UntitledIfEmpty text={survey.name} emptyText={untitledSurveyTitle(survey, t)} /></b>?
+          </Trans>
+        </p>
+        <p>{t('All the respondent information will be lost and cannot be undone.')}</p>
+      </span>,
+      onConfirm: () => {
+        const { dispatch } = this.props
+        dispatch(surveyActions.deleteSurvey(survey))
+      }
+    })
+  }
+
+  deletable() {
+    const { readOnly } = this.props
+    return !readOnly
+  }
+
+  movable() {
+    return false
+  }
+
+  actionable() {
+    return this.deletable() || this.movable()
+  }
+
+  render() {
+    const { panelSurvey, t, dispatch } = this.props
+    const survey = this.lastWave()
+
+    let actions = []
+    if (this.movable()) actions.push({ name: t('Move to'), func: this.moveSurvey })
+    if (this.deletable()) actions.push({ name: t('Delete wave'), func: this.deleteSurvey })
+
+    return (
+      <div className='col s12 m6 l4'>
+        <div className='panel-survey-card-0'>
+          <div className='panel-survey-card-1'>
+            <div className='panel-survey-card-2'>
+              <InnerSurveyCard survey={survey}
+                               actions={actions}
+                               onClickRoute={routes.panelSurvey(survey.projectId, panelSurvey.id)}
+                               t={t}
+                               dispatch={dispatch}/>
             </div>
-          : surveyCard
-        }
+          </div>
+        </div>
+
         <ConfirmationModal modalId='survey_index_move_survey' ref='moveSurveyConfirmationModal' confirmationText={t('Move')} header={t('Move survey')} showCancel />
         <ConfirmationModal modalId='survey_index_delete' ref='deleteConfirmationModal' confirmationText={t('Delete')} header={t('Delete survey')} showCancel />
       </div>
@@ -179,4 +214,87 @@ class SurveyCard extends Component<any> {
   }
 }
 
-export default translate()(connect()(SurveyCard))
+class InnerSurveyCard extends Component<any> {
+  props: {
+    survey: Survey,
+    actions: Array<Object>,
+    onClickRoute: Function,
+    t: Function,
+    respondentsStats: ?Object,
+    dispatch: Function
+  };
+
+  constructor(props) {
+    super(props)
+  }
+
+  componentDidMount() {
+    const { survey, dispatch } = this.props
+
+    if (survey.state != 'not_ready') {
+      fetchRespondentsStats(survey.projectId, survey.id)(dispatch)
+    }
+  }
+
+  render() {
+    const { survey, respondentsStats, actions, onClickRoute, t } = this.props
+
+    // stats
+    let cumulativePercentages = respondentsStats ? (respondentsStats['cumulativePercentages'] || {}) : {}
+    let completionPercentage = respondentsStats ? (respondentsStats['completionPercentage'] || 0) : 0
+
+    return (
+      <div className='survey-card'>
+        <Card>
+          <div className='card-content'>
+            <div className='survey-card-status'>
+              <Link className='grey-text' to={onClickRoute}>
+                {t('{{percentage}}% of target completed', { percentage: String(Math.round(completionPercentage)) })}
+              </Link>
+              <ActionMenu actions={actions} />
+            </div>
+            <div className='card-chart'>
+              <RespondentsChart cumulativePercentages={cumulativePercentages} />
+            </div>
+            <div className='card-status'>
+              <Link className='card-title black-text truncate' title={survey.name} to={onClickRoute}>
+                <UntitledIfEmpty text={survey.name} emptyText={untitledSurveyTitle(survey, t)} />
+              </Link>
+              <Link to={onClickRoute}>
+                <div className='grey-text card-description'>
+                  {survey.description}
+                </div>
+                <SurveyStatus survey={survey} short />
+              </Link>
+            </div>
+          </div>
+        </Card>
+      </div>
+    )
+  }
+}
+
+const ActionMenu = (props) => {
+  const  { actions } = props
+
+  if (actions.length === 0) return null
+
+  return (
+    <Dropdown className='options' dataBelowOrigin={false} label={<i className='material-icons'>more_vert</i>}>
+      <DropdownItem className='dots'>
+        <i className='material-icons'>more_vert</i>
+      </DropdownItem>
+      { actions.map((action, index) => (
+        <DropdownItem key={index}>
+          <a onClick={e => action.func()}>
+            <i className='material-icons'>folder</i>
+            {action.name}
+          </a>
+        </DropdownItem>
+      ))}
+    </Dropdown>
+  )
+}
+
+export const SurveyCard = translate()(connect()(_SurveyCard))
+export const PanelSurveyCard = translate()(connect()(_PanelSurveyCard))

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -17,7 +17,7 @@ import {
   Action
 } from '../ui'
 import FolderCard from '../folders/FolderCard'
-import SurveyCard from './SurveyCard'
+import { SurveyCard, PanelSurveyCard } from './SurveyCard'
 import * as channelsActions from '../../actions/channels'
 import FolderForm from './FolderForm'
 import * as routes from '../../routes'
@@ -235,23 +235,21 @@ const FoldersGrid = (props) => {
 
 const SurveysGrid = (props) => {
   const { surveysAndPanelSurveys, isReadOnly } = props
+
+  const isPanelSurvey = function(survey) {
+    return survey.hasOwnProperty('occurrences')
+  }
+
   return (
     <div className='survey-index-grid'>
-      {surveysAndPanelSurveys.map(survey => (
-        <SurveyCard survey={survey} key={survey.id} readOnly={isReadOnly} />
-      ))}
+      { surveysAndPanelSurveys.map(survey =>  {
+          return isPanelSurvey(survey)
+            ? <PanelSurveyCard panelSurvey={survey} key={`panelsurvey-${survey.id}`} readOnly={isReadOnly} />
+            : <SurveyCard survey={survey} key={`survey-${survey.id}`} readOnly={isReadOnly} />
+        })}
     </div>
   )
 }
-
-// const surveysFromState = (state, folderId, includePanelSurveys = false) => {
-//   const { items } = state.surveys
-//   if (!items) return null
-//   return values(items).filter(survey =>
-//     survey.folderId == folderId &&
-//     (includePanelSurveys || !survey.panelSurveyId)
-//   )
-// }
 
 // const panelSurveysFromState = (state, folderId) => {
 //   const surveys = surveysFromState(state, folderId, true)
@@ -264,47 +262,6 @@ const SurveysGrid = (props) => {
 //   }))
 // }
 
-// const mergePanelSurveysIntoSurveys = (surveys, panelSurveys) => {
-//   if (panelSurveys == null) return surveys
-//   return panelSurveys.map(panelSurvey => ({
-//     ...panelSurvey.latestSurvey,
-//     folderId: panelSurvey.folderId,
-//     panelSurvey: panelSurvey
-//   })).concat(surveys)
-// }
-
-// const surveyIndexProps = (state) => {
-//   // If panelSurveyId, list the surveys for the panel survey view.
-//   // The panel survey view is the only one that shows every panel survey occurrence.
-//   // Other views show each panel survey grouped in a single card.
-//   let surveys = surveysFromState(state, folderId, !!panelSurveyId)
-//   if (!panelSurveyId) {
-//     surveys = mergePanelSurveysIntoSurveys(surveys, panelSurveysFromState(state, folderId))
-//   }
-//   const totalCount = surveys ? surveys.length : 0
-//   const pageIndex = state.surveys.page.index
-//   const pageSize = state.surveys.page.size
-
-//   if (surveys) {
-//     if (folderId) {
-//       surveys = surveys.filter(s => s.folderId == folderId)
-//     }
-
-//     // Sort by updated at, descending
-//     surveys = surveys.sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
-//     // Show only the current page
-//     surveys = surveys.slice(pageIndex, pageIndex + pageSize)
-//   }
-//   const startIndex = Math.min(totalCount, pageIndex + 1)
-//   const endIndex = Math.min(pageIndex + pageSize, totalCount)
-
-//   return {
-//     surveys,
-//     startIndex,
-//     endIndex,
-//     totalCount
-//   }
-// }
 // export const surveyIndexProps = (state: any, { panelSurveyId, folderId }: { panelSurveyId: ?number, folderId: ?number} = {
 //   panelSurveyId: null,
 //   folderId: null
@@ -358,8 +315,9 @@ const mapStateToProps = (state, ownProps) => {
   // merge all together to sort by date
   // At the same time remove surveys inside PanelSurvey (ie waves)
   // PanelSurvey is shown as a group and its waves are not shown in this view
+  // And also remove surveys inside Folders
   let surveysAndPanelSurveys = [
-    ...surveys.filter((survey) => (!survey.panelSurveyId)),
+    ...surveys.filter(survey => (!survey.panelSurveyId && !survey.folderId)),
     ...panelSurveys
   ]
 

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -316,9 +316,10 @@ const mapStateToProps = (state, ownProps) => {
   // At the same time remove surveys inside PanelSurvey (ie waves)
   // PanelSurvey is shown as a group and its waves are not shown in this view
   // And also remove surveys inside Folders
+  // And also remove panel surveys inside Folders
   let surveysAndPanelSurveys = [
     ...surveys.filter(survey => (!survey.panelSurveyId && !survey.folderId)),
-    ...panelSurveys
+    ...panelSurveys.filter(panelSurvey => (!panelSurvey.folderId))
   ]
 
   // Sort by updated_at (descending)

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -32,18 +32,22 @@ class SurveyIndex extends Component<any, State> {
     t: PropTypes.func,
     dispatch: PropTypes.func,
     router: PropTypes.object,
+
     projectId: PropTypes.any.isRequired,
     project: PropTypes.object,
-    surveys: PropTypes.array,
+
     folders: PropTypes.array,
-    loadingFolders: PropTypes.bool,
-    loadingSurveys: PropTypes.bool,
+    surveys: PropTypes.array,
+    panelSurveys: PropTypes.array,
+    surveysAndPanelSurveys: PropTypes.array,
+
     startIndex: PropTypes.number.isRequired,
     endIndex: PropTypes.number.isRequired,
     totalCount: PropTypes.number.isRequired,
-    panelSurveys: PropTypes.array,
+
+    loadingFolders: PropTypes.bool,
+    loadingSurveys: PropTypes.bool,
     loadingPanelSurveys: PropTypes.bool,
-    surveysAndPanelSurveys: PropTypes.array,
   }
 
   constructor(props) {
@@ -247,53 +251,6 @@ const SurveysGrid = (props) => {
     </div>
   )
 }
-
-// const panelSurveysFromState = (state, folderId) => {
-//   const surveys = surveysFromState(state, folderId, true)
-//   if (!surveys) return null
-//   const { items } = state.panelSurveys
-//   if (!items) return null
-//   return values(items).filter(panelSurvey => panelSurvey.folderId == folderId).map(panelSurvey => ({
-//     ...panelSurvey,
-//     latestSurvey: [...panelSurvey.occurrences].pop()
-//   }))
-// }
-
-// export const surveyIndexProps = (state: any, { panelSurveyId, folderId }: { panelSurveyId: ?number, folderId: ?number} = {
-//   panelSurveyId: null,
-//   folderId: null
-// }) => {
-//   // If panelSurveyId, list the surveys for the panel survey view.
-//   // The panel survey view is the only one that shows every panel survey occurrence.
-//   // Other views show each panel survey grouped in a single card.
-//   let surveys = surveysFromState(state, folderId, !!panelSurveyId)
-//   if (!panelSurveyId) {
-//     surveys = mergePanelSurveysIntoSurveys(surveys, panelSurveysFromState(state, folderId))
-//   }
-//   const totalCount = surveys ? surveys.length : 0
-//   const pageIndex = state.surveys.page.index
-//   const pageSize = state.surveys.page.size
-
-//   if (surveys) {
-//     if (folderId) {
-//       surveys = surveys.filter(s => s.folderId == folderId)
-//     }
-
-//     // Sort by updated at, descending
-//     surveys = surveys.sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
-//     // Show only the current page
-//     surveys = surveys.slice(pageIndex, pageIndex + pageSize)
-//   }
-//   const startIndex = Math.min(totalCount, pageIndex + 1)
-//   const endIndex = Math.min(pageIndex + pageSize, totalCount)
-
-//   return {
-//     surveys,
-//     startIndex,
-//     endIndex,
-//     totalCount
-//   }
-// }
 
 const mapStateToSurveys = (state) => {
   let { items } = state.surveys

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -42,7 +42,9 @@ class SurveyIndex extends Component<any, State> {
     endIndex: PropTypes.number.isRequired,
     totalCount: PropTypes.number.isRequired,
     panelSurveys: PropTypes.array,
-    loadingPanelSurveys: PropTypes.bool
+    loadingPanelSurveys: PropTypes.bool,
+
+    surveysAndPanelSurveys: PropTypes.array,
   }
 
   constructor(props) {
@@ -129,11 +131,30 @@ class SurveyIndex extends Component<any, State> {
   }
 
   render() {
-    const { folders, loadingFolders, loadingSurveys, surveys, project, startIndex, endIndex, totalCount, t, panelSurveys, loadingPanelSurveys } = this.props
-    if ((!surveys && loadingSurveys) || (!folders && loadingFolders) || (!panelSurveys && loadingPanelSurveys)) {
-      return (
-        <div>{t('Loading surveys...')}</div>
-      )
+    console.log("render")
+    const {
+      project,
+      folders,
+      loadingFolders,
+      surveys,
+      loadingSurveys,
+      panelSurveys,
+      loadingPanelSurveys,
+      surveysAndPanelSurveys,
+      startIndex,
+      endIndex,
+      totalCount,
+      t
+    } = this.props
+
+    const isLoading = (!surveys && loadingSurveys) ||
+                      (!folders && loadingFolders) ||
+                      (!panelSurveys && loadingPanelSurveys)
+
+    console.log("render 2")
+
+    if (isLoading) {
+      return (<div>{ t('Loading surveys...') }</div>)
     }
 
     const readOnly = !project || project.readOnly
@@ -166,7 +187,7 @@ class SurveyIndex extends Component<any, State> {
 
     const surveysGrid = (
       <div className='survey-index-grid'>
-        {surveys && surveys.map(survey => (
+        {surveysAndPanelSurveys.map(survey => (
           <SurveyCard survey={survey} key={survey.id} readOnly={readOnly} />
         ))}
       </div>
@@ -176,6 +197,8 @@ class SurveyIndex extends Component<any, State> {
       {...{ startIndex, endIndex, totalCount }}
       onPreviousPage={() => this.previousPage()}
       onNextPage={() => this.nextPage()} />
+
+    console.log("render 3")
 
     return (
       <div>
@@ -196,73 +219,151 @@ class SurveyIndex extends Component<any, State> {
   }
 }
 
-const surveysFromState = (state, folderId, includePanelSurveys = false) => {
-  const { items } = state.surveys
-  if (!items) return null
-  return values(items).filter(survey =>
-    survey.folderId == folderId &&
-    (includePanelSurveys || !survey.panelSurveyId)
-  )
+// const surveysFromState = (state, folderId, includePanelSurveys = false) => {
+//   const { items } = state.surveys
+//   if (!items) return null
+//   return values(items).filter(survey =>
+//     survey.folderId == folderId &&
+//     (includePanelSurveys || !survey.panelSurveyId)
+//   )
+// }
+
+// const panelSurveysFromState = (state, folderId) => {
+//   const surveys = surveysFromState(state, folderId, true)
+//   if (!surveys) return null
+//   const { items } = state.panelSurveys
+//   if (!items) return null
+//   return values(items).filter(panelSurvey => panelSurvey.folderId == folderId).map(panelSurvey => ({
+//     ...panelSurvey,
+//     latestSurvey: [...panelSurvey.occurrences].pop()
+//   }))
+// }
+
+// const mergePanelSurveysIntoSurveys = (surveys, panelSurveys) => {
+//   if (panelSurveys == null) return surveys
+//   return panelSurveys.map(panelSurvey => ({
+//     ...panelSurvey.latestSurvey,
+//     folderId: panelSurvey.folderId,
+//     panelSurvey: panelSurvey
+//   })).concat(surveys)
+// }
+
+// const surveyIndexProps = (state) => {
+//   // If panelSurveyId, list the surveys for the panel survey view.
+//   // The panel survey view is the only one that shows every panel survey occurrence.
+//   // Other views show each panel survey grouped in a single card.
+//   let surveys = surveysFromState(state, folderId, !!panelSurveyId)
+//   if (!panelSurveyId) {
+//     surveys = mergePanelSurveysIntoSurveys(surveys, panelSurveysFromState(state, folderId))
+//   }
+//   const totalCount = surveys ? surveys.length : 0
+//   const pageIndex = state.surveys.page.index
+//   const pageSize = state.surveys.page.size
+
+//   if (surveys) {
+//     if (folderId) {
+//       surveys = surveys.filter(s => s.folderId == folderId)
+//     }
+
+//     // Sort by updated at, descending
+//     surveys = surveys.sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
+//     // Show only the current page
+//     surveys = surveys.slice(pageIndex, pageIndex + pageSize)
+//   }
+//   const startIndex = Math.min(totalCount, pageIndex + 1)
+//   const endIndex = Math.min(pageIndex + pageSize, totalCount)
+
+//   return {
+//     surveys,
+//     startIndex,
+//     endIndex,
+//     totalCount
+//   }
+// }
+// export const surveyIndexProps = (state: any, { panelSurveyId, folderId }: { panelSurveyId: ?number, folderId: ?number} = {
+//   panelSurveyId: null,
+//   folderId: null
+// }) => {
+//   // If panelSurveyId, list the surveys for the panel survey view.
+//   // The panel survey view is the only one that shows every panel survey occurrence.
+//   // Other views show each panel survey grouped in a single card.
+//   let surveys = surveysFromState(state, folderId, !!panelSurveyId)
+//   if (!panelSurveyId) {
+//     surveys = mergePanelSurveysIntoSurveys(surveys, panelSurveysFromState(state, folderId))
+//   }
+//   const totalCount = surveys ? surveys.length : 0
+//   const pageIndex = state.surveys.page.index
+//   const pageSize = state.surveys.page.size
+
+//   if (surveys) {
+//     if (folderId) {
+//       surveys = surveys.filter(s => s.folderId == folderId)
+//     }
+
+//     // Sort by updated at, descending
+//     surveys = surveys.sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
+//     // Show only the current page
+//     surveys = surveys.slice(pageIndex, pageIndex + pageSize)
+//   }
+//   const startIndex = Math.min(totalCount, pageIndex + 1)
+//   const endIndex = Math.min(pageIndex + pageSize, totalCount)
+
+//   return {
+//     surveys,
+//     startIndex,
+//     endIndex,
+//     totalCount
+//   }
+// }
+
+const mapStateToSurveys = (state) => {
+  console.log("mapStateToSurveys")
+
+  let { items } = state.surveys
+  console.log(items && values(items))
+  return items ? values(items) : []
 }
 
-const panelSurveysFromState = (state, folderId) => {
-  const surveys = surveysFromState(state, folderId, true)
-  if (!surveys) return null
-  const { items } = state.panelSurveys
-  if (!items) return null
-  return values(items).filter(panelSurvey => panelSurvey.folderId == folderId).map(panelSurvey => ({
-    ...panelSurvey,
-    latestSurvey: [...panelSurvey.occurrences].pop()
-  }))
-}
+const mapStateToPanelSurveys = (state) => {
+  console.log("mapStateToPanelSurveys")
 
-const mergePanelSurveysIntoSurveys = (surveys, panelSurveys) => {
-  if (panelSurveys == null) return surveys
-  return panelSurveys.map(panelSurvey => ({
-    ...panelSurvey.latestSurvey,
-    folderId: panelSurvey.folderId,
-    panelSurvey: panelSurvey
-  })).concat(surveys)
-}
-
-export const surveyIndexProps = (state: any, { panelSurveyId, folderId }: { panelSurveyId: ?number, folderId: ?number} = {
-  panelSurveyId: null,
-  folderId: null
-}) => {
-  // If panelSurveyId, list the surveys for the panel survey view.
-  // The panel survey view is the only one that shows every panel survey occurrence.
-  // Other views show each panel survey grouped in a single card.
-  let surveys = surveysFromState(state, folderId, !!panelSurveyId)
-  if (!panelSurveyId) {
-    surveys = mergePanelSurveysIntoSurveys(surveys, panelSurveysFromState(state, folderId))
-  }
-  const totalCount = surveys ? surveys.length : 0
-  const pageIndex = state.surveys.page.index
-  const pageSize = state.surveys.page.size
-
-  if (surveys) {
-    if (folderId) {
-      surveys = surveys.filter(s => s.folderId == folderId)
-    }
-
-    // Sort by updated at, descending
-    surveys = surveys.sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
-    // Show only the current page
-    surveys = surveys.slice(pageIndex, pageIndex + pageSize)
-  }
-  const startIndex = Math.min(totalCount, pageIndex + 1)
-  const endIndex = Math.min(pageIndex + pageSize, totalCount)
-
-  return {
-    surveys,
-    startIndex,
-    endIndex,
-    totalCount
-  }
+  let { items } = state.panelSurveys
+  console.log(items && values(items))
+  return items ? values(items) : []
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const { surveys, startIndex, endIndex, totalCount } = surveyIndexProps(state)
+
+  console.log("mapStateToProps")
+
+  let surveys = mapStateToSurveys(state)
+  let panelSurveys = mapStateToPanelSurveys(state)
+
+  // merge all together to sort by date
+  // at the same time remove surveys inside PanelSurvey (ie waves)
+  // PanelSurvey is shown as a group and its waves are not shown in this view
+  let surveysAndPanelSurveys = [
+    ...surveys.filter((survey) => (!survey.panelSurveyId)),
+    ...panelSurveys
+  ]
+
+  console.log(surveysAndPanelSurveys)
+
+  // Sort by updated_at (descending)
+  surveysAndPanelSurveys = surveysAndPanelSurveys.sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
+
+  // pagination
+  const totalCount = surveysAndPanelSurveys ? surveysAndPanelSurveys.length : 0
+  const { page } = state.surveys
+  const pageIndex = page.index
+  const pageSize = page.size
+
+  // Show only the current page
+  surveysAndPanelSurveys = surveysAndPanelSurveys.slice(pageIndex, pageIndex + pageSize)
+
+  const startIndex = Math.min(totalCount, pageIndex + 1)
+  const endIndex = Math.min(pageIndex + pageSize, totalCount)
+
   return {
     projectId: ownProps.params.projectId,
     project: state.project.data,
@@ -274,8 +375,9 @@ const mapStateToProps = (state, ownProps) => {
     loadingSurveys: state.surveys.fetching,
     loadingFolders: state.folder.loadingFetch,
     folders: state.folder.folders && Object.values(state.folder.folders),
-    panelSurveys: state.panelSurveys.items && Object.values(state.panelSurveys.items),
-    loadingPanelSurveys: state.panelSurveys.fetching
+    panelSurveys,
+    loadingPanelSurveys: state.panelSurveys.fetching,
+    surveysAndPanelSurveys
   }
 }
 

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -178,7 +178,8 @@ class SurveyIndex extends Component<any, State> {
                        t={t}/>
 
           <SurveysGrid surveysAndPanelSurveys={surveysAndPanelSurveys}
-                       isReadOnly={readOnly}/>
+                       isReadOnly={readOnly}
+                       t={t}/>
 
           <PagingFooter {...{ startIndex, endIndex, totalCount }}
                         onPreviousPage={() => this.previousPage()}
@@ -230,7 +231,7 @@ const FoldersGrid = (props) => {
 }
 
 const SurveysGrid = (props) => {
-  const { surveysAndPanelSurveys, isReadOnly } = props
+  const { surveysAndPanelSurveys, isReadOnly, t } = props
 
   const isPanelSurvey = function(survey) {
     return survey.hasOwnProperty('occurrences')
@@ -240,8 +241,8 @@ const SurveysGrid = (props) => {
     <div className='survey-index-grid'>
       { surveysAndPanelSurveys.map(survey =>  {
           return isPanelSurvey(survey)
-            ? <PanelSurveyCard panelSurvey={survey} key={`panelsurvey-${survey.id}`} readOnly={isReadOnly} />
-            : <SurveyCard survey={survey} key={`survey-${survey.id}`} readOnly={isReadOnly} />
+            ? <PanelSurveyCard panelSurvey={survey} key={`panelsurvey-${survey.id}`} readOnly={isReadOnly} t={t} />
+            : <SurveyCard survey={survey} key={`survey-${survey.id}`} readOnly={isReadOnly} t={t} />
         })}
     </div>
   )

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -136,13 +136,9 @@ class SurveyIndex extends Component<any, State> {
       )
     }
 
-    const footer = <PagingFooter
-      {...{startIndex, endIndex, totalCount}}
-      onPreviousPage={() => this.previousPage()}
-      onNextPage={() => this.nextPage()} />
-
     const readOnly = !project || project.readOnly
 
+    // Main Button
     const mainAction = (
       <MainAction text={t('Add')} icon='add' className='survey-index-main-action'>
         <Action text={t('Survey')} icon='assignment_turned_in' onClick={() => this.newSurvey()} />
@@ -151,25 +147,48 @@ class SurveyIndex extends Component<any, State> {
       </MainAction>
     )
 
+    // Empty view
+    const noDataToShow = surveys && surveys.length === 0 &&
+                         folders && folders.length === 0 &&
+                         panelSurveys && panelSurveys.length === 0
+
+    const emptyView = <EmptyPage icon='assignment_turned_in'
+                                 title={t('You have no surveys on this project')}
+                                 onClick={(e) => this.newSurvey()}
+                                 readOnly={readOnly}
+                                 createText={t('Create one', { context: 'survey' })} />
+
+    const foldersGrid = (
+      <div className='survey-index-grid'>
+        {folders && folders.map(folder => <FolderCard key={folder.id} {...folder} t={t} onDelete={this.deleteFolder} onRename={this.renameFolder} readOnly={readOnly} />)}
+      </div>
+    )
+
+    const surveysGrid = (
+      <div className='survey-index-grid'>
+        {surveys && surveys.map(survey => (
+          <SurveyCard survey={survey} key={survey.id} readOnly={readOnly} />
+        ))}
+      </div>
+    )
+
+    const footer = <PagingFooter
+      {...{ startIndex, endIndex, totalCount }}
+      onPreviousPage={() => this.previousPage()}
+      onNextPage={() => this.nextPage()} />
+
     return (
       <div>
-        { readOnly ? null : mainAction}
-        { (surveys && surveys.length == 0 && folders && folders.length === 0)
-        ? <EmptyPage icon='assignment_turned_in' title={t('You have no surveys on this project')} onClick={(e) => this.newSurvey()} readOnly={readOnly} createText={t('Create one', {context: 'survey'})} />
+        { readOnly ? null : mainAction }
+        { noDataToShow
+        ? emptyView
         : (
           <div>
-            <div className='survey-index-grid'>
-              { folders && folders.map(folder => <FolderCard key={folder.id} {...folder} t={t} onDelete={this.deleteFolder} onRename={this.renameFolder} readOnly={readOnly} />)}
-            </div>
-            <div className='survey-index-grid'>
-              {surveys && surveys.map(survey => (
-                <SurveyCard survey={survey} key={survey.id} readOnly={readOnly} />
-              ))}
-            </div>
+            { foldersGrid }
+            { surveysGrid }
             { footer }
           </div>
-        )
-        }
+        )}
         <ConfirmationModal modalId='survey_index_folder_create' ref='createFolderConfirmationModal' confirmationText={t('Create')} header={t('Create Folder')} showCancel />
         <ConfirmationModal modalId='survey_index_folder_rename' ref='renameFolderConfirmationModal' confirmationText={t('Rename')} header={t('Rename Folder')} showCancel />
       </div>


### PR DESCRIPTION
Related #1981 

In this PR we code refactor 3 main components to add "Move PanelSurveys to folder":
- `SurveyIndex`
- `FolderShow`
- `PanelSurveyShow`

The code refactor was necessary to remove "flags" that made the components behaviour depend on the element it was showing (survey or panel survey)
On the other hand auxiliar components were added to make these components feel "React". For example in the 3 components we added:
- `<MainActions>`
- `<Title>`
- `<MainView>`
- `<FoldersGrid>`
- `<SurveysGrid>`
- `<PagingFooter>`

Resulting in a render structure looking like this:
```
return (
  <div>
    <MainActions ...>
      <Action ... />
      <Action ... />
    </MainActions>

    <MainView ...>
      <FoldersGrid .../>
      <SurveysGrid .../>
      <PagingFooter ... />
    </MainView>

    <ConfirmationModal ... />
    <ConfirmationModal ... />
  </div>
)
```

This structure (and the functions related) are shared between the 3 main components. A second "code refactor" pass is needed to remove the repeated logic.

On the other hand we introduce another component: `PanelSurveyCard` along the already existing `SurveyCard`. The logic shared between both components is reified in the (also new) component `InnerSurveyCard`