### PR TITLE
Add delete Panel Survey

### DIFF
--- a/web/controllers/panel_survey_controller.ex
+++ b/web/controllers/panel_survey_controller.ex
@@ -68,6 +68,8 @@ defmodule Ask.PanelSurveyController do
       |> assoc(:panel_surveys)
       |> Repo.get!(id)
 
+    # TODO: should we explicitly delete associated waves?
+
     with {:ok, %PanelSurvey{}} <- PanelSurvey.delete_panel_survey(panel_survey) do
       send_resp(conn, :no_content, "")
     end

--- a/web/controllers/panel_survey_controller.ex
+++ b/web/controllers/panel_survey_controller.ex
@@ -68,8 +68,6 @@ defmodule Ask.PanelSurveyController do
       |> assoc(:panel_surveys)
       |> Repo.get!(id)
 
-    # TODO: should we explicitly delete associated waves?
-
     with {:ok, %PanelSurvey{}} <- PanelSurvey.delete_panel_survey(panel_survey) do
       send_resp(conn, :no_content, "")
     end

--- a/web/static/css/_global.scss
+++ b/web/static/css/_global.scss
@@ -375,7 +375,7 @@ path.respondentsData.referenceStrokeColor15 { stroke: var(--reference-color15); 
     }
   }
   .dropdown-content {
-    min-width: 150px;
+    min-width: 200px;
   }
 
   .card-title {

--- a/web/static/js/actions/panelSurvey.js
+++ b/web/static/js/actions/panelSurvey.js
@@ -46,3 +46,15 @@ export const changeFolder = (panelSurvey: PanelSurvey, folderId: number) => (dis
       dispatch(panelSurveysActions.folderChanged(panelSurvey.id, folderId))
     })
 }
+
+export const deletePanelSurvey = (panelSurvey: PanelSurvey) => (dispatch: Function) => {
+  api.deletePanelSurvey(panelSurvey.projectId, panelSurvey)
+    .then(response => {
+      if (panelSurvey.folderId) {
+        // panelSurvey was in a folder so we refresh the folder
+        dispatch(folderActions.fetchFolder(panelSurvey.projectId, panelSurvey.folderId))
+      }
+
+      return dispatch(panelSurveysActions.deleted(panelSurvey))
+    })
+}

--- a/web/static/js/actions/panelSurveys.js
+++ b/web/static/js/actions/panelSurveys.js
@@ -3,6 +3,7 @@ import * as panelSurveyActions from './panelSurvey'
 
 export const FETCH = 'FETCH_PANEL_SURVEYS'
 export const RECEIVE = 'RECEIVE_PANEL_SURVEYS'
