### PR TITLE
Fix: #1471 (restored branch by Mati)

### DIFF
--- a/test/js/reducers/survey.spec.js
+++ b/test/js/reducers/survey.spec.js
@@ -525,11 +525,11 @@ describe('survey reducer', () => {
             {'condition': [{store: 'Age', value: [20, 29]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [30, 39]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [40, 49]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
-            {'condition': [{store: 'Age', value: [50, 119]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
+            {'condition': [{store: 'Age', value: [50, 120]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [20, 29]}, {store: 'Smokes', value: 'No'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [30, 39]}, {store: 'Smokes', value: 'No'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [40, 49]}, {store: 'Smokes', value: 'No'}], 'quota': 0},
-            {'condition': [{store: 'Age', value: [50, 119]}, {store: 'Smokes', value: 'No'}], 'quota': 0}
+            {'condition': [{store: 'Age', value: [50, 120]}, {store: 'Smokes', value: 'No'}], 'quota': 0}
           ]
         }
       }
@@ -548,7 +548,7 @@ describe('survey reducer', () => {
           },
           {
             'condition': [
-              { store: 'age', value: [10, 49] }
+              { store: 'age', value: [10, 50] }
             ]
           }
         ]

--- a/test/js/reducers/survey.spec.js
+++ b/test/js/reducers/survey.spec.js
@@ -536,6 +536,44 @@ describe('survey reducer', () => {
     })
   })
 
+  describe('quota buckets intervals', () => {
+    const questionnaire = deepFreeze({
+      steps: [
+        {
+          type: 'numeric',
+          store: 'Age'
+        }
+      ],
+      id: 1
+    })
+
+    const baseState = deepFreeze(playActions([
+      actions.fetch(1, 1),
+      actions.receive(survey),
+      actions.setQuotaVars([{var: 'Age', steps: '20, 30, 40'}], questionnaire)
+    ]))
+
+    let intervalStrings = [
+      '20, 30, 40',
+      '20, 40, 30',
+      '30, 20, 40',
+      '30, 40, 20',
+      '40, 20, 30',
+      '40, 30, 20'
+    ]
+
+    intervalStrings.forEach((intervalString) => {
+      it('should build sort-insensitive quota buckets intervals', () => {
+        const actionsToPlay = [
+          actions.fetch(1, 1),
+          actions.receive(survey),
+          actions.setQuotaVars([{var: 'Age', steps: intervalString}], questionnaire)
+        ]
+        expect(playActions(actionsToPlay)).toEqual(baseState)
+      })
+    })
+  })
+
   it('should rebuild input from quota buckets', () => {
     const survey = deepFreeze({
       quotas: {

--- a/test/lib/runtime/survey_test.exs
+++ b/test/lib/runtime/survey_test.exs
@@ -2503,6 +2503,49 @@ defmodule Ask.Runtime.SurveyTest do
     end)
   end
 
+  test "accepts respondent in bucket upper bound" do
+    [survey, _group, _test_channel, respondent, _phone_number] = create_running_survey_with_channel_and_respondent()
+
+    quotas = %{
+      "vars" => ["Perfect Number"],
+      "buckets" => [
+        %{
+          "condition" => [%{"store" => "Perfect Number", "value" => [18, 29]}],
+          "quota" => 1,
+          "count" => 0
+        },
+        %{
+          "condition" => [%{"store" => "Perfect Number", "value" => [30, 79]}],
+          "quota" => 1,
+          "count" => 0
+        },
+        %{
+          "condition" => [%{"store" => "Perfect Number", "value" => [80, 120]}],
+          "quota" => 1,
+          "count" => 0
+        },
+      ]
+    }
+
+    survey
+    |> Repo.preload([:quota_buckets])
+    |> Ask.Survey.changeset(%{quotas: quotas})
+    |> Repo.update!
+
+    {:ok, survey_logger} = SurveyLogger.start_link
+    {:ok, broker} = Broker.start_link
+    poll_survey()
+
+    _reply = Survey.sync_step(Repo.get(Respondent, respondent.id), Flow.Message.reply("2"))
+    _reply = Survey.sync_step(Repo.get(Respondent, respondent.id), Flow.Message.reply("2"))
+
+    assert {:reply, %{stores: %{"Perfect Number" => "120"}}, _respondent} = Survey.sync_step(Repo.get(Respondent, respondent.id), Flow.Message.reply("120"))
+    assert %{disposition: :started} = Repo.get(Respondent, respondent.id)
+
+    :ok = broker |> GenServer.stop
+    :ok = survey_logger |> GenServer.stop
+  end
+
   defp day_after_tomorrow_schedule_day_of_week() do
     {erl_date, _} = Timex.now |> Timex.to_erl
     case :calendar.day_of_the_week(erl_date) do

--- a/web/static/js/components/surveys/SurveyShow.jsx
+++ b/web/static/js/components/surveys/SurveyShow.jsx
@@ -148,7 +148,7 @@ class SurveyShow extends Component<any, State> {
       estimatedSuccessRate, initialSuccessRate, successRate, completionRate, exhausted, available, neededToComplete, additionalCompletes, additionalRespondents } = this.props
     const { stopUnderstood } = this.state
 
-    if (!survey || !cumulativePercentages || !questionnaires || !respondentsByDisposition || !reference) {
+    if (!survey || !cumulativePercentages || !questionnaires) {
       return <p>{t('Loading...')}</p>
     }
 
@@ -189,17 +189,27 @@ class SurveyShow extends Component<any, State> {
 
     let title = this.titleFor(questionnaires)
 
-    let stats = [
-      {value: target, label: t('Target')},
-      {value: respondentsByDisposition.responsive.detail.completed.count, label: t('Completes')},
-      {value: respondentsByDisposition.responsive.detail.partial.count, label: t('Partials')},
-      {value: attemptedRespondents, label: t('Attempted Respondents')}
-    ]
-    let colors = referenceColors(reference.length)
+    let stats
+    if (respondentsByDisposition) {
+      stats = [
+        {value: target, label: t('Target')},
+        {value: respondentsByDisposition.responsive.detail.completed.count, label: t('Completes')},
+        {value: respondentsByDisposition.responsive.detail.partial.count, label: t('Partials')},
+        {value: attemptedRespondents, label: t('Attempted Respondents')}
+      ]
+    } else {
+      stats = [
+        {value: target, label: t('Target')},
+        {value: 0, label: t('Completes')},
+        {value: 0, label: t('Partials')},
+        {value: attemptedRespondents, label: t('Attempted Respondents')}
+      ]
+    }
+    let colors = referenceColors((reference || []).length)
 
     const hasQuotas = survey.quotas.vars.length > 0
 
-    let forecastsReferences = reference.map((r, i) => {
+    let forecastsReferences = (reference || []).map((r, i) => {
       const name = r.name ? r.name : ''
       const modes = r.modes ? modeLabel(r.modes) : ''
       const separator = name && modes ? ' | ' : ''
@@ -325,7 +335,7 @@ class SurveyShow extends Component<any, State> {
         </div>
         <div className='row'>
           <div className='col s12'>
-            {this.dispositions(respondentsByDisposition, reference, hasQuotas)}
+            {respondentsByDisposition ? this.dispositions(respondentsByDisposition, reference, hasQuotas) : ''}
           </div>
         </div>
       </div>

--- a/web/static/js/reducers/survey.js
+++ b/web/static/js/reducers/survey.js
@@ -246,7 +246,7 @@ const buildBuckets = (storeVars, options) => {
 }
 
 const intervalsFrom = (valueString) => {
-  const values = map(split(valueString, ','), (value) => parseInt(value.trim()))
+  const values = map(split(valueString, ','), (value) => parseInt(value.trim())).sort((a, b) => a - b)
   if (values.length <= 1) {
     return []
   }

--- a/web/static/js/reducers/survey.js
+++ b/web/static/js/reducers/survey.js
@@ -251,6 +251,10 @@ const intervalsFrom = (valueString) => {
     return []
   }
 
+  if (values.length == 2) {
+    return [[values[0], values[1]]]
+  }
+
   return [[values[0], values[1] - 1], ...intervalsFrom(drop(values))]
 }
 
@@ -313,7 +317,9 @@ export const sumQuotasIfValid = (condition: Condition[], buckets: Bucket[], newQ
 export const rebuildInputFromQuotaBuckets = (store: string, survey: Survey) => {
   const buckets = survey.quotas.buckets.filter((bucket) => bucket.condition.map((condition) => condition.store).includes(store))
   let conditions = uniqWith(buckets.map((bucket) => find(bucket.condition, (condition) => condition.store == store).value), isEqual)
+  let lastCondition = conditions.pop() // last condition's upper bound doesn't have to be incremented
   conditions = conditions.map(x => [x[0], x[1] + 1])
+  conditions.push(lastCondition)
   conditions = flatten(conditions)
   conditions = uniqWith(conditions, isEqual)
   return conditions.join()


### PR DESCRIPTION
I believe #1471 has never been really fixed. I dig into the pull request and commit histories, and couldn't find anything even remotely related. The notifications created by Juan & Brian also seem to indicate that: the issue was moved from 0.22 upto 0.25.0 then removed, with nothing happening.

If the fixes were never merged, it makes sense that it still appears in Sentry (see #1999), though not that frequently, since it's an edge case.

I noticed lost commit references by @matiasgarciaisaia's in #1471 which I could restore — :bow: to GitHub for keeping those commits somewhere (they're not in Git) and returning a patch when adding `.patch` to the commit URL!

I eventually rebased the restored branch against the current `master` branch, and the patches still applied properly (nice).

closes #1471 
closes #1999 