### PR TITLE
Disable pool timeout along with Repo's timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,7 +19,7 @@ config :ask,
   ecto_repos: [Ask.Repo]
 
 if System.get_env("DISABLE_REPO_TIMEOUT") == "true" do
-  config :ask, Ask.Repo, timeout: :infinity
+  config :ask, Ask.Repo, timeout: :infinity, pool_timeout: :infinity
 end
 
 # Configures the endpoint


### PR DESCRIPTION
Generating the Interactions file is a long process that usually timeouts for large surveys. But the process doesn't involve a single, long query that times out - it instead performs a lot of queries, that time out the pool of connections. So increasing the `Ask.Repo`'s `timeout` isn't enough.

This PR makes the `DISABLE_REPO_TIMEOUT` flag to also disable the `pool_timeout`.