+export const DELETED = 'PANEL_SURVEY_DELETED'
 export const FOLDER_CHANGED = 'PANEL_SURVEY_FOLDER_CHANGED'
 
 export const fetchPanelSurveys = (projectId: number) => (dispatch: Function, getState: () => Store): Promise<?SurveyList> => {
@@ -33,6 +34,11 @@ export const receivePanelSurveys = (projectId: number, items: IndexedList<PanelS
   type: RECEIVE,
   projectId,
   items
+})
+
+export const deleted = (panelSurvey: PanelSurvey) => ({
+  type: DELETED,
+  id: panelSurvey.id
 })
 
 export const folderChanged = (panelSurveyId: number, folderId: number) => ({

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -215,6 +215,10 @@ export const deleteSurvey = (projectId, survey) => {
   return apiDelete(`projects/${projectId}/surveys/${survey.id}`)
 }
 
+export const deletePanelSurvey = (projectId, panelSurvey) => {
+  return apiDelete(`projects/${projectId}/panel_surveys/${panelSurvey.id}`)
+}
+
 const getTimezone = () => {
   try {
     return Intl.DateTimeFormat().resolvedOptions().timeZone

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -178,8 +178,7 @@ class _PanelSurveyCard extends Component<any> {
 
   confirmDeletePanelSurvey = (panelSurvey: PanelSurvey) => {
     const { dispatch } = this.props
-    // dispatch(panelSurveyActions.deletePanelSurvey(panelSurvey))
-    console.log("delete panel survey")
+    dispatch(panelSurveyActions.deletePanelSurvey(panelSurvey))
   }
 
   // The option Delete on the PanelSurveyCard means:

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -183,8 +183,7 @@ class _PanelSurveyCard extends Component<any> {
       </span>,
       onConfirm: () => {
         const { dispatch } = this.props
-        console.log("hey")
-        // dispatch(surveyActions.deleteSurvey(survey))
+        dispatch(panelSurveyActions.deletePanelSurvey(panelSurvey))
       }
     })
   }

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -168,6 +168,27 @@ class _PanelSurveyCard extends Component<any> {
     })
   }
 
+  deletePanelSurvey = () => {
+    const deleteConfirmationModal: ConfirmationModal = this.refs.deleteConfirmationModal
+    const { panelSurvey, t } = this.props
+
+    deleteConfirmationModal.open({
+      modalText: <span>
+        <p>
+          <Trans>
+            Are you sure you want to delete the panel survey <b><UntitledIfEmpty text={panelSurvey.name} emptyText={untitledSurveyTitle(panelSurvey, t)} /></b> and all its waves?
+          </Trans>
+        </p>
+        <p>{t('All the respondent information will be lost and cannot be undone.')}</p>
+      </span>,
+      onConfirm: () => {
+        const { dispatch } = this.props
+        console.log("hey")
+        // dispatch(surveyActions.deleteSurvey(survey))
+      }
+    })
+  }
+
   // The option Delete on the PanelSurveyCard means:
   // delete the last wave in the PanelSurvey
   deletable() {
@@ -193,6 +214,7 @@ class _PanelSurveyCard extends Component<any> {
     let actions = []
     if (this.movable()) actions.push({ name: t('Move to'), func: this.moveSurvey })
     if (this.deletable()) actions.push({ name: t('Delete wave'), func: this.deleteSurvey })
+    actions.push({ name: t('Delete Panel Survey'), func: this.deletePanelSurvey })
 
     return (
       <div className='col s12 m6 l4'>

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -200,7 +200,6 @@ class _PanelSurveyCard extends Component<any> {
   }
 
   render() {
-    const { deletePanelSurveyUnderstood } = this.state
     const { panelSurvey, t, dispatch } = this.props
     const survey = this.latestWave()
 
@@ -352,7 +351,7 @@ class ConfirmationCheckModal extends Component<Props, State> {
   }
 
   render() {
-    const { checked, onConfirm } = this.state
+    const { checked } = this.state
     const { modalId, t } = this.props
 
     return (

--- a/web/static/js/components/surveys/SurveyCard.jsx
+++ b/web/static/js/components/surveys/SurveyCard.jsx
@@ -40,21 +40,23 @@ class _SurveyCard extends Component<any> {
 
   changeFolder = (folderId) => this.setState({ folderId })
 
-  moveSurvey = () => {
+  askMoveSurvey = () => {
     const moveSurveyConfirmationModal: ConfirmationModal = this.refs.moveSurveyConfirmationModal
     const { survey } = this.props
     const modalText = <MoveSurveyForm defaultFolderId={survey.folderId} onChangeFolderId={folderId => this.changeFolder(folderId)} />
     moveSurveyConfirmationModal.open({
       modalText: modalText,
-      onConfirm: () => {
-        const { dispatch } = this.props
-        const { folderId } = this.state
-        dispatch(surveyActions.changeFolder(survey, folderId))
-      }
+      onConfirm: () => (this.confirmMoveSurvey(survey))
     })
   }
 
-  deleteSurvey = () => {
+  confirmMoveSurvey = (survey: Survey) => {
+    const { dispatch } = this.props
+    const { folderId } = this.state
+    dispatch(surveyActions.changeFolder(survey, folderId))
+  }
+
+  askDeleteSurvey = () => {
     const deleteConfirmationModal: ConfirmationModal = this.refs.deleteConfirmationModal
     const { t, survey } = this.props
     deleteConfirmationModal.open({
@@ -66,11 +68,13 @@ class _SurveyCard extends Component<any> {
         </p>
         <p>{t('All the respondent information will be lost and cannot be undone.')}</p>
       </span>,
-      onConfirm: () => {
-        const { dispatch } = this.props
-        dispatch(surveyActions.deleteSurvey(survey))
-      }
+      onConfirm: () => this.confirmDeleteSurvey(survey)
     })
+  }
+
+  confirmDeleteSurvey = (survey: Survey) => {
+    const { dispatch } = this.props
+    dispatch(surveyActions.deleteSurvey(survey))
   }
 
   deletable() {
@@ -92,7 +96,7 @@ class _SurveyCard extends Component<any> {
 
     let actions = []
     if (this.movable()) actions.push({ name: t('Move to'), func: this.askMoveSurvey })
-    if (this.deletable()) actions.push({ name: t('Delete'), func: this.deleteSurvey })
+    if (this.deletable()) actions.push({ name: t('Delete'), func: this.askDeleteSurvey })
 
     return (
       <div className='col s12 m6 l4'>
@@ -145,27 +149,27 @@ class _PanelSurveyCard extends Component<any> {
     dispatch(panelSurveyActions.changeFolder(panelSurvey, folderId))
   }
 
-  askDeleteSurvey = () => {
+  askDeletePanelSurveyWave = () => {
     const { t } = this.props
 
-    const survey = this.latestWave()
+    const wave = this.latestWave()
 
     this.refs.deleteSurveyConfirmationModal.open({
       modalText: <span>
         <p>
           <Trans>
-            Are you sure you want to delete the last wave <b><UntitledIfEmpty text={survey.name} emptyText={untitledSurveyTitle(survey, t)} /></b>?
+            Are you sure you want to delete the last wave <b><UntitledIfEmpty text={wave.name} emptyText={untitledSurveyTitle(wave, t)} /></b>?
           </Trans>
         </p>
         <p>{t('All the respondent information will be lost and cannot be undone.')}</p>
       </span>,
-      onConfirm: () => this.confirmDeleteSurvey(survey)
+      onConfirm: () => this.confirmDeletePanelSurveyWave(wave)
     })
   }
 
-  confirmDeleteSurvey = (survey: Survey) => {
+  confirmDeletePanelSurveyWave = (wave: Survey) => {
     const { dispatch } = this.props
-    dispatch(surveyActions.deleteSurvey(survey))
+    dispatch(surveyActions.deleteSurvey(wave))
   }
 
   askDeletePanelSurvey = () => {
@@ -205,7 +209,7 @@ class _PanelSurveyCard extends Component<any> {
 
     let actions = []
     if (this.movable()) actions.push({ name: t('Move to'), func: this.askMovePanelSurvey })
-    if (this.deletable()) actions.push({ name: t('Delete wave'), func: this.askDeleteSurvey })
+    if (this.deletable()) actions.push({ name: t('Delete wave'), func: this.askDeletePanelSurveyWave })
     actions.push({ name: t('Delete Panel Survey'), func: this.askDeletePanelSurvey })
 
     return (
@@ -224,7 +228,7 @@ class _PanelSurveyCard extends Component<any> {
 
         <ConfirmationModal modalId='survey_index_move_survey' ref='moveSurveyConfirmationModal' confirmationText={t('Move')} header={t('Move survey')} showCancel />
         <ConfirmationModal modalId='survey_index_delete' ref='deleteSurveyConfirmationModal' confirmationText={t('Delete')} header={t('Delete survey')} showCancel />
-        <ConfirmationCheckModal modalId='panel_survey_index_delete' ref='deletePanelSurveyConfirmationModal' t={t} />
+        <TwoStepsConfirmationModal modalId='panel_survey_index_delete' ref='deletePanelSurveyConfirmationModal' t={t} />
       </div>
     )
   }
@@ -312,9 +316,9 @@ ActionMenu.propTypes = {
   actions: PropTypes.array
 }
 
-class ConfirmationCheckModal extends Component<Props, State> {
+class TwoStepsConfirmationModal extends Component<Props, State> {
   static propTypes = {
-    modalId: PropTypes.String,
+    modalId: PropTypes.string,
     t: PropTypes.func
   }
 
@@ -355,10 +359,10 @@ class ConfirmationCheckModal extends Component<Props, State> {
     const { modalId, t } = this.props
 
     return (
-      <div style={{ 'text-align': 'center' }}>
+      <div style={{ textAlign: 'center' }}>
         <Modal card id={modalId} ref='modal'>
           <div className='modal-content'>
-            <div className='card-title header' style={{'margin-bottom': '48px'}}>
+            <div className='card-title header' style={{ marginBottom: '48px' }}>
               <h5>{t('Delete Panel Survey')}</h5>
             </div>
             <div className='card-content'>

--- a/web/static/js/components/surveys/SurveyIndex.jsx
+++ b/web/static/js/components/surveys/SurveyIndex.jsx
@@ -224,7 +224,12 @@ const FoldersGrid = (props) => {
   return (
     <div className='survey-index-grid'>
       {folders && folders.map(folder =>
-        <FolderCard key={folder.id} {...folder} t={t} onRename={onRename} onDelete={onDelete} readOnly={isReadOnly} />)}
+        <FolderCard key={`folder-${folder.id}`}
+                    {...folder}
+                    onRename={onRename}
+                    onDelete={onDelete}
+                    readOnly={isReadOnly}
+                    t={t} />)}
     </div>
   )
 }

--- a/web/static/js/reducers/panelSurveys.js
+++ b/web/static/js/reducers/panelSurveys.js
@@ -3,15 +3,21 @@ import collectionReducer, { projectFilterProvider } from './collection'
 
 const itemsReducer = (state: IndexedList<PanelSurvey>, action): IndexedList<PanelSurvey> => {
   switch (action.type) {
+    case actions.DELETED: return deleteItem(state, action)
     case actions.FOLDER_CHANGED: return changeFolder(state, action)
     default: return state
   }
 }
 
+const deleteItem = (state: IndexedList<PanelSurvey>, action: any) => {
+  const items = { ...state }
+  delete items[action.id]
+  return items
+}
+
 const changeFolder = (state: IndexedList<PanelSurvey>, action: any) => {
   const items = { ...state }
   delete items[action.panelSurveyId]
-
   return items
 }
 

--- a/web/static/js/reducers/surveys.js
+++ b/web/static/js/reducers/surveys.js
@@ -19,7 +19,6 @@ const deleteItem = (state: IndexedList<Survey>, action: any) => {
 const changeFolder = (state: IndexedList<Survey>, action: any) => {
   const items = {...state}
   delete items[action.surveyId]
-
   return items
 }
 


### PR DESCRIPTION
Related #2029 

- Add Delete Panel Survey feature.
- The card of a Panel Survey now have 3 options:
   - Move
   - Delete wave (delete the wave shown - ie. the last wave)
   - Delete Panel Survey
