### PR TITLE
Fix the default endpoint for testing

### DIFF
--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -26,7 +26,7 @@ defmodule AskWeb.ChannelCase do
       import Ecto.Query
 
       # The default endpoint for testing
-      @endpoint Ask.Endpoint
+      @endpoint AskWeb.Endpoint
     end
   end
 


### PR DESCRIPTION
Ask.Endpoint was renamed to AskWeb.Endpoint in #2067