### PR TITLE
Feature/2081 enhance channel label in survey

### DIFF
--- a/assets/js/components/surveys/RespondentsList.jsx
+++ b/assets/js/components/surveys/RespondentsList.jsx
@@ -154,7 +154,7 @@ const NewRespondentChannel = (
           <option value="">{t("Select a channel...")}</option>
           {channels.map((channel) => (
             <option key={channel.id} value={channel.id}>
-              {channel.name + channelFriendlyName(channel)}
+              {channel.name + channelFriendlyName(channel) + " (" + channel.userEmail + ")"}
             </option>
           ))}
         </Input>

--- a/lib/ask_web/controllers/channel_controller.ex
+++ b/lib/ask_web/controllers/channel_controller.ex
@@ -9,6 +9,9 @@ defmodule AskWeb.ChannelController do
       |> load_project(project_id)
       |> assoc(:channels)
       |> Repo.all()
+      |> Enum.map(fn channel ->
+        Map.put(channel, :user_email, AskWeb.UserController.email(conn, channel.user_id))
+      end)
 
     render(conn, "index.json", channels: channels |> Repo.preload(:projects))
   end
@@ -21,6 +24,9 @@ defmodule AskWeb.ChannelController do
       |> Repo.all()
       |> Repo.preload(:projects)
       |> Enum.map(&(&1 |> Channel.with_status()))
+      |> Enum.map(fn channel ->
+        Map.put(channel, :user_email, AskWeb.UserController.email(conn, channel.user_id))
+      end)
 
     render(conn, "index.json", channels: channels)
   end

--- a/lib/ask_web/controllers/channel_controller.ex
+++ b/lib/ask_web/controllers/channel_controller.ex
@@ -10,7 +10,7 @@ defmodule AskWeb.ChannelController do
       |> assoc(:channels)
       |> Repo.all()
       |> Enum.map(fn channel ->
-        Map.put(channel, :user_email, AskWeb.UserController.email(conn, channel.user_id))
+        Map.put(channel, :user_email, AskWeb.UserController.email(channel.user_id))
       end)
 
     render(conn, "index.json", channels: channels |> Repo.preload(:projects))
@@ -25,7 +25,7 @@ defmodule AskWeb.ChannelController do
       |> Repo.preload(:projects)
       |> Enum.map(&(&1 |> Channel.with_status()))
       |> Enum.map(fn channel ->
-        Map.put(channel, :user_email, AskWeb.UserController.email(conn, channel.user_id))
+        Map.put(channel, :user_email, AskWeb.UserController.email(channel.user_id))
       end)
 
     render(conn, "index.json", channels: channels)
@@ -39,6 +39,8 @@ defmodule AskWeb.ChannelController do
       |> Repo.preload(:projects)
       |> Channel.with_status()
 
+    channel = Map.put(channel, :user_email, AskWeb.UserController.email(channel.user_id))
+
     render(conn, "show.json", channel: channel)
   end
 
@@ -48,6 +50,8 @@ defmodule AskWeb.ChannelController do
       |> Repo.get!(id)
       |> authorize_channel(conn)
       |> Repo.preload([:projects])
+
+    channel = Map.put(channel, :user_email, AskWeb.UserController.email(channel.user_id))
 
     changeset =
       channel
@@ -107,6 +111,7 @@ defmodule AskWeb.ChannelController do
 
     provider = Ask.Channel.provider(provider)
     channel = provider.create_channel(user, base_url, api_channel)
+    channel = Map.put(channel, :user_email, AskWeb.UserController.email(channel.user_id))
 
     render(conn, "show.json", channel: channel |> Repo.preload(:projects))
   end

--- a/lib/ask_web/controllers/channel_controller.ex
+++ b/lib/ask_web/controllers/channel_controller.ex
@@ -10,9 +10,7 @@ defmodule AskWeb.ChannelController do
       |> assoc(:channels)
       |> Repo.all()
 
-    render(conn, "index.json",
-      channels: channels |> Repo.preload(:projects) |> Repo.preload(:user)
-    )
+    render(conn, "index.json", channels: channels |> Repo.preload([:projects, :user]))
   end
 
   def index(conn, _params) do
@@ -21,8 +19,7 @@ defmodule AskWeb.ChannelController do
       |> current_user
       |> assoc(:channels)
       |> Repo.all()
-      |> Repo.preload(:user)
-      |> Repo.preload(:projects)
+      |> Repo.preload([:projects, :user])
       |> Enum.map(&(&1 |> Channel.with_status()))
 
     render(conn, "index.json", channels: channels)
@@ -33,8 +30,7 @@ defmodule AskWeb.ChannelController do
       Channel
       |> Repo.get!(id)
       |> authorize_channel(conn)
-      |> Repo.preload(:projects)
-      |> Repo.preload(:user)
+      |> Repo.preload([:projects, :user])
       |> Channel.with_status()
 
     render(conn, "show.json", channel: channel)
@@ -45,8 +41,7 @@ defmodule AskWeb.ChannelController do
       Channel
       |> Repo.get!(id)
       |> authorize_channel(conn)
-      |> Repo.preload([:projects])
-      |> Repo.preload(:user)
+      |> Repo.preload([:projects, :user])
 
     changeset =
       channel
@@ -107,6 +102,6 @@ defmodule AskWeb.ChannelController do
     provider = Ask.Channel.provider(provider)
     channel = provider.create_channel(user, base_url, api_channel)
 
-    render(conn, "show.json", channel: channel |> Repo.preload(:projects) |> Repo.preload(:user))
+    render(conn, "show.json", channel: channel |> Repo.preload([:projects, :user]))
   end
 end

--- a/lib/ask_web/controllers/user_controller.ex
+++ b/lib/ask_web/controllers/user_controller.ex
@@ -9,7 +9,7 @@ defmodule AskWeb.UserController do
     render(conn, "settings.json", settings: settings)
   end
 
-  def email(conn, user_id) do
+  def email(user_id) do
     user =
       Repo.one(
         from u in Ask.User,

--- a/lib/ask_web/controllers/user_controller.ex
+++ b/lib/ask_web/controllers/user_controller.ex
@@ -9,6 +9,16 @@ defmodule AskWeb.UserController do
     render(conn, "settings.json", settings: settings)
   end
 
+  def email(conn, user_id) do
+    user =
+      Repo.one(
+        from u in Ask.User,
+          where: u.id == ^user_id
+      )
+
+    user.email
+  end
+
   def update_settings(conn, user_params) do
     user = conn |> current_user
 

--- a/lib/ask_web/controllers/user_controller.ex
+++ b/lib/ask_web/controllers/user_controller.ex
@@ -9,16 +9,6 @@ defmodule AskWeb.UserController do
     render(conn, "settings.json", settings: settings)
   end
 
-  def email(user_id) do
-    user =
-      Repo.one(
-        from u in Ask.User,
-          where: u.id == ^user_id
-      )
-
-    user.email
-  end
-
   def update_settings(conn, user_params) do
     user = conn |> current_user
 

--- a/lib/ask_web/views/channel_view.ex
+++ b/lib/ask_web/views/channel_view.ex
@@ -21,7 +21,7 @@ defmodule AskWeb.ChannelView do
       settings: channel.settings,
       patterns: channel.patterns,
       status_info: channel.status,
-      userEmail: channel.user_email
+      user_email: channel.user.email
     }
   end
 end

--- a/lib/ask_web/views/channel_view.ex
+++ b/lib/ask_web/views/channel_view.ex
@@ -20,7 +20,8 @@ defmodule AskWeb.ChannelView do
       channelBaseUrl: channel.base_url,
       settings: channel.settings,
       patterns: channel.patterns,
-      status_info: channel.status
+      status_info: channel.status,
+      userEmail: channel.user_email
     }
   end
 end

