### PR TITLE
GHA: avoid duplicated runs and useless builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,15 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - "**"
+
+  pull_request:
+    branches:
+      - "**:**"
 
 jobs:
   test:
@@ -23,13 +32,15 @@ jobs:
           docker-compose run --rm webpack yarn eslint
 
   build:
-    needs: test
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    needs: test
+    if: contains('refs/heads/main', github.ref) || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/preview') || startsWith(github.ref, 'refs/tags/')
+
     env:
       DOCKER_REPOSITORY: 'instedd/ask'
       DOCKER_USER: ${{ secrets.DOCKER_USER }}
       DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Build image & push to Docker Hub

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
-    if: contains('refs/heads/main', github.ref) || startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/preview') || startsWith(github.ref, 'refs/tags/')
+    if: contains('refs/heads/main', github.ref) || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/preview/') || startsWith(github.ref, 'refs/tags/')
 
     env:
       DOCKER_REPOSITORY: 'instedd/ask'


### PR DESCRIPTION
Avoids the duplicated run on `push` and `pull_request` events for internal branches. Also avoids building the Docker image unless we really want one: main, release or preview branches, and release tags.