### PR TITLE
Truncate long messages in IVR simulator

### DIFF
--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -88,6 +88,7 @@
   "Choose the data you want to download": "",
   "Choose the disposition you want to set at this point of the questionnaire.": "",
   "Choose the questionnaire answers you want to use to define quotas": "",
+  "Click to expand message": "",
   "Close": "",
   "Collaborator level successfully updated": "",
   "Collaborator successfully removed": "",

--- a/locales/translations/fr.json
+++ b/locales/translations/fr.json
@@ -131,6 +131,7 @@
     "Choose the disposition you want to set at this point of the questionnaire.": "Choisissez la disposition que vous voulez définir à ce moment du questionnaire.",
     "Choose the questionnaire answers you want to use to define quotas": "Choisissez les questions de questionnaire pour lesquelles vous voulez définir des quotas",
     "Clickatell, DTAC, I-POP, Multimodem iSms and 8 more": "Clickatell, DTAC, I-POP, Multimodem iSms et 8 autres",
+    "Click to expand message": "Cliquez pour afficher le message",
     "Close": "Fermer",
     "Collaborator level successfully updated": "Le niveau de collaborateur a bien été mis à jour",
     "Collaborator successfully removed": "Le collaborateur a bien été supprimé",

--- a/web/static/css/_quex-simulation.scss
+++ b/web/static/css/_quex-simulation.scss
@@ -110,6 +110,10 @@ $smallChatWindowBodyHeight: $smallSimulationHeight -
       position: relative;
       clear: both; //for maintaining a one bubble per row
 
+      &.is-expandable {
+        cursor: pointer;
+      }
+
       .content-text {
         display: inline-block;
         overflow-wrap: break-word;

--- a/web/static/js/components/simulation/MessagesList.jsx
+++ b/web/static/js/components/simulation/MessagesList.jsx
@@ -16,6 +16,7 @@ type MessagesListProps = {
 type MessageProps = {
   message: ChatMessage,
   truncateAt: ?number,
+  t: Function,
 }
 
 type MessageState = {

--- a/web/static/js/components/simulation/MessagesList.jsx
+++ b/web/static/js/components/simulation/MessagesList.jsx
@@ -22,46 +22,43 @@ type MessageState = {
   truncated: boolean,
 }
 
-const Message = translate()(class extends Component<MessageProps, MessageState> {
-  constructor(props) {
-    super(props)
+const Message = translate()(
+  class extends Component<MessageProps, MessageState> {
+    constructor(props) {
+      super(props)
 
-    this.state = {
-      truncated: props.truncateAt && props.message.body.length > props.truncateAt,
-    }
-  }
-
-  render() {
-    const { message, t } = this.props
-    const body = this.truncate(message.body.trim())
-    let expandable, title
-
-    if (this.state.truncated) {
-      expandable = "is-expandable"
-      title = t("Click to expand message")
+      this.state = {
+        truncated: props.truncateAt && props.message.body.length > props.truncateAt,
+      }
     }
 
-    return (
-      <li
-        className={`message-bubble ${message.type}-message ${expandable}`}
-        title={title}
-        onClick={() => this.expand()}
-      >
-        <div className="content-text" dangerouslySetInnerHTML={{ __html: linkifyStr(body) }} />
-      </li>
-    )
-  }
+    render() {
+      const { message, t } = this.props
+      const { truncated } = this.state
+      const body = this.truncate(message.body.trim())
 
-  truncate(body) {
-    return this.state.truncated === true ? `${body.slice(0, this.props.truncateAt)}…` : body
-  }
+      return (
+        <li
+          className={`message-bubble ${message.type}-message ${truncated && "is-expandable"}`}
+          title={truncated && t("Click to expand message")}
+          onClick={() => this.expand()}
+        >
+          <div className="content-text" dangerouslySetInnerHTML={{ __html: linkifyStr(body) }} />
+        </li>
+      )
+    }
 
-  expand() {
-    if (this.state.truncated) {
-      this.setState({ truncated: false })
+    truncate(body) {
+      return this.state.truncated === true ? `${body.slice(0, this.props.truncateAt)}…` : body
+    }
+
+    expand() {
+      if (this.state.truncated) {
+        this.setState({ truncated: false })
+      }
     }
   }
-})
+)
 
 export class MessagesList extends Component<MessagesListProps> {
   messagesBottomDivRef: any

--- a/web/static/js/components/simulation/MessagesList.jsx
+++ b/web/static/js/components/simulation/MessagesList.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import linkifyStr from "linkifyjs/string"
+import { translate } from "react-i18next"
 
 export type ChatMessage = {
   type: string,
@@ -21,7 +22,7 @@ type MessageState = {
   truncated: boolean,
 }
 
-class Message extends Component<MessageProps, MessageState> {
+const Message = translate()(class extends Component<MessageProps, MessageState> {
   constructor(props) {
     super(props)
 
@@ -31,11 +32,21 @@ class Message extends Component<MessageProps, MessageState> {
   }
 
   render() {
-    const { message } = this.props
+    const { message, t } = this.props
     const body = this.truncate(message.body.trim())
+    let expandable, title
+
+    if (this.state.truncated) {
+      expandable = "is-expandable"
+      title = t("Click to expand message")
+    }
 
     return (
-      <li className={`message-bubble ${message.type}-message`} onClick={() => this.expand()}>
+      <li
+        className={`message-bubble ${message.type}-message ${expandable}`}
+        title={title}
+        onClick={() => this.expand()}
+      >
         <div className="content-text" dangerouslySetInnerHTML={{ __html: linkifyStr(body) }} />
       </li>
     )
@@ -50,7 +61,7 @@ class Message extends Component<MessageProps, MessageState> {
       this.setState({ truncated: false })
     }
   }
-}
+})
 
 export class MessagesList extends Component<MessagesListProps> {
   messagesBottomDivRef: any

--- a/web/static/js/components/simulation/VoiceWindow.jsx
+++ b/web/static/js/components/simulation/VoiceWindow.jsx
@@ -181,7 +181,7 @@ const VoiceWindow = translate()(
               className="voice-spectrum-bands"
             />
           </div>
-          <MessagesList messages={messages} scrollToBottom />
+          <MessagesList messages={messages} truncateAt={140} scrollToBottom />
 
           <div className="voice-keypad">
             <div


### PR DESCRIPTION
Truncates long message in the IVR simulator, and adds an ellipsis.

It also doesn't automatically scroll to the bottom when expanding a message, only when sending and receiving the message.

Maybe the message bubble should have the `cursor: pointer` CSS property when the message can be expanded? Maybe it could have an explicit `(click to expand)` or alike message?

closes #2053 