--- a/test/ask_web/controllers/channel_controller_test.exs
+++ b/test/ask_web/controllers/channel_controller_test.exs
@@ -34,7 +34,7 @@ defmodule AskWeb.ChannelControllerTest do
         "projects" => [],
         "channelBaseUrl" => channel.base_url,
         "status_info" => %{"status" => "unknown"},
-        "userEmail" => user.email
+        "user_email" => user.email
       }
 
       insert(:channel)
@@ -64,7 +64,7 @@ defmodule AskWeb.ChannelControllerTest do
         "projects" => [project.id],
         "channelBaseUrl" => channel1.base_url,
         "status_info" => nil,
-        "userEmail" => user.email
+        "user_email" => user.email
       }
 
       channel_map2 = %{
@@ -78,7 +78,7 @@ defmodule AskWeb.ChannelControllerTest do
         "projects" => [project.id],
         "channelBaseUrl" => channel2.base_url,
         "status_info" => nil,
-        "userEmail" => user2.email
+        "user_email" => user2.email
       }
 
       conn = get(conn, project_channel_path(conn, :index, project.id))
@@ -102,7 +102,7 @@ defmodule AskWeb.ChannelControllerTest do
                "projects" => [],
                "channelBaseUrl" => channel.base_url,
                "status_info" => %{"status" => "unknown"},
