### PR TITLE
Proper height for the tooltip in retries histogram

### DIFF
--- a/assets/css/_charts.scss
+++ b/assets/css/_charts.scss
@@ -347,7 +347,7 @@
   background-color: rgba(0, 0, 0, 0.85) !important;
   font-family: "Roboto", sans-serif !important;
   font-size: 11px !important;
-  height: 12px !important;
+  height: 24px !important;
   padding: 4px 8px !important;
   border-radius: 2px !important;
   border: 0 !important;


### PR DESCRIPTION
Closes #2176.

Tooltip in the retries histograms have now the proper height and shows correctly:

![image](https://user-images.githubusercontent.com/13782680/218117315-49a2243d-845b-40ab-bc0c-275bf463e13f.png)

The project was scanned to look if this fix could break some other tooltip, but as far as I've searched, this has no impact elsewhere. 

