### PR TITLE
Verify that the Surveda build is broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && updat
 
 RUN \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-client inotify-tools sox libsox-fmt-mp3 festival && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y default-mysql-client inotify-tools sox libsox-fmt-mp3 festival && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mix local.hex --force

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,7 @@ RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && updat
 
 RUN \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-client inotify-tools sox libsox-fmt-mp3 festival vim && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y default-mysql-client inotify-tools sox libsox-fmt-mp3 festival vim && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mix local.hex --force

--- a/verify-broken-build
+++ b/verify-broken-build
@@ -1,0 +1,1 @@
+Verify that the Surveda build is broken


### PR DESCRIPTION
The base Docker image was updated from Debian Stretch to Buster
https://github.com/erlang/docker-erlang-otp/commit/fd21a3b#diff-bba869fab39f9ce4816fb8f2ce9d4635751cae7c386ab70341ec08356a7dbe23

This upgrade breaks the Surveda build with the following error:
`E: Package 'mysql-client' has no installation candidate`
https://github.com/instedd/surveda/runs/7436387784?check_suite_focus=true#step:3:66

This implies replacing the MySQL client with the MariaDB client
https://stackoverflow.com/a/57049357