-               "userEmail" => user.email
+               "user_email" => user.email
              }
     end
 
@@ -199,7 +199,7 @@ defmodule AskWeb.ChannelControllerTest do
                "projects" => [],
                "patterns" => [],
                "status_info" => nil,
-               "userEmail" => user.email
+               "user_email" => user.email
              }
     end
 

--- a/test/ask_web/controllers/channel_controller_test.exs
+++ b/test/ask_web/controllers/channel_controller_test.exs
@@ -33,7 +33,8 @@ defmodule AskWeb.ChannelControllerTest do
         "user_id" => channel.user_id,
         "projects" => [],
         "channelBaseUrl" => channel.base_url,
-        "status_info" => %{"status" => "unknown"}
+        "status_info" => %{"status" => "unknown"},
+        "userEmail" => user.email
       }
 
       insert(:channel)
@@ -62,7 +63,8 @@ defmodule AskWeb.ChannelControllerTest do
         "user_id" => channel1.user_id,
         "projects" => [project.id],
         "channelBaseUrl" => channel1.base_url,
-        "status_info" => nil
+        "status_info" => nil,
+        "userEmail" => user.email
       }
 
       channel_map2 = %{
@@ -75,7 +77,8 @@ defmodule AskWeb.ChannelControllerTest do
         "user_id" => channel2.user_id,
         "projects" => [project.id],
         "channelBaseUrl" => channel2.base_url,
-        "status_info" => nil
+        "status_info" => nil,
+        "userEmail" => user2.email
       }
 
       conn = get(conn, project_channel_path(conn, :index, project.id))
@@ -98,7 +101,8 @@ defmodule AskWeb.ChannelControllerTest do
                "patterns" => [],
                "projects" => [],
                "channelBaseUrl" => channel.base_url,
-               "status_info" => %{"status" => "unknown"}
+               "status_info" => %{"status" => "unknown"},
+               "userEmail" => user.email
              }
     end
 
@@ -194,7 +198,8 @@ defmodule AskWeb.ChannelControllerTest do
                "channelBaseUrl" => channel.base_url,
                "projects" => [],
                "patterns" => [],
-               "status_info" => nil
+               "status_info" => nil,
+               "userEmail" => user.email
              }
     end
 


### PR DESCRIPTION
Closes #2081.

On survey creation, the drop-down listing of the project channels now includes the email of the channel owner (in Surveda). This will help the users correctly identify the channels, as described in the issue, avoiding potential identical items within the list. 

The dropdown now looks like this:

![Screensh](https://user-images.githubusercontent.com/13782680/173626593-bf82fbe4-224a-4946-9576-f5e643ff2bb6.png)
 
A channel with a very very long name was created to test how the elements display. As can be seen, they display in multiple lines properly.

To accomplish it, the `ChannelController` was modified. Now, when a channel is returned, it comes with an `userEmail` attribute. Test needed to be modified accordingly. 

A question arose: within `channel_view.ex` there is a mixture of camel case and snake case attributes. I went with camel case for `userEmail`. I can easily change it, not sure what is correct there.


