### PR TITLE
Add daily success rate chart

### DIFF
--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -50,6 +50,7 @@ class SurveyShow extends Component<any, State> {
     target: PropTypes.number,
     completionPercentage: PropTypes.number,
     cumulativePercentages: PropTypes.object,
+    percentages: PropTypes.object,
     completionRate: PropTypes.number,
     estimatedSuccessRate: PropTypes.number,
     initialSuccessRate: PropTypes.number,
@@ -158,6 +159,7 @@ class SurveyShow extends Component<any, State> {
       reference,
       attemptedRespondents,
       cumulativePercentages,
+      percentages,
       target,
       project,
       t,
@@ -244,7 +246,7 @@ class SurveyShow extends Component<any, State> {
         { value: attemptedRespondents, label: t("Attempted Respondents") },
       ]
     }
-    let colors = referenceColors((reference || []).length - 1)
+    let colors = referenceColors((reference || []).length)
 
     const hasQuotas = survey.quotas.vars.length > 0
 
@@ -255,7 +257,7 @@ class SurveyShow extends Component<any, State> {
 
       return {
         label: `${name}${separator}${modes}`,
-        color: r.id == 0 ? "#000000" : colors[i],
+        color: colors[i],
         id: r.id,
       }
     })
@@ -271,9 +273,17 @@ class SurveyShow extends Component<any, State> {
       ]
     }
 
