### PR TITLE
Allow to disable HTTP requests timeouts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,8 +18,8 @@ config :phoenix, :json_library, Poison
 config :ask,
   ecto_repos: [Ask.Repo]
 
-if System.get_env("DISABLE_REPO_TIMEOUT") == "true" do
-  config :ask, Ask.Repo, timeout: :infinity
+if System.get_env("DISABLE_TIMEOUTS") == "true" do
+  config :ask, AskWeb.Endpoint, http: [protocol_options: [idle_timeout: :infinity]]
 end
 
 # Configures the endpoint


### PR DESCRIPTION
Since the upgrade of Ecto, it doesn't have the issue with timeouts (nor pool timeouts) anymore, due to Ecto using a new queing system[0].

But we've also upgraded Cowboy, and now has a default 1-minute timeout for HTTP requests[1]. So, in order for large downloads not to fail, that's the timeout we have to remove.

Superseedes #2141 

[0]: https://github.com/elixir-ecto/ecto/issues/2833#issuecomment-440400022
[1]: https://elixirforum.com/t/request-to-phoenix-server-times-out-after-60-seconds/20851/6