### PR TITLE
Fix: can't import huge CSV of respondents

### DIFF
--- a/lib/ask/runtime/respondent_group_action.ex
+++ b/lib/ask/runtime/respondent_group_action.ex
@@ -268,8 +268,12 @@ defmodule Ask.Runtime.RespondentGroupAction do
     invalid_entries =
       entries
       |> Stream.with_index()
-      |> Stream.filter(fn {entry, _} -> Respondent.is_respondent_id?(entry) and not (entry in loaded_respondent_ids) end)
-      |> Stream.map(fn {entry, index} -> %{entry: entry, line_number: index + 1, type: "invalid-respondent-id"} end)
+      |> Stream.filter(fn {entry, _} ->
+        Respondent.is_respondent_id?(entry) and not (entry in loaded_respondent_ids)
+      end)
+      |> Stream.map(fn {entry, index} ->
+        %{entry: entry, line_number: index + 1, type: "invalid-respondent-id"}
+      end)
       |> Enum.to_list()
 
     case invalid_entries do
@@ -285,6 +289,7 @@ defmodule Ask.Runtime.RespondentGroupAction do
     keep_digits = fn phone_number ->
       Regex.replace(~r/\D/, phone_number, "", [:global])
     end
+
     {phone_numbers, respondent_ids} = partition_entries(entries)
 
     phone_numbers

--- a/test/ask/runtime/respondent_group_action_test.exs
+++ b/test/ask/runtime/respondent_group_action_test.exs
@@ -58,8 +58,8 @@ defmodule Ask.Runtime.RespondentGroupActionTest do
       assert result == :ok
 
       assert loaded_entries == [
-               %{phone_number: phone_number_1, hashed_number: respondent_id},
-               %{phone_number: phone_number_2}
+               %{phone_number: phone_number_2},
+               %{phone_number: phone_number_1, hashed_number: respondent_id}
              ]
     end
 

--- a/test/ask_web/controllers/respondent_group_controller_test.exs
+++ b/test/ask_web/controllers/respondent_group_controller_test.exs
@@ -813,17 +813,16 @@ defmodule AskWeb.RespondentGroupControllerTest do
              }
 
       respondents = Repo.all(from r in Respondent, where: r.survey_id == ^survey.id)
+      phone_numbers = respondents |> Enum.map(& &1.phone_number)
 
       assert length(respondents) == 15
 
       assert group
       assert group.respondents_count == 15
-      assert group.sample == respondents |> Enum.take(5) |> Enum.map(& &1.phone_number)
+      assert Enum.count(group.sample) == 5
+      assert Enum.count(group.sample -- phone_numbers) == 0
 
       assert Enum.at(respondents, 2).survey_id == survey.id
-      assert Enum.at(respondents, 2).phone_number == "(549) 11 2421 3125"
-      assert Enum.at(respondents, 2).sanitized_phone_number == "5491124213125"
-      assert Enum.at(respondents, 2).canonical_phone_number == "5491124213125"
       assert Enum.at(respondents, 2).respondent_group_id == group.id
     end
 


### PR DESCRIPTION
Only fixes the initial load of respondents for a Survey using a CSV of phone numbers.

The following situations will still fail:
- loading a CSV of respondents (not phone numbers).
- adding the CSV of phone numbers twice (import once then add again).