### PR TITLE
Add move PanelSurveys to a folder

### DIFF
--- a/test/js/fixtures.js
+++ b/test/js/fixtures.js
@@ -332,6 +332,7 @@ export const questionnaireWithLangSelection: Questionnaire = deepFreeze(quizWith
 const bareSurvey: Survey = {
   id: 1,
   projectId: 1,
+  folderId: null,
   name: 'Foo',
   description: null,
   cutoff: 123,

--- a/web/models/activity_log.ex
+++ b/web/models/activity_log.ex
@@ -1,7 +1,14 @@
 defmodule Ask.ActivityLog do
   use Ask.Web, :model
   import User.Helper
-  alias Ask.{ActivityLog, Project, Survey, Questionnaire, Folder}
+  alias Ask.{
+    ActivityLog,
+    Folder,
+    PanelSurvey,
+    Project,
+    Questionnaire,
+    Survey
+  }
 
   schema "activity_log" do
     belongs_to :project, Ask.Project
@@ -21,6 +28,9 @@ defmodule Ask.ActivityLog do
   def valid_actions("survey"), do:
     ["create", "edit", "rename", "change_description", "lock", "unlock", "delete", "start", "repeat", "request_cancel", "completed_cancel", "download", "enable_public_link", "regenerate_public_link", "disable_public_link", "change_folder", "add_respondents"]
 
+  def valid_actions("panel_survey"), do:
+    ["panel_survey_change_folder"]
+
   def valid_actions("questionnaire"), do:
     ["create", "edit", "rename", "delete", "add_mode", "remove_mode", "add_language", "remove_language", "create_step", "delete_step", "rename_step", "edit_step", "edit_settings", "create_section", "rename_section", "delete_section", "edit_section", "archive", "unarchive"]
 
@@ -38,6 +48,7 @@ defmodule Ask.ActivityLog do
 
   defp typeof(%Project{}), do: "project"
   defp typeof(%Survey{}), do: "survey"
+  defp typeof(%PanelSurvey{}), do: "panel_survey"
   defp typeof(%Questionnaire{}), do: "questionnaire"
   defp typeof(%Folder{}), do: "folder"
 
@@ -301,5 +312,13 @@ defmodule Ask.ActivityLog do
   def update_archived_status(project, conn, questionnaire, archived) do
     action = if archived, do: "archive", else: "unarchive"
     create(action, project, conn, questionnaire, %{questionnaire_name: questionnaire.name})
+  end
+
+  def panel_survey_change_folder(project, conn, panel_survey, old_folder_name, new_folder_name) do
+    create("panel_survey_change_folder", project, conn, panel_survey, %{
+      panel_survey_name: panel_survey.name,
+      old_folder_name: old_folder_name,
+      new_folder_name: new_folder_name
+    })
   end
 end

--- a/web/models/activity_log.ex
+++ b/web/models/activity_log.ex
@@ -29,7 +29,7 @@ defmodule Ask.ActivityLog do
     ["create", "edit", "rename", "change_description", "lock", "unlock", "delete", "start", "repeat", "request_cancel", "completed_cancel", "download", "enable_public_link", "regenerate_public_link", "disable_public_link", "change_folder", "add_respondents"]
 
   def valid_actions("panel_survey"), do:
-    ["panel_survey_change_folder"]
+    ["change_folder"]
 
   def valid_actions("questionnaire"), do:
     ["create", "edit", "rename", "delete", "add_mode", "remove_mode", "add_language", "remove_language", "create_step", "delete_step", "rename_step", "edit_step", "edit_settings", "create_section", "rename_section", "delete_section", "edit_section", "archive", "unarchive"]
@@ -315,7 +315,7 @@ defmodule Ask.ActivityLog do
   end
 
   def panel_survey_change_folder(project, conn, panel_survey, old_folder_name, new_folder_name) do
-    create("panel_survey_change_folder", project, conn, panel_survey, %{
+    create("change_folder", project, conn, panel_survey, %{
       panel_survey_name: panel_survey.name,
       old_folder_name: old_folder_name,
       new_folder_name: new_folder_name

--- a/web/models/survey.ex
+++ b/web/models/survey.ex
@@ -670,7 +670,8 @@ defmodule Ask.Survey do
 
   # Regular survey can always change its folder
   def movable?(%{panel_survey_id: nil} = _survey), do: true
-  # Panel survey waves can't change its folder (because they don't belong to folders)
+  # Panel survey waves can't change its folder by its own, although the PanelSurvey
+  # they belong to, can be moved to a folder
   def movable?(_survey), do: false
 
   defp only_wave_of_panel_survey?(%{panel_survey_id: nil} = _survey), do: false

--- a/web/router.ex
+++ b/web/router.ex
@@ -76,6 +76,7 @@ defmodule Ask.Router do
         end
         resources "/panel_surveys", PanelSurveyController, except: [:new, :edit] do
           post "/new_wave/", PanelSurveyController, :new_wave
+          post "/set_folder_id", PanelSurveyController, :set_folder_id
         end
         delete "/memberships/remove", MembershipController, :remove, as: :membership_remove
         put "/memberships/update", MembershipController, :update, as: :membership_update

--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -375,7 +375,7 @@ path.respondentsData.referenceStrokeColor15 { stroke: var(--reference-color15); 
     }
   }
   .dropdown-content {
-    min-width: 120px;
+    min-width: 150px;
   }
 
   .card-title {

--- a/web/static/js/actions/panelSurvey.js
+++ b/web/static/js/actions/panelSurvey.js
@@ -1,6 +1,7 @@
 // @flow
 import * as api from '../api'
 import * as panelSurveysActions from '../actions/panelSurveys'
+import * as folderActions from '../actions/folder'
 
 export const FETCH = 'FETCH_PANEL_SURVEY'
 export const RECEIVE = 'RECEIVE_PANEL_SURVEY'
@@ -37,5 +38,11 @@ export const receive = (panelSurvey: PanelSurvey) => ({
 
 export const changeFolder = (panelSurvey: PanelSurvey, folderId: number) => (dispatch: Function, getState: () => Store) => {
   return api.panelSurveySetFolderId(panelSurvey.projectId, panelSurvey.id, folderId)
-    .then(() => dispatch(panelSurveysActions.folderChanged(panelSurvey.id, folderId)))
+    .then(() => {
+      if (panelSurvey.folderId) {
+        // panelSurvey was in a folder so we refresh the current panelSurvey's folder
+        dispatch(folderActions.fetchFolder(panelSurvey.projectId, panelSurvey.folderId))
+      }
+      dispatch(panelSurveysActions.folderChanged(panelSurvey.id, folderId))
+    })
 }

--- a/web/static/js/actions/panelSurvey.js
+++ b/web/static/js/actions/panelSurvey.js
@@ -1,5 +1,6 @@
 // @flow
 import * as api from '../api'
+import * as panelSurveysActions from '../actions/panelSurveys'
 
 export const FETCH = 'FETCH_PANEL_SURVEY'
 export const RECEIVE = 'RECEIVE_PANEL_SURVEY'
@@ -33,3 +34,8 @@ export const receive = (panelSurvey: PanelSurvey) => ({
   type: RECEIVE,
   data: panelSurvey
 })
+
+export const changeFolder = (panelSurvey: PanelSurvey, folderId: number) => (dispatch: Function, getState: () => Store) => {
+  return api.panelSurveySetFolderId(panelSurvey.projectId, panelSurvey.id, folderId)
+    .then(() => dispatch(panelSurveysActions.folderChanged(panelSurvey.id, folderId)))
+}

--- a/web/static/js/actions/panelSurveys.js
+++ b/web/static/js/actions/panelSurveys.js
@@ -3,6 +3,7 @@ import * as panelSurveyActions from './panelSurvey'
 
 export const FETCH = 'FETCH_PANEL_SURVEYS'
 export const RECEIVE = 'RECEIVE_PANEL_SURVEYS'
+export const FOLDER_CHANGED = 'PANEL_SURVEY_FOLDER_CHANGED'
 
 export const fetchPanelSurveys = (projectId: number) => (dispatch: Function, getState: () => Store): Promise<?SurveyList> => {
   const state = getState()
@@ -32,4 +33,10 @@ export const receivePanelSurveys = (projectId: number, items: IndexedList<PanelS
   type: RECEIVE,
   projectId,
   items
+})
+
+export const folderChanged = (panelSurveyId: number, folderId: number) => ({
+  type: FOLDER_CHANGED,
+  panelSurveyId,
+  folderId
 })

--- a/web/static/js/actions/survey.js
+++ b/web/static/js/actions/survey.js
@@ -179,8 +179,7 @@ export const changeName = (newName: string) => (dispatch: Function, getState: ()
 
 export const changeFolder = (survey: Survey, folderId: number) => (dispatch: Function, getState: () => Store) => {
   return api.setFolderId(survey.projectId, survey.id, folderId)
-    .then(() => dispatch(surveysActions.folderChanged(survey.id, folderId))
-  )
+    .then(() => dispatch(surveysActions.folderChanged(survey.id, folderId)))
 }
 
 export const changeDescription = (newDescription: string) => (dispatch: Function, getState: () => Store) => {

--- a/web/static/js/actions/survey.js
+++ b/web/static/js/actions/survey.js
@@ -5,6 +5,7 @@ import { stepStoreValues } from '../reducers/questionnaire'
 import * as surveysActions from './surveys'
 import * as panelSurveyActions from '../actions/panelSurvey'
 import * as panelSurveysActions from '../actions/panelSurveys'
+import * as folderActions from '../actions/folder'
 
 export const CHANGE_CUTOFF = 'SURVEY_CHANGE_CUTOFF'
 export const CHANGE_QUOTA = 'SURVEY_CHANGE_QUOTA'
@@ -179,7 +180,13 @@ export const changeName = (newName: string) => (dispatch: Function, getState: ()
 
 export const changeFolder = (survey: Survey, folderId: number) => (dispatch: Function, getState: () => Store) => {
   return api.setFolderId(survey.projectId, survey.id, folderId)
-    .then(() => dispatch(surveysActions.folderChanged(survey.id, folderId)))
+    .then(() => {
+      if (survey.folderId) {
+        // survey was in a folder so we refresh the current survey's folder
+        dispatch(folderActions.fetchFolder(survey.projectId, survey.folderId))
+      }
+      dispatch(surveysActions.folderChanged(survey.id, folderId))
+    })
 }
 
 export const changeDescription = (newDescription: string) => (dispatch: Function, getState: () => Store) => {

--- a/web/static/js/actions/survey.js
+++ b/web/static/js/actions/survey.js
@@ -302,6 +302,12 @@ export const deleteSurvey = (survey: Survey) => (dispatch: Function) => {
         dispatch(panelSurveyActions.fetchPanelSurvey(survey.projectId, survey.panelSurveyId))
         dispatch(panelSurveysActions.fetchPanelSurveys(survey.projectId))
       }
+
+      if (survey.folderId) {
+        // survey was in a folder so we refresh the current survey's folder
+        dispatch(folderActions.fetchFolder(survey.projectId, survey.folderId))
+      }
+
       return dispatch(surveysActions.deleted(survey))
     })
 }

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -292,8 +292,13 @@ export const updateSurvey = (projectId, survey) => {
 export const setSurveyName = (projectId, surveyId, name) => {
   return apiPostJSON(`projects/${projectId}/surveys/${surveyId}/set_name`, null, { name })
 }
+
 export const setFolderId = (projectId, surveyId, folderId) => {
   return apiPostJSON(`projects/${projectId}/surveys/${surveyId}/set_folder_id`, null, { folderId: folderId || null })
+}
+
+export const panelSurveySetFolderId = (projectId, panelSurveyId, folderId) => {
+  return apiPostJSON(`projects/${projectId}/panel_surveys/${panelSurveyId}/set_folder_id`, null, { folderId: folderId || null })
 }
 
 export const setSurveyDescription = (projectId, surveyId, description) => {

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -346,7 +346,7 @@ export const stopSurvey = (projectId, surveyId) => {
   return apiPostJSON(`projects/${projectId}/surveys/${surveyId}/stop`, surveySchema)
 }
 
-export const newOccurrence = (projectId, panelSurveyId) => {
+export const newWave = (projectId, panelSurveyId) => {
   return apiPostJSON(`projects/${projectId}/panel_surveys/${panelSurveyId}/new_wave`, surveySchema)
 }
 

--- a/web/static/js/components/activity/ActivityDescription.jsx
+++ b/web/static/js/components/activity/ActivityDescription.jsx
@@ -168,7 +168,6 @@ class ActivityDescription extends Component {
         break
       case 'panelSurvey':
         const panelSurveyName = metadata['panelSurveyName'] || 'Untitled'
-        const reportType = this.reportTypeText(metadata['reportType'])
         switch (activity.action) {
           case 'change_folder':
             const { oldFolderName, newFolderName } = metadata
@@ -180,7 +179,6 @@ class ActivityDescription extends Component {
           default:
             return ''
         }
-        break
       default:
         return ''
     }

--- a/web/static/js/components/activity/ActivityDescription.jsx
+++ b/web/static/js/components/activity/ActivityDescription.jsx
@@ -166,6 +166,21 @@ class ActivityDescription extends Component {
             return t('Renamed <i>{{oldFolderName}}</i> folder to <i>{{newFolderName}}</i>', {oldFolderName, newFolderName})
         }
         break
+      case 'panelSurvey':
+        const panelSurveyName = metadata['panelSurveyName'] || 'Untitled'
+        const reportType = this.reportTypeText(metadata['reportType'])
+        switch (activity.action) {
+          case 'change_folder':
+            const { oldFolderName, newFolderName } = metadata
+            if (oldFolderName) {
+              return t('Moved <i>{{panelSurveyName}}</i> from folder <i>{{oldFolderName}}</i> to <i>{{newFolderName}}</i>', { panelSurveyName: panelSurveyName, oldFolderName: oldFolderName, newFolderName: newFolderName })
+            } else {
+              return t('Moved <i>{{panelSurveyName}}</i> from folder <i>No folder</i> to <i>{{newFolderName}}</i>', { panelSurveyName: panelSurveyName, newFolderName: newFolderName })
+            }
+          default:
+            return ''
+        }
+        break
       default:
         return ''
     }

--- a/web/static/js/components/folders/FolderCard.jsx
+++ b/web/static/js/components/folders/FolderCard.jsx
@@ -10,8 +10,8 @@ class FolderCard extends PureComponent {
     id: PropTypes.number,
     name: PropTypes.string,
     t: PropTypes.func,
-    onDelete: Function,
-    onRename: Function,
+    onDelete: PropTypes.func,
+    onRename: PropTypes.func,
     readOnly: PropTypes.bool
   }
 

--- a/web/static/js/components/folders/FolderShow.jsx
+++ b/web/static/js/components/folders/FolderShow.jsx
@@ -6,7 +6,7 @@ import * as surveysActions from '../../actions/surveys'
 import * as surveyActions from '../../actions/survey'
 import * as actions from '../../actions/folder'
 import * as panelSurveyActions from '../../actions/panelSurvey'
-import { MainAction, Action, EmptyPage, ConfirmationModal, PagingFooter } from '../ui'
+import { MainAction, Action, EmptyPage, PagingFooter } from '../ui'
 import { SurveyCard, PanelSurveyCard } from '../surveys/SurveyCard'
 import * as routes from '../../routes'
 import { translate } from 'react-i18next'
@@ -72,8 +72,6 @@ class FolderShow extends Component<any, any> {
       projectId,
       project,
       folder,
-      surveys,
-      panelSurveys,
       surveysAndPanelSurveys,
 
       isLoading,
@@ -137,6 +135,12 @@ const Title = (props) => {
   )
 }
 
+Title.propTypes = {
+  projectId: PropTypes.any,
+  folder: PropTypes.object,
+  t: PropTypes.func
+}
+
 const MainActions = (props) => {
   const { isReadOnly, children, t } = props
   if (isReadOnly) return null
@@ -148,11 +152,25 @@ const MainActions = (props) => {
   )
 }
 
+MainActions.propTypes = {
+  isReadOnly: PropTypes.bool,
+  children: PropTypes.node,
+  t: PropTypes.func
+}
+
 const MainView = (props) => {
-  const { isReadOnly, isEmpty, onNew, t, children } = props
+  const { isReadOnly, isEmpty, onNew, children, t } = props
   return (isEmpty)
     ? <EmptyView isReadOnly={isReadOnly} onClick={onNew} t={t} />
     : (<div>{children}</div>)
+}
+
+MainView.propTypes = {
+  isReadOnly: PropTypes.bool,
+  isEmpty: PropTypes.bool,
+  onNew: PropTypes.func,
+  children: PropTypes.node,
+  t: PropTypes.func
 }
 
 const EmptyView = (props) => {
@@ -164,11 +182,17 @@ const EmptyView = (props) => {
                      createText={t('Create one', { context: 'survey' })} />)
 }
 
+EmptyView.propTypes = {
+  isReadOnly: PropTypes.bool,
+  onClick: PropTypes.func,
+  t: PropTypes.func
+}
+
 const SurveysGrid = (props) => {
   const { surveysAndPanelSurveys, isReadOnly, t } = props
 
-  const isPanelSurvey = function (survey) {
-    return survey.hasOwnProperty('occurrences')
+  const isPanelSurvey = function(survey) {
+    return survey.hasOwnProperty('latestWave')
   }
 
   return (
@@ -180,6 +204,12 @@ const SurveysGrid = (props) => {
       })}
     </div>
   )
+}
+
+SurveysGrid.propTypes = {
+  surveysAndPanelSurveys: PropTypes.array,
+  isReadOnly: PropTypes.bool,
+  t: PropTypes.func
 }
 
 const mapStateToFolder = (state, folderId) => {
@@ -215,7 +245,7 @@ const mapStateToProps = (state, ownProps) => {
 
   // Merge all together and sort by updated_at (descending)
   const surveysAndPanelSurveys = [
-    ...surveys, //.filter(survey => !survey.panelSurveyId),
+    ...surveys,
     ...panelSurveys
   ].sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
 
@@ -225,7 +255,7 @@ const mapStateToProps = (state, ownProps) => {
     paginatedElements,
     totalCount,
     startIndex,
-    endIndex,
+    endIndex
   } = paginate(surveysAndPanelSurveys, page)
 
   // loading, readonly and emptyview
@@ -264,11 +294,11 @@ const paginate = (surveysAndPanelSurveys: Array<Survey | PanelSurvey>, page) => 
   const endIndex = Math.min(pageIndex + pageSize, totalCount)
 
   return {
-    paginatedElements:
-      (surveysAndPanelSurveys.slice(pageIndex, pageIndex + pageSize): Array<Survey| PanelSurvey >),
+    paginatedElements: (surveysAndPanelSurveys
+      .slice(pageIndex, pageIndex + pageSize): Array<Survey | PanelSurvey>),
     totalCount,
     startIndex,
-    endIndex,
+    endIndex
   }
 }
 

--- a/web/static/js/components/surveys/PanelSurveyShow.jsx
+++ b/web/static/js/components/surveys/PanelSurveyShow.jsx
@@ -103,8 +103,6 @@ class PanelSurveyShow extends Component<any, any> {
       )
     }
 
-    console.log(panelSurvey)
-
     return (
       <div className='folder-show'>
         <MainActions isReadOnly={isReadOnly}>
@@ -125,71 +123,6 @@ class PanelSurveyShow extends Component<any, any> {
       </div>
     )
   }
-
-  // render() {
-  //   const loading = this.loadingMessage()
-  //   if (loading) {
-  //     return loading
-  //   }
-
-  //   const { surveys, project, t, panelSurveyId } = this.props
-  //   const readOnly = !project || project.readOnly
-
-  //   if (surveys && surveys.length == 0) {
-  //     throw Error(t('Empty panel survey'))
-  //   }
-
-  //   return (
-  //     <div className='folder-show'>
-  //       {readOnly || this.primaryButton()}
-  //       {this.titleLink()}
-  //       <div>
-  //         <div className='survey-index-grid'>
-  //           { surveys && surveys.map(survey => {
-  //             return (
-  //               <SurveyCard survey={survey} key={survey.id} readOnly={readOnly} t={t} panelSurveyId={panelSurveyId} />
-  //             )
-  //           }) }
-  //         </div>
-  //         {this.footer()}
-  //       </div>
-  //     </div>
-  //   )
-  // }
-
-  // loadingMessage() {
-  //   const { t, loadingPanelSurvey } = this.props
-  //   if (loadingPanelSurvey) {
-  //     return <div className='folder-show'>{this.titleLink()}{t('Loading panel survey...')}</div>
-  //   }
-  // }
-
-  // titleLink() {
-  //   const { t, projectId, panelSurvey } = this.props
-
-  //   if (panelSurvey) {
-  //     const to = panelSurvey.folderId
-  //       ? routes.folder(projectId, panelSurvey.folderId)
-  //       : routes.project(projectId)
-  //     const name = panelSurvey.name || t('Untitled panel survey')
-  //     return <Link to={to} className='folder-header'><i className='material-icons black-text'>arrow_back</i>{name}</Link>
-  //   }
-  // }
-
-  // primaryButton() {
-  //   const { t, panelSurvey } = this.props
-  //   const addWaveDisabled = panelSurvey ? !panelSurvey.isRepeatable : true
-  //   return <RepeatButton text={t('Add wave')} disabled={addWaveDisabled} onClick={() => this.newWave()} />
-  // }
-
-  // footer() {
-  //   const { startIndex, endIndex, totalCount } = this.props
-
-  //   return <PagingFooter
-  //     {...{startIndex, endIndex, totalCount}}
-  //     onPreviousPage={() => this.previousPage()}
-  //     onNextPage={() => this.nextPage()} />
-  // }
 }
 
 const Title = (props) => {

--- a/web/static/js/components/surveys/PanelSurveyShow.jsx
+++ b/web/static/js/components/surveys/PanelSurveyShow.jsx
@@ -58,7 +58,7 @@ class PanelSurveyShow extends Component<any, any> {
     newWave(projectId, panelSurvey.id)
       .then(response => {
         const panelSurvey = response.entities.surveys[response.result]
-        const survey = panelSurvey.latestOccurrence
+        const survey = panelSurvey.latestWave
         // A wave of the panel survey was created -> the panel survey has changed.
         // The Redux store must be updated with the panel survey new state.
         panelSurveysActions.updateStore(dispatch, projectId, panelSurveyId)

--- a/web/static/js/components/surveys/PanelSurveyShow.jsx
+++ b/web/static/js/components/surveys/PanelSurveyShow.jsx
@@ -6,7 +6,7 @@ import * as surveysActions from '../../actions/surveys'
 import * as actions from '../../actions/panelSurvey'
 import * as panelSurveysActions from '../../actions/panelSurveys'
 import { PagingFooter } from '../ui'
-import { SurveyCard, PanelSurveyCard } from '../surveys/SurveyCard'
+import { SurveyCard } from '../surveys/SurveyCard'
 import * as routes from '../../routes'
 import { translate } from 'react-i18next'
 import { RepeatButton } from '../ui/RepeatButton'
@@ -37,18 +37,9 @@ class PanelSurveyShow extends Component<any, any> {
     totalCount: PropTypes.number.isRequired
   }
 
-  // componentWillMount() {
-  //   const { dispatch, projectId, panelSurvey, panelSurveyId } = this.props
-
-  //   if (!panelSurvey) {
-  //     dispatch(actions.fetchPanelSurvey(projectId, panelSurveyId))
-  //   }
-  // }
-
   componentDidMount() {
     const { dispatch, projectId, panelSurveyId } = this.props
     dispatch(actions.fetchPanelSurvey(projectId, panelSurveyId))
-    // dispatch(actions.fetchFolder(projectId, folderId))
   }
 
   nextPage() {
@@ -78,10 +69,7 @@ class PanelSurveyShow extends Component<any, any> {
   render() {
     const {
       projectId,
-      project,
-      panelSurveyId,
       panelSurvey,
-      surveys,
       surveysAndPanelSurveys,
 
       isLoading,
@@ -142,11 +130,22 @@ const Title = (props) => {
   )
 }
 
+Title.propTypes = {
+  projectId: PropTypes.any,
+  panelSurvey: PropTypes.object,
+  t: PropTypes.func
+}
+
 const MainActions = (props) => {
   const { isReadOnly, children } = props
   if (isReadOnly) return null
 
   return (<div>{children}</div>)
+}
+
+MainActions.propTypes = {
+  isReadOnly: PropTypes.bool,
+  children: PropTypes.node
 }
 
 const MainView = (props) => {
@@ -155,6 +154,12 @@ const MainView = (props) => {
   if (isEmpty) throw Error(t('Empty panel survey'))
 
   return (<div>{children}</div>)
+}
+
+MainView.propTypes = {
+  isEmpty: PropTypes.bool,
+  children: PropTypes.node,
+  t: PropTypes.func
 }
 
 const SurveysGrid = (props) => {
@@ -167,6 +172,12 @@ const SurveysGrid = (props) => {
       })}
     </div>
   )
+}
+
+SurveysGrid.propTypes = {
+  surveysAndPanelSurveys: PropTypes.array,
+  isReadOnly: PropTypes.bool,
+  t: PropTypes.func
 }
 
 const mapStateToPanelSurvey = (state, panelSurveyId) => {
@@ -211,7 +222,7 @@ const mapStateToProps = (state, ownProps) => {
     paginatedElements,
     totalCount,
     startIndex,
-    endIndex,
+    endIndex
   } = paginate(surveysAndPanelSurveys, page)
 
   // loading, readonly and emptyview
@@ -249,11 +260,11 @@ const paginate = (surveysAndPanelSurveys: Array<Survey | PanelSurvey>, page) => 
   const endIndex = Math.min(pageIndex + pageSize, totalCount)
 
   return {
-    paginatedElements:
-      (surveysAndPanelSurveys.slice(pageIndex, pageIndex + pageSize): Array<Survey| PanelSurvey >),
+    paginatedElements: (surveysAndPanelSurveys
+      .slice(pageIndex, pageIndex + pageSize): Array<Survey | PanelSurvey>),
     totalCount,
     startIndex,
-    endIndex,
+    endIndex
   }
 }
 

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -164,12 +164,12 @@ class SurveyCard extends Component<any> {
         {
           showAsPanelSurveyCard
           ? <div className='panel-survey-card-0'>
-            <div className='panel-survey-card-1'>
-              <div className='panel-survey-card-2'>
-                { surveyCard }
+              <div className='panel-survey-card-1'>
+                <div className='panel-survey-card-2'>
+                  { surveyCard }
+                </div>
               </div>
             </div>
-          </div>
           : surveyCard
         }
         <ConfirmationModal modalId='survey_index_move_survey' ref='moveSurveyConfirmationModal' confirmationText={t('Move')} header={t('Move survey')} showCancel />

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, PropTypes } from 'react'
 import { translate, Trans } from 'react-i18next'
 
 import { Link } from 'react-router'
@@ -88,7 +88,6 @@ class _SurveyCard extends Component<any> {
 
   render() {
     const { survey, t, dispatch } = this.props
-    const { panelSurvey } = survey
 
     let actions = []
     if (this.movable()) actions.push({ name: t('Move to'), func: this.moveSurvey })
@@ -149,7 +148,7 @@ class _PanelSurveyCard extends Component<any> {
 
   deleteSurvey = () => {
     const deleteConfirmationModal: ConfirmationModal = this.refs.deleteConfirmationModal
-    const { t, panelSurvey } = this.props
+    const { t } = this.props
 
     const survey = this.latestWave()
 
@@ -226,10 +225,6 @@ class InnerSurveyCard extends Component<any> {
     dispatch: Function
   };
 
-  constructor(props) {
-    super(props)
-  }
-
   componentDidMount() {
     const { survey, dispatch } = this.props
 
@@ -296,6 +291,10 @@ const ActionMenu = (props) => {
       ))}
     </Dropdown>
   )
+}
+
+ActionMenu.propTypes = {
+  actions: PropTypes.array
 }
 
 export const SurveyCard = translate()(connect()(_SurveyCard))

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -4,6 +4,7 @@ import { translate, Trans } from 'react-i18next'
 import { Link } from 'react-router'
 import * as routes from '../../routes'
 import * as surveyActions from '../../actions/survey'
+import * as panelSurveyActions from '../../actions/panelSurvey'
 import { fetchRespondentsStats } from '../../actions/respondents'
 import { untitledSurveyTitle } from './SurveyTitle'
 import { Card, UntitledIfEmpty, Dropdown, DropdownItem, ConfirmationModal } from '../ui'
@@ -13,15 +14,12 @@ import MoveSurveyForm from './MoveSurveyForm'
 
 import { connect } from 'react-redux'
 
-class SurveyCard extends Component<any> {
+class _SurveyCard extends Component<any> {
   props: {
     t: Function,
     dispatch: Function,
-    respondentsStats: ?Object,
     survey: Survey,
-    onDelete: (survey: Survey) => void,
-    readOnly: boolean,
-    panelSurveyId: ?number
+    readOnly: boolean
   };
 
   constructor(props) {
@@ -34,7 +32,6 @@ class SurveyCard extends Component<any> {
 
   componentDidMount() {
     const { survey, dispatch } = this.props
-
     if (survey.state != 'not_ready') {
       fetchRespondentsStats(survey.projectId, survey.id)(dispatch)
     }
@@ -77,14 +74,12 @@ class SurveyCard extends Component<any> {
 
   deletable() {
     const { survey, readOnly } = this.props
-    if (readOnly) return false
-    return survey.isDeletable
+    return !readOnly && survey.isDeletable
   }
 
   movable() {
     const { survey, readOnly } = this.props
-    if (readOnly) return false
-    return survey.isMovable
+    return !readOnly && survey.isMovable
   }
 
   actionable() {
@@ -92,86 +87,129 @@ class SurveyCard extends Component<any> {
   }
 
   render() {
-    const { survey, respondentsStats, t, panelSurveyId } = this.props
+    const { survey, t, dispatch } = this.props
     const { panelSurvey } = survey
 
-    let cumulativePercentages = respondentsStats ? (respondentsStats['cumulativePercentages'] || {}) : {}
-    let completionPercentage = respondentsStats ? (respondentsStats['completionPercentage'] || 0) : 0
-
-    let description = <div className='grey-text card-description'>
-      {survey.description}
-    </div>
-
-    const redirectTo = panelSurvey
-    ? routes.panelSurvey(panelSurvey.projectId, panelSurvey.id)
-    : routes.showOrEditSurvey(survey)
-
-    const name = panelSurvey ? panelSurvey.name : survey.name
-
-    const actionMenu = (
-      <Dropdown className='options' dataBelowOrigin={false} label={<i className='material-icons'>more_vert</i>}>
-        <DropdownItem className='dots'>
-          <i className='material-icons'>more_vert</i>
-        </DropdownItem>
-        {
-          this.movable()
-          ? <DropdownItem>
-            <a onClick={e => this.moveSurvey()}><i className='material-icons'>folder</i>{t('Move to')}</a>
-          </DropdownItem>
-          : null
-        }
-        {
-          this.deletable()
-            ? <DropdownItem>
-              <a onClick={e => this.deleteSurvey()}><i className='material-icons'>delete</i>{t('Delete')}</a>
-            </DropdownItem>
-            : null
-        }
-      </Dropdown>
-    )
-
-    const surveyCard = <div className='survey-card'>
-      <Card>
-        <div className='card-content'>
-          <div className='survey-card-status'>
-            <Link className='grey-text' to={redirectTo}>
-              {t('{{percentage}}% of target completed', {percentage: String(Math.round(completionPercentage))})}
-            </Link>
-            { this.actionable() ? actionMenu : null }
-          </div>
-          <div className='card-chart'>
-            <RespondentsChart cumulativePercentages={cumulativePercentages} />
-          </div>
-          <div className='card-status'>
-            <Link className='card-title black-text truncate' title={name} to={redirectTo}>
-              <UntitledIfEmpty text={name} emptyText={untitledSurveyTitle(survey, t)} />
-            </Link>
-            <Link to={redirectTo}>
-              {description}
-              <SurveyStatus survey={survey} short />
-            </Link>
-          </div>
-        </div>
-      </Card>
-    </div>
-
-    const inPanelSurveyIndex = !!panelSurveyId
-    const isWaveOfPanelSurvey = panelSurvey || survey.generatesPanelSurvey
-    const showAsPanelSurveyCard = !inPanelSurveyIndex && isWaveOfPanelSurvey
+    let actions = []
+    if (this.movable()) actions.push({ name: t('Move to'), func: this.moveSurvey })
+    if (this.deletable()) actions.push({ name: t('Delete'), func: this.deleteSurvey })
 
     return (
       <div className='col s12 m6 l4'>
-        {
-          showAsPanelSurveyCard
-          ? <div className='panel-survey-card-0'>
-              <div className='panel-survey-card-1'>
-                <div className='panel-survey-card-2'>
-                  { surveyCard }
-                </div>
-              </div>
+        <InnerSurveyCard survey={survey}
+          actions={actions}
+          onClickRoute={routes.showOrEditSurvey(survey)}
+          t={t}
+          dispatch={dispatch} />
+
+        <ConfirmationModal modalId='survey_index_move_survey' ref='moveSurveyConfirmationModal' confirmationText={t('Move')} header={t('Move survey')} showCancel />
+        <ConfirmationModal modalId='survey_index_delete' ref='deleteConfirmationModal' confirmationText={t('Delete')} header={t('Delete survey')} showCancel />
+      </div>
+    )
+  }
+}
+class _PanelSurveyCard extends Component<any> {
+  props: {
+    t: Function,
+    dispatch: Function,
+    panelSurvey: Survey,
+    readOnly: boolean,
+  };
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      folderId: props.panelSurvey.folderId || ''
+    }
+  }
+
+  lastWave() {
+    const { panelSurvey } = this.props
+
+    return [...panelSurvey.occurrences].pop() // TODO
+  }
+
+  changeFolder(folderId) {
+    this.setState({ folderId })
+  }
+
+  moveSurvey = () => {
+    const { panelSurvey } = this.props
+
+    const moveSurveyConfirmationModal: ConfirmationModal = this.refs.moveSurveyConfirmationModal
+    moveSurveyConfirmationModal.open({
+      modalText: <MoveSurveyForm defaultFolderId={panelSurvey.folderId} onChangeFolderId={folderId => this.changeFolder(folderId)} />,
+      onConfirm: () => {
+        const { dispatch } = this.props
+        const { folderId } = this.state
+        dispatch(panelSurveyActions.changeFolder(panelSurvey, folderId))
+      }
+    })
+  }
+
+  deleteSurvey = () => {
+    const deleteConfirmationModal: ConfirmationModal = this.refs.deleteConfirmationModal
+    const { t, panelSurvey } = this.props
+
+    const survey = this.lastWave()
+
+    deleteConfirmationModal.open({
+      modalText: <span>
+        <p>
+          <Trans>
+            Are you sure you want to delete the last wave <b><UntitledIfEmpty text={survey.name} emptyText={untitledSurveyTitle(survey, t)} /></b>?
+          </Trans>
+        </p>
+        <p>{t('All the respondent information will be lost and cannot be undone.')}</p>
+      </span>,
+      onConfirm: () => {
+        const { dispatch } = this.props
+        dispatch(surveyActions.deleteSurvey(survey))
+      }
+    })
+  }
+
+  // The option Delete on the PanelSurveyCard means:
+  // delete the last wave in the PanelSurvey
+  deletable() {
+    const { readOnly } = this.props
+    const survey = this.lastWave()
+
+    return !readOnly && survey.isDeletable
+  }
+
+  movable() {
+    const { readOnly } = this.props
+    return !readOnly
+  }
+
+  actionable() {
+    return this.deletable() || this.movable()
+  }
+
+  render() {
+    const { panelSurvey, t, dispatch } = this.props
+    const survey = this.lastWave()
+
+    let actions = []
+    if (this.movable()) actions.push({ name: t('Move to'), func: this.moveSurvey })
+    if (this.deletable()) actions.push({ name: t('Delete wave'), func: this.deleteSurvey })
+
+    return (
+      <div className='col s12 m6 l4'>
+        <div className='panel-survey-card-0'>
+          <div className='panel-survey-card-1'>
+            <div className='panel-survey-card-2'>
+              <InnerSurveyCard survey={survey}
+                actions={actions}
+                onClickRoute={routes.panelSurvey(survey.projectId, panelSurvey.id)}
+                t={t}
+                dispatch={dispatch} />
             </div>
-          : surveyCard
-        }
+          </div>
+        </div>
+
         <ConfirmationModal modalId='survey_index_move_survey' ref='moveSurveyConfirmationModal' confirmationText={t('Move')} header={t('Move survey')} showCancel />
         <ConfirmationModal modalId='survey_index_delete' ref='deleteConfirmationModal' confirmationText={t('Delete')} header={t('Delete survey')} showCancel />
       </div>
@@ -179,4 +217,87 @@ class SurveyCard extends Component<any> {
   }
 }
 
-export default translate()(connect()(SurveyCard))
+class InnerSurveyCard extends Component<any> {
+  props: {
+    survey: Survey,
+    actions: Array<Object>,
+    onClickRoute: Function,
+    t: Function,
+    respondentsStats: ?Object,
+    dispatch: Function
+  };
+
+  constructor(props) {
+    super(props)
+  }
+
+  componentDidMount() {
+    const { survey, dispatch } = this.props
+
+    if (survey.state != 'not_ready') {
+      fetchRespondentsStats(survey.projectId, survey.id)(dispatch)
+    }
+  }
+
+  render() {
+    const { survey, respondentsStats, actions, onClickRoute, t } = this.props
+
+    // stats
+    let cumulativePercentages = respondentsStats ? (respondentsStats['cumulativePercentages'] || {}) : {}
+    let completionPercentage = respondentsStats ? (respondentsStats['completionPercentage'] || 0) : 0
+
+    return (
+      <div className='survey-card'>
+        <Card>
+          <div className='card-content'>
+            <div className='survey-card-status'>
+              <Link className='grey-text' to={onClickRoute}>
+                {t('{{percentage}}% of target completed', { percentage: String(Math.round(completionPercentage)) })}
+              </Link>
+              <ActionMenu actions={actions} />
+            </div>
+            <div className='card-chart'>
+              <RespondentsChart cumulativePercentages={cumulativePercentages} />
+            </div>
+            <div className='card-status'>
+              <Link className='card-title black-text truncate' title={survey.name} to={onClickRoute}>
+                <UntitledIfEmpty text={survey.name} emptyText={untitledSurveyTitle(survey, t)} />
+              </Link>
+              <Link to={onClickRoute}>
+                <div className='grey-text card-description'>
+                  {survey.description}
+                </div>
+                <SurveyStatus survey={survey} short />
+              </Link>
+            </div>
+          </div>
+        </Card>
+      </div>
+    )
+  }
+}
+
+const ActionMenu = (props) => {
+  const { actions } = props
+
+  if (actions.length === 0) return null
+
+  return (
+    <Dropdown className='options' dataBelowOrigin={false} label={<i className='material-icons'>more_vert</i>}>
+      <DropdownItem className='dots'>
+        <i className='material-icons'>more_vert</i>
+      </DropdownItem>
+      {actions.map((action, index) => (
+        <DropdownItem key={index}>
+          <a onClick={e => action.func()}>
+            <i className='material-icons'>folder</i>
+            {action.name}
+          </a>
+        </DropdownItem>
+      ))}
+    </Dropdown>
+  )
+}
+
+export const SurveyCard = translate()(connect()(_SurveyCard))
+export const PanelSurveyCard = translate()(connect()(_PanelSurveyCard))

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -124,10 +124,9 @@ class _PanelSurveyCard extends Component<any> {
     }
   }
 
-  lastWave() {
+  latestWave() {
     const { panelSurvey } = this.props
-
-    return [...panelSurvey.occurrences].pop() // TODO
+    return panelSurvey.latestWave
   }
 
   changeFolder(folderId) {
@@ -152,7 +151,7 @@ class _PanelSurveyCard extends Component<any> {
     const deleteConfirmationModal: ConfirmationModal = this.refs.deleteConfirmationModal
     const { t, panelSurvey } = this.props
 
-    const survey = this.lastWave()
+    const survey = this.latestWave()
 
     deleteConfirmationModal.open({
       modalText: <span>
@@ -174,7 +173,7 @@ class _PanelSurveyCard extends Component<any> {
   // delete the last wave in the PanelSurvey
   deletable() {
     const { readOnly } = this.props
-    const survey = this.lastWave()
+    const survey = this.latestWave()
 
     return !readOnly && survey.isDeletable
   }
@@ -190,7 +189,7 @@ class _PanelSurveyCard extends Component<any> {
 
   render() {
     const { panelSurvey, t, dispatch } = this.props
-    const survey = this.lastWave()
+    const survey = this.latestWave()
 
     let actions = []
     if (this.movable()) actions.push({ name: t('Move to'), func: this.moveSurvey })

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -38,13 +38,13 @@ class SurveyIndex extends Component<any, State> {
     panelSurveys: PropTypes.array,
     surveysAndPanelSurveys: PropTypes.array,
 
+    isLoading: PropTypes.bool,
+    isReadOnly: PropTypes.bool,
+    isEmptyView: PropTypes.bool,
+
     startIndex: PropTypes.number.isRequired,
     endIndex: PropTypes.number.isRequired,
-    totalCount: PropTypes.number.isRequired,
-
-    loadingFolders: PropTypes.bool,
-    loadingSurveys: PropTypes.bool,
-    loadingPanelSurveys: PropTypes.bool
+    totalCount: PropTypes.number.isRequired
   }
 
   constructor(props) {
@@ -129,9 +129,9 @@ class SurveyIndex extends Component<any, State> {
       panelSurveys,
       surveysAndPanelSurveys,
 
-      loadingFolders,
-      loadingSurveys,
-      loadingPanelSurveys,
+      isLoading,
+      isReadOnly,
+      isEmptyView,
 
       startIndex,
       endIndex,
@@ -139,35 +139,28 @@ class SurveyIndex extends Component<any, State> {
       t
     } = this.props
 
-    // TODO: move to mapStateToProps
-    const isLoading = loadingSurveys || loadingFolders || loadingPanelSurveys
-    const readOnly = !project || project.readOnly
-    const isEmptyView = surveys && surveys.length === 0 &&
-                        folders && folders.length === 0 &&
-                        panelSurveys && panelSurveys.length === 0
-
     if (isLoading) return (<div>{t('Loading surveys...')}</div>)
 
     return (
       <div>
-        <MainActions isReadOnly={readOnly} t={t}>
+        <MainActions isReadOnly={isReadOnly} t={t}>
           <Action text={t('Survey')} icon={'assignment_turned_in'} onClick={() => this.newSurvey()} />
           <Action text={t('Panel Survey')} icon={'repeat'} onClick={() => this.newPanelSurvey()} />
           <Action text={t('Folder')} icon={'folder'} onClick={() => this.newFolder()} />
         </MainActions>
 
-        <MainView isReadOnly={readOnly}
+        <MainView isReadOnly={isReadOnly}
                   isEmpty={isEmptyView}
                   onNew={() => this.newSurvey()}
                   t={t}>
           <FoldersGrid folders={folders}
-                       isReadOnly={readOnly}
+                       isReadOnly={isReadOnly}
                        onRename={() => this.renameFolder()}
                        onDelete={() => this.deleteFolder()}
                        t={t} />
 
           <SurveysGrid surveysAndPanelSurveys={surveysAndPanelSurveys}
-                       isReadOnly={readOnly}
+                       isReadOnly={isReadOnly}
                        t={t} />
 
           <PagingFooter {...{ startIndex, endIndex, totalCount }}
@@ -270,6 +263,8 @@ const paginate = (surveysAndPanelSurveys: Array<Survey|PanelSurvey>, page) => {
 }
 
 const mapStateToProps = (state, ownProps) => {
+  const project = state.project.data
+
   let folders = mapStateToFolders(state)
   let surveys = mapStateToSurveys(state)
   let panelSurveys = mapStateToPanelSurveys(state)
@@ -289,22 +284,30 @@ const mapStateToProps = (state, ownProps) => {
     endIndex,
   } = paginate(surveysAndPanelSurveys, page)
 
+  const isLoadingFolders = state.folders && state.folders.loadingFetch
+  const isLoadingSurveys = state.surveys && state.surveys.fetching
+  const isLoadingPanelSurveys = state.panelSurveys && state.panelSurveys.fetching
+
+  const isLoading = isLoadingFolders || isLoadingSurveys || isLoadingPanelSurveys
+  const isReadOnly = !project || project.readOnly
+  const isEmptyView = folders.length === 0 && surveys.length === 0 && panelSurveys.length === 0
+
   return {
     projectId: ownProps.params.projectId,
-    project: state.project.data,
+    project,
 
     surveys,
     folders,
     panelSurveys,
     surveysAndPanelSurveys: paginatedElements,
 
+    isLoading,
+    isReadOnly,
+    isEmptyView,
+
     startIndex,
     endIndex,
-    totalCount,
-
-    loadingFolders: state.folders && state.folders.loadingFetch,
-    loadingSurveys: state.surveys && state.surveys.fetching,
-    loadingPanelSurveys: state.panelSurveys && state.panelSurveys.fetching
+    totalCount
   }
 }
 

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -123,10 +123,7 @@ class SurveyIndex extends Component<any, State> {
 
   render() {
     const {
-      project,
       folders,
-      surveys,
-      panelSurveys,
       surveysAndPanelSurveys,
 
       isLoading,
@@ -186,11 +183,25 @@ const MainActions = (props) => {
   )
 }
 
+MainActions.propTypes = {
+  isReadOnly: PropTypes.bool,
+  children: PropTypes.node,
+  t: PropTypes.func
+}
+
 const MainView = (props) => {
-  const { isReadOnly, isEmpty, onNew, t, children } = props
+  const { isReadOnly, isEmpty, onNew, children, t } = props
   return (isEmpty)
     ? <EmptyView isReadOnly={isReadOnly} onClick={onNew} t={t} />
     : (<div>{children}</div>)
+}
+
+MainView.propTypes = {
+  isReadOnly: PropTypes.bool,
+  isEmpty: PropTypes.bool,
+  onNew: PropTypes.func,
+  children: PropTypes.node,
+  t: PropTypes.func
 }
 
 const EmptyView = (props) => {
@@ -200,6 +211,12 @@ const EmptyView = (props) => {
                      onClick={onClick}
                      readOnly={isReadOnly}
                      createText={t('Create one', { context: 'survey' })} />)
+}
+
+EmptyView.propTypes = {
+  isReadOnly: PropTypes.bool,
+  onClick: PropTypes.func,
+  t: PropTypes.func
 }
 
 const FoldersGrid = (props) => {
@@ -212,11 +229,19 @@ const FoldersGrid = (props) => {
   )
 }
 
+FoldersGrid.propTypes = {
+  folders: PropTypes.array,
+  isReadOnly: PropTypes.bool,
+  isEmpty: PropTypes.bool,
+  onRename: PropTypes.func,
+  onDelete: PropTypes.func,
+  t: PropTypes.func
+}
 
 const SurveysGrid = (props) => {
   const { surveysAndPanelSurveys, isReadOnly, t } = props
 
-  const isPanelSurvey = function (survey) {
+  const isPanelSurvey = function(survey) {
     return survey.hasOwnProperty('latestWave')
   }
 
@@ -229,6 +254,12 @@ const SurveysGrid = (props) => {
       })}
     </div>
   )
+}
+
+SurveysGrid.propTypes = {
+  surveysAndPanelSurveys: PropTypes.array,
+  isReadOnly: PropTypes.bool,
+  t: PropTypes.func
 }
 
 const mapStateToFolders = (state) => {
@@ -255,7 +286,7 @@ const mapStateToProps = (state, ownProps) => {
 
   // Merge all together and sort by updated_at (descending)
   const surveysAndPanelSurveys = [
-    ...surveys, //.filter(survey => !survey.panelSurveyId),
+    ...surveys,
     ...panelSurveys
   ].sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
 
@@ -265,7 +296,7 @@ const mapStateToProps = (state, ownProps) => {
     paginatedElements,
     totalCount,
     startIndex,
-    endIndex,
+    endIndex
   } = paginate(surveysAndPanelSurveys, page)
 
   // loading, readonly and emptyview
@@ -304,11 +335,11 @@ const paginate = (surveysAndPanelSurveys: Array<Survey | PanelSurvey>, page) => 
   const endIndex = Math.min(pageIndex + pageSize, totalCount)
 
   return {
-    paginatedElements:
-      (surveysAndPanelSurveys.slice(pageIndex, pageIndex + pageSize): Array<Survey| PanelSurvey >),
+    paginatedElements: (surveysAndPanelSurveys
+      .slice(pageIndex, pageIndex + pageSize): Array<Survey | PanelSurvey>),
     totalCount,
     startIndex,
-    endIndex,
+    endIndex
   }
 }
 

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -226,7 +226,7 @@ const SurveysGrid = (props) => {
   const { surveysAndPanelSurveys, isReadOnly, t } = props
 
   const isPanelSurvey = function (survey) {
-    return survey.hasOwnProperty('waves')
+    return survey.hasOwnProperty('latestWave')
   }
 
   return (
@@ -239,46 +239,6 @@ const SurveysGrid = (props) => {
     </div>
   )
 }
-
-// const mergePanelSurveysIntoSurveys = (surveys, panelSurveys) => {
-//   return panelSurveys
-//     .map(panelSurvey => ({
-//       ...panelSurvey.latestWave,
-//       panelSurvey: panelSurvey
-//     }))
-//     .concat(surveys)
-// }
-
-// Merges the latest panel survey wave into surveys, sorts the resulting
-// collection, and eventually paginates the result, generating props to display
-// a list of surveys and panel surveys.
-//
-// At least used by the FolderShow and PanelSurveyShow components.
-// export const surveyIndexProps = (state: any, surveys: ?Array<Survey>, panelSurveys: ?Array<PanelSurvey>) => {
-//   if (surveys && panelSurveys) {
-//     surveys = mergePanelSurveysIntoSurveys(surveys, panelSurveys)
-//   }
-
-//   const totalCount = surveys ? surveys.length : 0
-//   const pageIndex = state.surveys.page.index
-//   const pageSize = state.surveys.page.size
-//   const startIndex = Math.min(totalCount, pageIndex + 1)
-//   const endIndex = Math.min(pageIndex + pageSize, totalCount)
-
-//   if (surveys) {
-//     // Sort by updated at, descending
-//     surveys = surveys.sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
-//     // Show only the current page
-//     surveys = (surveys.slice(pageIndex, pageIndex + pageSize): Array<Survey>)
-//   }
-
-//   return {
-//     surveys,
-//     startIndex,
-//     endIndex,
-//     totalCount
-//   }
-// }
 
 const mapStateToFolders = (state) => {
   let { items } = state.folders

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -246,22 +246,6 @@ const mapStateToPanelSurveys = (state) => {
   return values(items) || []
 }
 
-const paginate = (surveysAndPanelSurveys: Array<Survey|PanelSurvey>, page) => {
-  const totalCount = surveysAndPanelSurveys ? surveysAndPanelSurveys.length : 0
-  const pageIndex = page.index
-  const pageSize = page.size
-  const startIndex = Math.min(totalCount, pageIndex + 1)
-  const endIndex = Math.min(pageIndex + pageSize, totalCount)
-
-  return {
-    paginatedElements:
-      (surveysAndPanelSurveys.slice(pageIndex, pageIndex + pageSize): Array<Survey| PanelSurvey >),
-    totalCount,
-    startIndex,
-    endIndex,
-  }
-}
-
 const mapStateToProps = (state, ownProps) => {
   const project = state.project.data
 
@@ -284,6 +268,7 @@ const mapStateToProps = (state, ownProps) => {
     endIndex,
   } = paginate(surveysAndPanelSurveys, page)
 
+  // loading, readonly and emptyview
   const isLoadingFolders = state.folders && state.folders.loadingFetch
   const isLoadingSurveys = state.surveys && state.surveys.fetching
   const isLoadingPanelSurveys = state.panelSurveys && state.panelSurveys.fetching
@@ -308,6 +293,22 @@ const mapStateToProps = (state, ownProps) => {
     startIndex,
     endIndex,
     totalCount
+  }
+}
+
+const paginate = (surveysAndPanelSurveys: Array<Survey | PanelSurvey>, page) => {
+  const totalCount = surveysAndPanelSurveys ? surveysAndPanelSurveys.length : 0
+  const pageIndex = page.index
+  const pageSize = page.size
+  const startIndex = Math.min(totalCount, pageIndex + 1)
+  const endIndex = Math.min(pageIndex + pageSize, totalCount)
+
+  return {
+    paginatedElements:
+      (surveysAndPanelSurveys.slice(pageIndex, pageIndex + pageSize): Array<Survey| PanelSurvey >),
+    totalCount,
+    startIndex,
+    endIndex,
   }
 }
 

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -15,7 +15,7 @@ import {
   Action
 } from '../ui'
 import FolderCard from '../folders/FolderCard'
-import SurveyCard from './SurveyCard'
+import { SurveyCard, PanelSurveyCard } from './SurveyCard'
 import FolderForm from './FolderForm'
 import * as routes from '../../routes'
 import { translate } from 'react-i18next'
@@ -29,16 +29,21 @@ class SurveyIndex extends Component<any, State> {
     t: PropTypes.func,
     dispatch: PropTypes.func,
     router: PropTypes.object,
+
     projectId: PropTypes.any.isRequired,
     project: PropTypes.object,
-    surveys: PropTypes.array,
+
     folders: PropTypes.array,
-    loadingFolders: PropTypes.bool,
-    loadingSurveys: PropTypes.bool,
+    surveys: PropTypes.array,
+    panelSurveys: PropTypes.array,
+    surveysAndPanelSurveys: PropTypes.array,
+
     startIndex: PropTypes.number.isRequired,
     endIndex: PropTypes.number.isRequired,
     totalCount: PropTypes.number.isRequired,
-    panelSurveys: PropTypes.array,
+
+    loadingFolders: PropTypes.bool,
+    loadingSurveys: PropTypes.bool,
     loadingPanelSurveys: PropTypes.bool
   }
 
@@ -117,47 +122,61 @@ class SurveyIndex extends Component<any, State> {
   }
 
   render() {
-    const { folders, loadingFolders, loadingSurveys, surveys, project, startIndex, endIndex, totalCount, t, panelSurveys, loadingPanelSurveys } = this.props
-    if ((!surveys && loadingSurveys) || (!folders && loadingFolders) || (!panelSurveys && loadingPanelSurveys)) {
-      return (
-        <div>{t('Loading surveys...')}</div>
-      )
-    }
+    const {
+      project,
+      folders,
+      surveys,
+      panelSurveys,
+      surveysAndPanelSurveys,
 
-    const footer = <PagingFooter
-      {...{startIndex, endIndex, totalCount}}
-      onPreviousPage={() => this.previousPage()}
-      onNextPage={() => this.nextPage()} />
+      loadingFolders,
+      loadingSurveys,
+      loadingPanelSurveys,
 
+      startIndex,
+      endIndex,
+      totalCount,
+      t
+    } = this.props
+
+    // TODO: move to mapStateToProps
+    const isLoading = (!surveys && loadingSurveys) ||
+                      (!folders && loadingFolders) ||
+                      (!panelSurveys && loadingPanelSurveys)
     const readOnly = !project || project.readOnly
+    const isEmptyView = surveys && surveys.length === 0 &&
+                        folders && folders.length === 0 &&
+                        panelSurveys && panelSurveys.length === 0
 
-    const mainAction = (
-      <MainAction text={t('Add')} icon='add' className='survey-index-main-action'>
-        <Action text={t('Survey')} icon='assignment_turned_in' onClick={() => this.newSurvey()} />
-        <Action text={t('Panel Survey')} icon='repeat' onClick={() => this.newPanelSurvey()} />
-        <Action text='Folder' icon='folder' onClick={() => this.newFolder()} />
-      </MainAction>
-    )
+    if (isLoading) return (<div>{t('Loading surveys...')}</div>)
 
     return (
       <div>
-        { readOnly ? null : mainAction}
-        { (surveys && surveys.length == 0 && folders && folders.length === 0)
-        ? <EmptyPage icon='assignment_turned_in' title={t('You have no surveys on this project')} onClick={(e) => this.newSurvey()} readOnly={readOnly} createText={t('Create one', {context: 'survey'})} />
-        : (
-          <div>
-            <div className='survey-index-grid'>
-              { folders && folders.map(folder => <FolderCard key={folder.id} {...folder} t={t} onDelete={this.deleteFolder} onRename={this.renameFolder} readOnly={readOnly} />)}
-            </div>
-            <div className='survey-index-grid'>
-              {surveys && surveys.map(survey => (
-                <SurveyCard survey={survey} key={survey.id} readOnly={readOnly} />
-              ))}
-            </div>
-            { footer }
-          </div>
-        )
-        }
+        <MainActions isReadOnly={readOnly} t={t}>
+          <Action text={t('Survey')} icon={'assignment_turned_in'} onClick={() => this.newSurvey()} />
+          <Action text={t('Panel Survey')} icon={'repeat'} onClick={() => this.newPanelSurvey()} />
+          <Action text={t('Folder')} icon={'folder'} onClick={() => this.newFolder()} />
+        </MainActions>
+
+        <MainView isReadOnly={readOnly}
+                  isEmpty={isEmptyView}
+                  onNew={() => this.newSurvey()}
+                  t={t}>
+          <FoldersGrid folders={folders}
+                       isReadOnly={readOnly}
+                       onRename={() => this.renameFolder()}
+                       onDelete={() => this.deleteFolder()}
+                       t={t} />
+
+          <SurveysGrid surveysAndPanelSurveys={surveysAndPanelSurveys}
+                       isReadOnly={readOnly}
+                       t={t} />
+
+          <PagingFooter {...{ startIndex, endIndex, totalCount }}
+                        onPreviousPage={() => this.previousPage()}
+                        onNextPage={() => this.nextPage()} />
+        </MainView>
+
         <ConfirmationModal modalId='survey_index_folder_create' ref='createFolderConfirmationModal' confirmationText={t('Create')} header={t('Create Folder')} showCancel />
         <ConfirmationModal modalId='survey_index_folder_rename' ref='renameFolderConfirmationModal' confirmationText={t('Rename')} header={t('Rename Folder')} showCancel />
       </div>
@@ -165,65 +184,174 @@ class SurveyIndex extends Component<any, State> {
   }
 }
 
-const mergePanelSurveysIntoSurveys = (surveys, panelSurveys) => {
-  return panelSurveys
-    .map(panelSurvey => ({
-      ...panelSurvey.latestWave,
-      panelSurvey: panelSurvey
-    }))
-    .concat(surveys)
+const MainActions = (props) => {
+  const { isReadOnly, children, t } = props
+  if (isReadOnly) return null
+
+  return (
+    <MainAction text={t('Add')} icon='add' className='survey-index-main-action'>
+      {children}
+    </MainAction>
+  )
 }
+
+const MainView = (props) => {
+  const { isReadOnly, isEmpty, onNew, t, children } = props
+  return (isEmpty)
+    ? <EmptyView isReadOnly={isReadOnly} onClick={onNew} t={t} />
+    : (<div>{children}</div>)
+}
+
+const EmptyView = (props) => {
+  const { isReadOnly, onClick, t } = props
+  return (<EmptyPage icon='assignment_turned_in'
+                     title={t('You have no surveys on this project')}
+                     onClick={onClick}
+                     readOnly={isReadOnly}
+                     createText={t('Create one', { context: 'survey' })} />)
+}
+
+const FoldersGrid = (props) => {
+  const { folders, isReadOnly, onRename, onDelete, t } = props
+  return (
+    <div className='survey-index-grid'>
+      {folders && folders.map(folder =>
+        <FolderCard key={folder.id} {...folder} t={t} onRename={onRename} onDelete={onDelete} readOnly={isReadOnly} />)}
+    </div>
+  )
+}
+
+
+const SurveysGrid = (props) => {
+  const { surveysAndPanelSurveys, isReadOnly, t } = props
+
+  const isPanelSurvey = function (survey) {
+    return survey.hasOwnProperty('waves')
+  }
+
+  return (
+    <div className='survey-index-grid'>
+      {surveysAndPanelSurveys.map(survey => {
+        return isPanelSurvey(survey)
+          ? <PanelSurveyCard panelSurvey={survey} key={`panelsurvey-${survey.id}`} readOnly={isReadOnly} t={t} />
+          : <SurveyCard survey={survey} key={`survey-${survey.id}`} readOnly={isReadOnly} t={t} />
+      })}
+    </div>
+  )
+}
+
+// const mergePanelSurveysIntoSurveys = (surveys, panelSurveys) => {
+//   return panelSurveys
+//     .map(panelSurvey => ({
+//       ...panelSurvey.latestWave,
+//       panelSurvey: panelSurvey
+//     }))
+//     .concat(surveys)
+// }
 
 // Merges the latest panel survey wave into surveys, sorts the resulting
 // collection, and eventually paginates the result, generating props to display
 // a list of surveys and panel surveys.
 //
 // At least used by the FolderShow and PanelSurveyShow components.
-export const surveyIndexProps = (state: any, surveys: ?Array<Survey>, panelSurveys: ?Array<PanelSurvey>) => {
-  if (surveys && panelSurveys) {
-    surveys = mergePanelSurveysIntoSurveys(surveys, panelSurveys)
-  }
+// export const surveyIndexProps = (state: any, surveys: ?Array<Survey>, panelSurveys: ?Array<PanelSurvey>) => {
+//   if (surveys && panelSurveys) {
+//     surveys = mergePanelSurveysIntoSurveys(surveys, panelSurveys)
+//   }
 
-  const totalCount = surveys ? surveys.length : 0
-  const pageIndex = state.surveys.page.index
-  const pageSize = state.surveys.page.size
+//   const totalCount = surveys ? surveys.length : 0
+//   const pageIndex = state.surveys.page.index
+//   const pageSize = state.surveys.page.size
+//   const startIndex = Math.min(totalCount, pageIndex + 1)
+//   const endIndex = Math.min(pageIndex + pageSize, totalCount)
+
+//   if (surveys) {
+//     // Sort by updated at, descending
+//     surveys = surveys.sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
+//     // Show only the current page
+//     surveys = (surveys.slice(pageIndex, pageIndex + pageSize): Array<Survey>)
+//   }
+
+//   return {
+//     surveys,
+//     startIndex,
+//     endIndex,
+//     totalCount
+//   }
+// }
+
+const mapStateToFolders = (state) => {
+  let { items } = state.folders
+  return values(items) || []
+}
+
+const mapStateToSurveys = (state) => {
+  let { items } = state.surveys
+  return values(items) || []
+}
+
+const mapStateToPanelSurveys = (state) => {
+  let { items } = state.panelSurveys
+  return values(items) || []
+}
+
+const paginate = (surveysAndPanelSurveys: Array<Survey|PanelSurvey>, page) => {
+  const totalCount = surveysAndPanelSurveys ? surveysAndPanelSurveys.length : 0
+  const pageIndex = page.index
+  const pageSize = page.size
   const startIndex = Math.min(totalCount, pageIndex + 1)
   const endIndex = Math.min(pageIndex + pageSize, totalCount)
 
-  if (surveys) {
-    // Sort by updated at, descending
-    surveys = surveys.sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
-    // Show only the current page
-    surveys = (surveys.slice(pageIndex, pageIndex + pageSize): Array<Survey>)
-  }
-
   return {
-    surveys,
+    paginatedElements:
+      (surveysAndPanelSurveys.slice(pageIndex, pageIndex + pageSize): Array<Survey| PanelSurvey >),
+    totalCount,
     startIndex,
     endIndex,
-    totalCount
   }
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const { folders, surveys, panelSurveys } = state
+  let folders = mapStateToFolders(state)
+  let surveys = mapStateToSurveys(state)
+  let panelSurveys = mapStateToPanelSurveys(state)
 
-  function values<T>(obj: ?Map<number, T>): ?Array<T> {
-    if (obj) {
-      return (Object.values(obj): any)
-    }
-  }
+  // Merge all together and sort by updated_at (descending)
+  const surveysAndPanelSurveys = [
+    ...surveys, //.filter(survey => !survey.panelSurveyId),
+    ...panelSurveys
+  ].sort((x, y) => y.updatedAt.localeCompare(x.updatedAt))
+
+  // pagination
+  const { page } = state.surveys
+  const {
+    paginatedElements,
+    totalCount,
+    startIndex,
+    endIndex,
+  } = paginate(surveysAndPanelSurveys, page)
 
   return {
-    ...surveyIndexProps(state, values(surveys.items), values(panelSurveys.items)),
     projectId: ownProps.params.projectId,
     project: state.project.data,
-    loadingSurveys: surveys && surveys.fetching,
-    loadingFolders: folders && folders.loadingFetch,
-    folders: values(folders.items),
-    panelSurveys: values(panelSurveys.items),
-    loadingPanelSurveys: state.panelSurveys.fetching
+
+    surveys,
+    folders,
+    panelSurveys,
+    surveysAndPanelSurveys: paginatedElements,
+
+    startIndex,
+    endIndex,
+    totalCount,
+
+    loadingFolders: state.folders && state.folders.loadingFetch,
+    loadingSurveys: state.surveys && state.surveys.fetching,
+    loadingPanelSurveys: state.panelSurveys && state.panelSurveys.fetching
   }
+}
+
+const values = function <T>(obj: ?Map<number, T>): ?Array<T> {
+  if (obj) return (Object.values(obj): any)
 }
 
 export default translate()(withRouter(connect(mapStateToProps)(SurveyIndex)))

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -140,9 +140,7 @@ class SurveyIndex extends Component<any, State> {
     } = this.props
 
     // TODO: move to mapStateToProps
-    const isLoading = (!surveys && loadingSurveys) ||
-                      (!folders && loadingFolders) ||
-                      (!panelSurveys && loadingPanelSurveys)
+    const isLoading = loadingSurveys || loadingFolders || loadingPanelSurveys
     const readOnly = !project || project.readOnly
     const isEmptyView = surveys && surveys.length === 0 &&
                         folders && folders.length === 0 &&

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -168,7 +168,7 @@ class SurveyIndex extends Component<any, State> {
 const mergePanelSurveysIntoSurveys = (surveys, panelSurveys) => {
   return panelSurveys
     .map(panelSurvey => ({
-      ...panelSurvey.latestOccurrence,
+      ...panelSurvey.latestWave,
       panelSurvey: panelSurvey
     }))
     .concat(surveys)

--- a/web/static/js/decls/survey.js
+++ b/web/static/js/decls/survey.js
@@ -8,6 +8,7 @@ export type Folder = {
 export type Survey = {
   id: number,
   projectId: number,
+  folderId: number,
   questionnaireIds: number[],
   questionnaires?: {[id: string]: Questionnaire},
   channels: number[],

--- a/web/static/js/decls/survey.js
+++ b/web/static/js/decls/survey.js
@@ -49,7 +49,8 @@ export type PanelSurvey = {
   folderId: number,
   projectId: number,
   latestOccurrence: ?Survey,
-  isRepeatable: boolean
+  isRepeatable: boolean,
+  updatedAt: Date
 }
 
 export type Link = {

--- a/web/static/js/decls/survey.js
+++ b/web/static/js/decls/survey.js
@@ -8,7 +8,7 @@ export type Folder = {
 export type Survey = {
   id: number,
   projectId: number,
-  folderId: number,
+  folderId: ?number,
   questionnaireIds: number[],
   questionnaires?: {[id: string]: Questionnaire},
   channels: number[],

--- a/web/static/js/reducers/panelSurveys.js
+++ b/web/static/js/reducers/panelSurveys.js
@@ -3,8 +3,16 @@ import collectionReducer, { projectFilterProvider } from './collection'
 
 const itemsReducer = (state: IndexedList<PanelSurvey>, action): IndexedList<PanelSurvey> => {
   switch (action.type) {
+    case actions.FOLDER_CHANGED: return changeFolder(state, action)
     default: return state
   }
+}
+
+const changeFolder = (state: IndexedList<PanelSurvey>, action: any) => {
+  const items = { ...state }
+  delete items[action.panelSurveyId]
+
+  return items
 }
 
 const initialState = {

--- a/web/static/js/reducers/surveys.js
+++ b/web/static/js/reducers/surveys.js
@@ -18,7 +18,8 @@ const deleteItem = (state: IndexedList<Survey>, action: any) => {
 
 const changeFolder = (state: IndexedList<Survey>, action: any) => {
   const items = {...state}
-  items[action.surveyId].folderId = action.folderId
+  delete items[action.surveyId]
+
   return items
 }
 


### PR DESCRIPTION
This PR is the branch-rebase (with conflicts resolved) continuation of PR #2031

Related #1981 

In this PR we code refactor 3 main components to add "Move PanelSurveys to folder":
- `SurveyIndex`
- `FolderShow`
- `PanelSurveyShow`

The code refactor was necessary to remove "flags" that made the components behaviour depend on the element it was showing (survey or panel survey)
On the other hand auxiliar components were added to make these components feel "React". For example in the 3 components we added:
- `<MainActions>`
- `<Title>`
- `<MainView>`
- `<FoldersGrid>`
- `<SurveysGrid>`
- `<PagingFooter>`

Resulting in a render structure looking like this:
```
return (
  <div>
    <MainActions ...>
      <Action ... />
      <Action ... />
    </MainActions>

    <MainView ...>
      <FoldersGrid .../>
      <SurveysGrid .../>
      <PagingFooter ... />
    </MainView>

    <ConfirmationModal ... />
    <ConfirmationModal ... />
  </div>
)
```

On the other hand we introduce another component: `PanelSurveyCard` along the already existing `SurveyCard`. The logic shared between both components is reified in the (also new) component `InnerSurveyCard`

This structure (and the functions related) are shared between the 3 main components `SurveyIndex`, `PanelSurveyShow` and `FolderShow`. A second "code refactor" pass is needed to remove the repeated logic

### Also in this PR
- Fix refresh issues in `SurveyIndex` and `FolderShow`