+    if (percentages) {
+      forecastsReferences.push({
+        label: "Success rate",
+        color: "#000000",
+        id: "successRate",
+      })
+    }
+
     // TODO: we should be doing this when receiving properties, not at render
     let forecasts = forecastsReferences.map((d) => {
-      const values = (cumulativePercentages[d.id] || []).map((v) => ({
+      const values = (cumulativePercentages[d.id] || percentages[d.id] || []).map((v) => ({
         time: new Date(v.date),
         value: Number(v.percent),
       }))
@@ -583,6 +593,7 @@ const mapStateToProps = (state, ownProps) => {
 
   let respondentsByDisposition = null
   let cumulativePercentages = {}
+  let percentages = {}
   let attemptedRespondents = 0
   let totalRespondents = 0
   let target = 0
@@ -592,6 +603,7 @@ const mapStateToProps = (state, ownProps) => {
   if (respondentsStatsRoot) {
     respondentsByDisposition = respondentsStatsRoot.respondentsByDisposition
     cumulativePercentages = respondentsStatsRoot.cumulativePercentages
+    percentages = respondentsStatsRoot.percentages
     attemptedRespondents = respondentsStatsRoot.attemptedRespondents
     totalRespondents = respondentsStatsRoot.totalRespondents
     target = respondentsStatsRoot.target
@@ -607,6 +619,7 @@ const mapStateToProps = (state, ownProps) => {
     questionnaires: !state.survey.data ? {} : state.survey.data.questionnaires,
     respondentsByDisposition: respondentsByDisposition,
     cumulativePercentages: cumulativePercentages,
+    percentages: percentages,
     attemptedRespondents: attemptedRespondents,
     totalRespondents: totalRespondents,
     target: target,

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -244,7 +244,7 @@ class SurveyShow extends Component<any, State> {
         { value: attemptedRespondents, label: t("Attempted Respondents") },
       ]
     }
-    let colors = referenceColors((reference || []).length)
+    let colors = referenceColors((reference || []).length - 1)
 
     const hasQuotas = survey.quotas.vars.length > 0
 
@@ -255,7 +255,7 @@ class SurveyShow extends Component<any, State> {
 
       return {
         label: `${name}${separator}${modes}`,
-        color: colors[i],
+        color: r.id == 0 ? "#000000" : colors[i],
         id: r.id,
       }
     })

--- a/lib/ask/survey.ex
+++ b/lib/ask/survey.ex
@@ -584,6 +584,7 @@ defmodule Ask.Survey do
   def completion_rate(_, 0), do: 0.0
   def completion_rate(completed, respondents_target), do: completed / respondents_target
 
+  # Calculates the current success rate since the survey was launched.
   def get_success_rate(survey, respondents_by_disposition) do
     completed_respondents = get_completed_respondents(survey, respondents_by_disposition)
 
@@ -591,6 +592,42 @@ defmodule Ask.Survey do
       exhausted_respondents(respondents_by_disposition, survey.count_partial_results)
 
     success_rate(completed_respondents, exhausted_respondents)
+  end
+
+  # Calculates the daily sucess rate since the survey was launched until it
+  # ended or today if it's running.
+  def success_rate_history(survey) do
+    completed_dispositions = Respondent.completed_dispositions(survey.count_partial_results)
+    completed = survey |> respondents_history(completed_dispositions)
+
+    exhausted_dispositions = Respondent.metrics_final_dispositions(survey.count_partial_results)
+    exhausted = survey |> respondents_history(exhausted_dispositions)
+
+    running_date_range(survey)
+    |> Enum.map(fn date ->
+      {date, completion_rate(completed[date], exhausted[date]) * 100}
+    end)
+  end
+
+  # Counts respondents with specified dispositions with daily granularity.
+  defp respondents_history(survey, dispositions) do
+    survey
+    |> assoc(:respondents)
+    |> select({fragment("DATE(completed_at)"), fragment("COUNT(*)")})
+    |> group_by(fragment("DATE(completed_at)"))
+    |> where([r], r.disposition in ^dispositions)
+    |> Repo.all()
+    |> Enum.into(%{})
+  end
+
+  # Generates the actual running date range, from the day the survey started to
+  # the day it ended (or today if it's still running).
+  defp running_date_range(%Survey{started_at: started_at, ended_at: nil}) do
+    Date.range(started_at |> DateTime.to_date(), Date.utc_today())
+  end
+
+  defp running_date_range(%Survey{started_at: started_at, ended_at: ended_at}) do
+    Date.range(started_at |> DateTime.to_date(), ended_at |> DateTime.to_date())
   end
 
   def get_completed_respondents(survey, respondents_by_disposition) do

--- a/lib/ask/survey.ex
+++ b/lib/ask/survey.ex
@@ -582,6 +582,7 @@ defmodule Ask.Survey do
 
   def completion_rate(_, nil), do: 0.0
   def completion_rate(_, 0), do: 0.0
+  def completion_rate(nil, _), do: 0.0
   def completion_rate(completed, respondents_target), do: completed / respondents_target
 
   # Calculates the current success rate since the survey was launched.
@@ -596,6 +597,8 @@ defmodule Ask.Survey do
 
   # Calculates the daily sucess rate since the survey was launched until it
   # ended or today if it's running.
+  def success_rate_history(%{started_at: nil}), do: []
+
   def success_rate_history(survey) do
     completed_dispositions = Respondent.completed_dispositions(survey.count_partial_results)
     completed = survey |> respondents_history(completed_dispositions)
@@ -613,8 +616,8 @@ defmodule Ask.Survey do
   defp respondents_history(survey, dispositions) do
     survey
     |> assoc(:respondents)
-    |> select({fragment("DATE(completed_at)"), fragment("COUNT(*)")})
-    |> group_by(fragment("DATE(completed_at)"))
+    |> select({fragment("DATE(COALESCE(completed_at, updated_at))"), fragment("COUNT(*)")})
+    |> group_by(fragment("DATE(COALESCE(completed_at, updated_at))"))
     |> where([r], r.disposition in ^dispositions)
     |> Repo.all()
     |> Enum.into(%{})

--- a/lib/ask_web/controllers/respondent_controller.ex
+++ b/lib/ask_web/controllers/respondent_controller.ex
@@ -277,9 +277,7 @@ defmodule AskWeb.RespondentController do
         respondent_counts(respondents_by_disposition, total_respondents),
       cumulative_percentages:
         cumulative_percentages(references, grouped_respondents, survey, target, buckets),
-      percentages: %{
-        "success_rate" => Survey.success_rate_history(survey)
-      },
+      percentages: percentages(survey),
       completion_percentage: completed_or_partial / target * 100,
       total_respondents: total_respondents,
       target: target,
@@ -564,6 +562,38 @@ defmodule AskWeb.RespondentController do
   defp add_percent(cumulative_percent, count, percent_provider) do
     (cumulative_percent + percent_provider.(count))
     |> min(100.0)
+  end
+
+  defp percentages(%{started_at: nil}), do: %{}
+
+  defp percentages(survey) do
+    %{
+      success_rate: cleanup_repetitive_percentages(Survey.success_rate_history(survey))
+    }
+  end
+
+  # Cleanup repetitive values, by skipping any repetitive value except for the
+  # first and last, because they don't contribute anything to the graph
+  # (straight line).
+  #
+  # For example take A, B, C, D consecutive dates, each at value 5.0 then we
+  # only keep A and D and skip B and C entirely.
+  #
+  # TODO: consider moving to RespondentView.
+  defp cleanup_repetitive_percentages(percentages, result \\ [])
+  defp cleanup_repetitive_percentages([], result), do: result
+  defp cleanup_repetitive_percentages([a], result), do: result ++ [a]
+  defp cleanup_repetitive_percentages([a, b], result), do: result ++ [a, b]
+
+  defp cleanup_repetitive_percentages(
+         [{_, value_a} = a, {_, value_b} = b, {_, value_c} = c | rest],
+         result
+       ) do
+    if value_a == value_b && value_a == value_c do
+      cleanup_repetitive_percentages([a, c | rest], result)
+    else
+      cleanup_repetitive_percentages([b, c | rest], result ++ [a])
+    end
   end
 
   defp respondents_by_questionnaire_and_disposition(survey) do

--- a/lib/ask_web/views/respondent_view.ex
+++ b/lib/ask_web/views/respondent_view.ex
@@ -220,6 +220,7 @@ defmodule AskWeb.RespondentView do
           id: id,
           reference: buckets,
           respondents_by_disposition: respondents_by_disposition,
+          percentages: percentages,
           cumulative_percentages: cumulative_percentages,
           attempted_respondents: attempted_respondents,
           total_respondents: total_respondents,
@@ -232,15 +233,8 @@ defmodule AskWeb.RespondentView do
         id: id,
         respondents_by_disposition: respondents_by_disposition,
         reference: render_many(buckets, AskWeb.RespondentView, "survey_bucket.json", as: :bucket),
-        cumulative_percentages:
-          cumulative_percentages
-          |> Enum.map(fn {questionnaire_id, date_percentages} ->
-            {to_string(questionnaire_id),
-             render_many(date_percentages, AskWeb.RespondentView, "date_percentages.json",
-               as: :completed
-             )}
-          end)
-          |> Enum.into(%{}),
+        percentages: render_percentages(percentages),
+        cumulative_percentages: render_percentages(cumulative_percentages),
         completion_percentage: completion_percentage,
         attempted_respondents: attempted_respondents,
         total_respondents: total_respondents,

--- a/lib/ask_web/views/respondent_view.ex
+++ b/lib/ask_web/views/respondent_view.ex
@@ -177,6 +177,7 @@ defmodule AskWeb.RespondentView do
       data: %{
         reference: %{},
         respondents_by_disposition: %{},
+        percentages: %{},
         cumulative_percentages: %{},
         completion_percentage: 0,
         attempted_respondents: 0,
@@ -191,6 +192,7 @@ defmodule AskWeb.RespondentView do
           id: id,
           respondents_by_disposition: respondents_by_disposition,
           reference: reference,
+          percentages: percentages,
           cumulative_percentages: cumulative_percentages,
           attempted_respondents: attempted_respondents,
           total_respondents: total_respondents,
@@ -203,15 +205,8 @@ defmodule AskWeb.RespondentView do
         id: id,
         reference: reference,
         respondents_by_disposition: respondents_by_disposition,
-        cumulative_percentages:
-          cumulative_percentages
-          |> Enum.map(fn {questionnaire_id, date_percentages} ->
-            {to_string(questionnaire_id),
-             render_many(date_percentages, AskWeb.RespondentView, "date_percentages.json",
-               as: :completed
-             )}
-          end)
-          |> Enum.into(%{}),
+        percentages: render_percentages(percentages),
+        cumulative_percentages: render_percentages(cumulative_percentages),
         completion_percentage: completion_percentage,
         attempted_respondents: attempted_respondents,
         total_respondents: total_respondents,
@@ -289,4 +284,15 @@ defmodule AskWeb.RespondentView do
     }
 
   defp render_index_meta(%{respondents_count: respondents_count}), do: %{count: respondents_count}
+
+  defp render_percentages(percentages) do
+    percentages
+    |> Enum.map(fn {id, date_percentages} ->
+      {to_string(id),
+       render_many(date_percentages, AskWeb.RespondentView, "date_percentages.json",
+         as: :completed
+       )}
+    end)
+    |> Enum.into(%{})
+  end
 end

--- a/test/ask/survey_test.exs
+++ b/test/ask/survey_test.exs
@@ -207,4 +207,44 @@ defmodule Ask.SurveyTest do
       assert created_survey.panel_survey_id == panel_survey.id
     end
   end
+
+  describe "success_rate_history" do
+    test "reports until today" do
+      started = DateTime.utc_now() |> Timex.shift(days: -5)
+      date = DateTime.to_date(started)
+
+      history =
+        insert(:survey, started_at: started)
+        |> Survey.success_rate_history()
+
+      assert history == [
+               {date, 0.0},
+               {date |> Timex.shift(days: 1), 0.0},
+               {date |> Timex.shift(days: 2), 0.0},
+               {date |> Timex.shift(days: 3), 0.0},
+               {date |> Timex.shift(days: 4), 0.0},
+               {date |> Timex.shift(days: 5), 0.0}
+             ]
+    end
+
+    test "reports until survey ends date" do
+      started = DateTime.utc_now() |> Timex.shift(days: -10)
+      ended = started |> Timex.shift(days: +6)
+      date = DateTime.to_date(started)
+
+      history =
+        insert(:survey, started_at: started, ended_at: ended)
+        |> Survey.success_rate_history()
+
+      assert history == [
+               {date, 0.0},
+               {date |> Timex.shift(days: 1), 0.0},
+               {date |> Timex.shift(days: 2), 0.0},
+               {date |> Timex.shift(days: 3), 0.0},
+               {date |> Timex.shift(days: 4), 0.0},
+               {date |> Timex.shift(days: 5), 0.0},
+               {date |> Timex.shift(days: 6), 0.0}
+             ]
+    end
+  end
 end

--- a/test/ask/survey_test.exs
+++ b/test/ask/survey_test.exs
@@ -211,39 +211,39 @@ defmodule Ask.SurveyTest do
   describe "success_rate_history" do
     test "reports until today" do
       started = DateTime.utc_now() |> Timex.shift(days: -5)
-      date = DateTime.to_date(started)
+      start_date = DateTime.to_date(started)
 
       history =
         insert(:survey, started_at: started)
         |> Survey.success_rate_history()
 
       assert history == [
-               {date, 0.0},
-               {date |> Timex.shift(days: 1), 0.0},
-               {date |> Timex.shift(days: 2), 0.0},
-               {date |> Timex.shift(days: 3), 0.0},
-               {date |> Timex.shift(days: 4), 0.0},
-               {date |> Timex.shift(days: 5), 0.0}
+               {start_date, 0.0},
+               {start_date |> Timex.shift(days: 1), 0.0},
+               {start_date |> Timex.shift(days: 2), 0.0},
+               {start_date |> Timex.shift(days: 3), 0.0},
+               {start_date |> Timex.shift(days: 4), 0.0},
+               {start_date |> Timex.shift(days: 5), 0.0}
              ]
     end
 
     test "reports until survey ends date" do
       started = DateTime.utc_now() |> Timex.shift(days: -10)
+      start_date = DateTime.to_date(started)
       ended = started |> Timex.shift(days: +6)
-      date = DateTime.to_date(started)
 
       history =
         insert(:survey, started_at: started, ended_at: ended)
         |> Survey.success_rate_history()
 
       assert history == [
-               {date, 0.0},
-               {date |> Timex.shift(days: 1), 0.0},
-               {date |> Timex.shift(days: 2), 0.0},
-               {date |> Timex.shift(days: 3), 0.0},
-               {date |> Timex.shift(days: 4), 0.0},
-               {date |> Timex.shift(days: 5), 0.0},
-               {date |> Timex.shift(days: 6), 0.0}
+               {start_date, 0.0},
+               {start_date |> Timex.shift(days: 1), 0.0},
+               {start_date |> Timex.shift(days: 2), 0.0},
+               {start_date |> Timex.shift(days: 3), 0.0},
+               {start_date |> Timex.shift(days: 4), 0.0},
+               {start_date |> Timex.shift(days: 5), 0.0},
+               {start_date |> Timex.shift(days: 6), 0.0}
              ]
     end
   end

--- a/test/ask_web/controllers/respondent_controller_test.exs
+++ b/test/ask_web/controllers/respondent_controller_test.exs
@@ -431,6 +431,15 @@ defmodule AskWeb.RespondentControllerTest do
 
       assert data["total_respondents"] == 15
 
+      assert data["percentages"] == %{
+               "success_rate" => [
+                 %{"date" => "2016-01-01", "percent" => 100.0},
+                 %{"date" => "2016-01-02", "percent" => 100.0},
+                 %{"date" => "2016-01-03", "percent" => 0.0},
+                 %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+               ]
+             }
+
       assert data["cumulative_percentages"] == %{
                to_string(questionnaire.id) => [
                  %{"date" => "2016-01-01", "percent" => 20.0},
@@ -520,8 +529,18 @@ defmodule AskWeb.RespondentControllerTest do
       )
 
       conn = get(conn, project_survey_respondents_stats_path(conn, :stats, project.id, survey.id))
+      %{"data" => data} = json_response(conn, 200)
 
-      assert json_response(conn, 200)["data"]["cumulative_percentages"] == %{
+      assert data["percentages"] == %{
+               "success_rate" => [
+                 %{"date" => "2016-01-01", "percent" => 100.0},
+                 %{"date" => "2016-01-02", "percent" => 100.0},
+                 %{"date" => "2016-01-03", "percent" => 0.0},
+                 %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+               ]
+             }
+
+      assert data["cumulative_percentages"] == %{
                "#{q1.id}sms" => [
                  %{"date" => "2016-01-01", "percent" => 40.0},
                  %{
@@ -606,8 +625,18 @@ defmodule AskWeb.RespondentControllerTest do
       )
 
       conn = get(conn, project_survey_respondents_stats_path(conn, :stats, project.id, survey.id))
+      %{"data" => data} = json_response(conn, 200)
 
-      assert json_response(conn, 200)["data"]["cumulative_percentages"] == %{
+      assert data["percentages"] == %{
+               "success_rate" => [
+                 %{"date" => "2016-01-01", "percent" => 100.0},
+                 %{"date" => "2016-01-02", "percent" => 100.0},
+                 %{"date" => "2016-01-03", "percent" => 0.0},
+                 %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+               ]
+             }
+
+      assert data["cumulative_percentages"] == %{
                "#{q1.id}sms" => [%{"date" => "2016-01-01", "percent" => 40.0}],
                "#{q1.id}ivr" => [%{"date" => "2016-01-01", "percent" => 0.0}],
                "#{q2.id}sms" => [%{"date" => "2016-01-01", "percent" => 40.0}],
@@ -669,8 +698,18 @@ defmodule AskWeb.RespondentControllerTest do
       )
 
       conn = get(conn, project_survey_respondents_stats_path(conn, :stats, project.id, survey.id))
+      %{"data" => data} = json_response(conn, 200)
 
-      assert json_response(conn, 200)["data"]["cumulative_percentages"] ==
+      assert data["percentages"] == %{
+               "success_rate" => [
+                 %{"date" => "2016-01-01", "percent" => 100.0},
+                 %{"date" => "2016-01-02", "percent" => 100.0},
+                 %{"date" => "2016-01-03", "percent" => 0.0},
+                 %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+               ]
+             }
+
+      assert data["cumulative_percentages"] ==
                %{
                  "ivr" => [%{"date" => "2016-01-01", "percent" => 100.0}],
                  "sms" => [
@@ -702,8 +741,17 @@ defmodule AskWeb.RespondentControllerTest do
       )
 
       conn = get(conn, project_survey_respondents_stats_path(conn, :stats, project.id, survey.id))
+      %{"data" => data} = json_response(conn, 200)
 
-      assert json_response(conn, 200)["data"]["cumulative_percentages"] == %{
+      assert data["percentages"] == %{
+               "success_rate" => [
+                 %{"date" => "2016-01-01", "percent" => 100.0},
+                 %{"date" => "2016-01-02", "percent" => 0.0},
+                 %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+               ]
+             }
+
+      assert data["cumulative_percentages"] == %{
                to_string(questionnaire.id) => [%{"date" => "2016-01-01", "percent" => 100.0}]
              }
     end
@@ -819,6 +867,15 @@ defmodule AskWeb.RespondentControllerTest do
              }
 
       assert data["total_respondents"] == 16
+
+      assert data["percentages"] == %{
+               "success_rate" => [
+                 %{"date" => "2016-01-01", "percent" => 100.0},
+                 %{"date" => "2016-01-02", "percent" => 75.0},
+                 %{"date" => "2016-01-03", "percent" => 0.0},
+                 %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+               ]
+             }
 
       assert data["cumulative_percentages"] ==
                %{
@@ -973,6 +1030,14 @@ defmodule AskWeb.RespondentControllerTest do
       assert data["total_respondents"] == 15
       assert data["completion_percentage"] == 20
 
+      assert data["percentages"] == %{
+               "success_rate" => [
+                 %{"date" => "2016-01-01", "percent" => 100.0},
+                 %{"date" => "2016-01-02", "percent" => 0.0},
+                 %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+               ]
+             }
+
       assert data["cumulative_percentages"] == %{
                to_string(questionnaire.id) => [%{"date" => "2016-01-01", "percent" => 10.0}]
              }
@@ -1006,8 +1071,19 @@ defmodule AskWeb.RespondentControllerTest do
       )
 
       conn = get(conn, project_survey_respondents_stats_path(conn, :stats, project.id, survey.id))
+      %{"data" => data} = json_response(conn, 200)
 
-      assert json_response(conn, 200)["data"]["cumulative_percentages"] == %{
+      assert data["percentages"] == %{
+               "success_rate" => [
+                 %{"date" => "2016-01-01", "percent" => 0.0},
+                 %{"date" => "2016-01-04", "percent" => 0.0},
+                 %{"date" => "2016-01-05", "percent" => 100.0},
+                 %{"date" => "2016-01-06", "percent" => 0.0},
+                 %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+               ]
+             }
+
+      assert data["cumulative_percentages"] == %{
                to_string(questionnaire.id) => [
                  %{"date" => "2016-01-01", "percent" => 0.0},
                  %{"date" => "2016-01-04", "percent" => 0.0},
@@ -1036,8 +1112,16 @@ defmodule AskWeb.RespondentControllerTest do
       insert_list(10, :respondent, survey: survey, state: "pending")
 
       conn = get(conn, project_survey_respondents_stats_path(conn, :stats, project.id, survey.id))
+      %{"data" => data} = json_response(conn, 200)
 
-      assert json_response(conn, 200)["data"]["cumulative_percentages"] == %{
+      assert data["percentages"] == %{
+               "success_rate" => [
+                 %{"date" => "2016-01-01", "percent" => 0.0},
+                 %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+               ]
+             }
+
+      assert data["cumulative_percentages"] == %{
                to_string(questionnaire.id) => [
                  %{"date" => "2016-01-01", "percent" => 0.0},
                  %{
@@ -1117,6 +1201,7 @@ defmodule AskWeb.RespondentControllerTest do
       assert data["id"] == nil
       assert data["reference"] == %{}
       assert data["respondents_by_disposition"] == %{}
+      assert data["percentages"] == %{}
       assert data["cumulative_percentages"] == %{}
       assert data["completion_percentage"] == 0
       assert data["attempted_respondents"] == 0
@@ -1175,6 +1260,7 @@ defmodule AskWeb.RespondentControllerTest do
                    }
                  }
                },
+               "percentages" => %{},
                "cumulative_percentages" => %{},
                "total_respondents" => 5,
                "target" => 5,
@@ -1254,6 +1340,12 @@ defmodule AskWeb.RespondentControllerTest do
                  ],
                  "completion_percentage" => 0.0,
                  "attempted_respondents" => 0,
+                 "percentages" => %{
+                   "success_rate" => [
+                     %{"date" => "2016-01-01", "percent" => 0.0},
+                     %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+                   ]
+                 },
                  "cumulative_percentages" => %{
                    to_string(qb1.id) => [%{"date" => "2016-01-01", "percent" => 0.0}],
                    to_string(qb4.id) => [%{"date" => "2016-01-01", "percent" => 0.0}]
@@ -1416,6 +1508,13 @@ defmodule AskWeb.RespondentControllerTest do
                  ],
                  "completion_percentage" => 30.0,
                  "attempted_respondents" => 4,
+                 "percentages" => %{
+                   "success_rate" => [
+                     %{"date" => "2016-01-01", "percent" => 100.0},
+                     %{"date" => "2016-01-02", "percent" => 0.0},
+                     %{"date" => Date.utc_today() |> Date.to_string(), "percent" => 0.0}
+                   ]
+                 },
                  "cumulative_percentages" => %{
                    to_string(qb2.id) => [%{"date" => "2016-01-01", "percent" => 0.0}],
                    to_string(qb4.id) => [%{"date" => "2016-01-01", "percent" => 40.0}]


### PR DESCRIPTION
Calculates and reports the daily success rate to the frontend, and renders a line to the main survey chart.

I'm reporting a new `percentages` property to hold the success rate daily history, instead of adding it to the current `cumulative_percentages` property, because it's not a cumulative percentage (always grows over time) but a daily success rate (goes up and down).

I'm also not meddling with the `references` property because it describes the different cumulative percentages, and trying to add an `{ id: "success_rate", label: "Success rate" }` to it led the AskWeb.RespondentController to inject dummy values for it into `cumulative_percentages`. I thus hardcoded the addition of the line & label to the frontend, which seems acceptable because unlike the other references that are specific to the survey, this one is static and always displayed.

closes #2054 