### PR TITLE
Fix/2173 only accept int numeric answers

### DIFF
--- a/lib/ask/runtime/step.ex
+++ b/lib/ask/runtime/step.ex
@@ -279,9 +279,11 @@ defmodule Ask.Runtime.Step do
   end
 
   defp is_numeric_permissive(str, language, step) do
-    case Float.parse(String.trim(str)) do
-      {num, _} ->
-        if Float.parse(String.trim(str)) == Integer.parse(String.trim(str)) do
+    str = String.trim(str)
+
+    case Float.parse(str) do
+      {num, rest} ->
+        if Integer.parse(str) == {num, rest} do
           round(num)
         else
           false

--- a/lib/ask/runtime/step.ex
+++ b/lib/ask/runtime/step.ex
@@ -279,9 +279,13 @@ defmodule Ask.Runtime.Step do
   end
 
   defp is_numeric_permissive(str, language, step) do
-    case Integer.parse(String.trim(str)) do
+    case Float.parse(String.trim(str)) do
       {num, _} ->
-        num
+        if Float.parse(String.trim(str)) == Integer.parse(String.trim(str)) do
+          round(num)
+        else
+          false
+        end
 
       :error ->
         if step["alphabetical_answers"] do

--- a/lib/ask/runtime/step.ex
+++ b/lib/ask/runtime/step.ex
@@ -270,7 +270,7 @@ defmodule Ask.Runtime.Step do
   end
 
   defp is_numeric(str) do
-    case Float.parse(str) do
+    case Integer.parse(str) do
       {num, ""} -> num
       # _r : remainder_of_bianry
       {_num, _r} -> false
@@ -279,13 +279,12 @@ defmodule Ask.Runtime.Step do
   end
 
   defp is_numeric_permissive(str, language, step) do
-    case Float.parse(String.trim(str)) do
-      {num, _} ->
-        if round(num) == num do
-          round(num)
-        else
-          num
-        end
+    case Integer.parse(String.trim(str)) do
+      {num, ""} ->
+        num
+
+      {_num, _r} ->
+        false
 
       :error ->
         if step["alphabetical_answers"] do

--- a/lib/ask/runtime/step.ex
+++ b/lib/ask/runtime/step.ex
@@ -281,7 +281,7 @@ defmodule Ask.Runtime.Step do
   defp is_numeric_permissive(str, language, step) do
     case Float.parse(String.trim(str)) do
       {num, _} ->
-        if round(num) == num do
+        if Float.parse(String.trim(str)) == Integer.parse(String.trim(str)) do
           round(num)
         else
           false

--- a/lib/ask/runtime/step.ex
+++ b/lib/ask/runtime/step.ex
@@ -279,12 +279,13 @@ defmodule Ask.Runtime.Step do
   end
 
   defp is_numeric_permissive(str, language, step) do
-    case Integer.parse(String.trim(str)) do
-      {num, ""} ->
-        num
-
-      {_num, _r} ->
-        false
+    case Float.parse(String.trim(str)) do
+      {num, _} ->
+        if round(num) == num do
+          round(num)
+        else
+          false
+        end
 
       :error ->
         if step["alphabetical_answers"] do

--- a/lib/ask/runtime/step.ex
+++ b/lib/ask/runtime/step.ex
@@ -279,13 +279,9 @@ defmodule Ask.Runtime.Step do
   end
 
   defp is_numeric_permissive(str, language, step) do
-    case Float.parse(String.trim(str)) do
+    case Integer.parse(String.trim(str)) do
       {num, _} ->
-        if Float.parse(String.trim(str)) == Integer.parse(String.trim(str)) do
-          round(num)
-        else
-          false
-        end
+        num
 
       :error ->
         if step["alphabetical_answers"] do

--- a/test/ask/runtime/flow_test.exs
+++ b/test/ask/runtime/flow_test.exs
@@ -636,10 +636,40 @@ defmodule Ask.Runtime.FlowTest do
       assert {:end, _, %Ask.Runtime.Reply{stores: %{"Probability" => "50"}}} = result
     end
 
+    test "does not accept floating point value" do
+      {:ok, flow, _} = init_quiz_and_send_response("S")
+      result = flow |> reply_sms(" 50.7 ")
+
+      assert {:ok, flow, reply} = result
+      prompts = Reply.prompts(reply)
+
+      assert flow.retries == 1
+
+      assert prompts == [
+               "You have entered an invalid answer",
+               "What is the probability that a number has more prime factors than the sum of its digits?"
+             ]
+    end
+
     test "when value is in a middle range it finds it, permissive" do
       {:ok, flow, _} = init_quiz_and_send_response("S")
       result = flow |> reply_sms(" 50 units ")
       assert {:end, _, %Ask.Runtime.Reply{stores: %{"Probability" => "50"}}} = result
+    end
+
+    test "does not accept a string with a floating point value, permissive" do
+      {:ok, flow, _} = init_quiz_and_send_response("S")
+      result = flow |> reply_sms(" 50.7 units ")
+
+      assert {:ok, flow, reply} = result
+      prompts = Reply.prompts(reply)
+
+      assert flow.retries == 1
+
+      assert prompts == [
+               "You have entered an invalid answer",
+               "What is the probability that a number has more prime factors than the sum of its digits?"
+             ]
     end
 
     test "accepts a string as an answer" do


### PR DESCRIPTION
Close #2173.

In Elixir, 

```
iex(2)> Integer.parse("22.1")
{22, ".1"}
iex(3)> Float.parse("22.1")  
{22.1, ""}
```

Then, the methods `is_numeric_permissive` & `is_numeric` were accepting float values and passed them through. 

While before it was continuing with the survey, now:

![image](https://user-images.githubusercontent.com/13782680/218151697-d6637847-9e53-4e04-ae25-d59f0f5600e8.png)

**Note:** is easy to round the integer part and get it: I moved forward accepting integers strictly, and returning `false` otherwise (and not the number rounded to an integer). 

**Note 2:** this was happening only in SMS mode (it couldn't happen in phone channels ─an error is thrown upon responses containing `#` or `*`─, neither in the mobile web mode, where ─at least in the simulator─ the validation is performed well. 
