### PR TITLE
Fix: reset respondent sanitized phone number

### DIFF
--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -610,20 +610,18 @@ defmodule Ask.Runtime.Session do
     canonical_number_as_list = respondent.canonical_phone_number |> String.graphemes()
     matching_patterns = ChannelPatterns.matching_patterns(patterns, canonical_number_as_list)
 
-    case matching_patterns do
-      [] ->
-        respondent
+    sanitized_phone_number =
+      case matching_patterns do
+        [] ->
+          respondent.canonical_phone_number
 
-      [p | _] ->
-        sanitized_phone_number = ChannelPatterns.apply_pattern(p, canonical_number_as_list)
+        [p | _] ->
+          ChannelPatterns.apply_pattern(p, canonical_number_as_list)
+      end
 
-        {:ok, updated_respondent} =
-          respondent
-          |> Respondent.changeset(%{sanitized_phone_number: sanitized_phone_number})
-          |> Repo.update()
-
-        updated_respondent
-    end
+    respondent
+    |> Respondent.changeset(%{sanitized_phone_number: sanitized_phone_number})
+    |> Repo.update!()
   end
 
   defp log_prompts(reply, channel, mode, respondent, force \\ false, persist \\ true) do

--- a/test/lib/runtime/session_test.exs
+++ b/test/lib/runtime/session_test.exs
@@ -153,7 +153,7 @@ defmodule Ask.SessionTest do
     assert (Respondent |> Repo.get(respondent.id)).sanitized_phone_number == "51234"
   end
 
-  test "sanitized_phone_number remains the same when starting and channel has no patterns", %{
+  test "sanitized_phone_number is reset when starting and channel has no patterns", %{
     quiz: quiz
   } do
     test_channel = TestChannel.new()
@@ -164,7 +164,7 @@ defmodule Ask.SessionTest do
     respondent =
       insert(:respondent,
         phone_number: phone_number,
-        sanitized_phone_number: canonical_phone_number,
+        sanitized_phone_number: "00331234",
         canonical_phone_number: canonical_phone_number
       )
 
@@ -177,7 +177,7 @@ defmodule Ask.SessionTest do
              canonical_phone_number
   end
 
-  test "sanitized_phone_number remains the same when starting and no pattern matches", %{
+  test "sanitized_phone_number is reset when starting and no pattern matches", %{
     quiz: quiz
   } do
     patterns = [
@@ -197,7 +197,7 @@ defmodule Ask.SessionTest do
     respondent =
       insert(:respondent,
         phone_number: phone_number,
-        sanitized_phone_number: canonical_phone_number,
+        sanitized_phone_number: "00331234",
         canonical_phone_number: canonical_phone_number
       )
 


### PR DESCRIPTION
Merely overwrites the sanitized phone number in the database instead of doing nothing. If another channel applied some patterns previously, then the new attempt with this channel will be reset to use the original phone number.

fixes #2055 