### PR TITLE
Fix: validate actual audio type + always transcode to MP3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ yarn-error.log
 /integration_tests/cypress/screenshots
 /integration_tests/cypress/videos
 /integration_tests/output
+
+# test artefacts
+/test/fixtures/mpeg.wav
+/test/fixtures/wave.mp3

--- a/lib/ask/audio.ex
+++ b/lib/ask/audio.ex
@@ -46,7 +46,6 @@ defmodule Ask.Audio do
 
     {%{}, types}
     |> cast(data, Map.keys(types))
-    #|> validate_change(:filename, &validate_file_type/2)
     |> validate_change(:mime_type, &validate_mime_type/2)
     |> validate_change(:size, &validate_size/2)
   end

--- a/lib/ask/audio.ex
+++ b/lib/ask/audio.ex
@@ -17,7 +17,10 @@ defmodule Ask.Audio do
     timestamps()
   end
 
+  @valid_extensions ~w(.mp3 .wav)
+  @valid_mime_types ~w(audio/mpeg audio/wave audio/wav audio/x-wav audio/x-pn-wav)
   @stored_audio_extension "mp3"
+
   def exported_audio_file_name(uuid), do: uuid <> ".#{@stored_audio_extension()}"
 
   @doc """
@@ -30,34 +33,43 @@ defmodule Ask.Audio do
     |> validate_change(:data, &validate_size/2)
   end
 
+  @doc """
+  Builds a changeset from an uploaded file, validating its type and size.
+  """
   def upload_changeset(upload) do
-    %{size: size} = File.stat!(upload.path)
-    data = %{filename: upload.filename, size: size}
-    types = %{filename: :string, size: :integer}
+    path = upload.path
+    %{size: size} = File.stat!(path)
+    %{^path => mime_type} = Ask.FileInfo.get_info(path)
+
+    data = %{filename: upload.filename, mime_type: mime_type, size: size}
+    types = %{filename: :string, mime_type: :string, size: :integer}
 
     {%{}, types}
     |> cast(data, Map.keys(types))
-    |> validate_change(:filename, &validate_file_type/2)
+    #|> validate_change(:filename, &validate_file_type/2)
+    |> validate_change(:mime_type, &validate_mime_type/2)
     |> validate_change(:size, &validate_size/2)
   end
 
+  @doc """
+  Transcodes the uploaded audio file into MP3 (single channel, 44.1khz) then
+  returns params suitable to create an `Ask.Audio`. Note that even MP3 audio
+  files will be transcoded to avoid issues with invalid or broken MP3 in
+  production.
+  """
   def params_from_converted_upload(upload) do
-    case Path.extname(upload.filename) do
-      ".wav" ->
-        case Sox.convert("wav", upload.path, @stored_audio_extension) do
-          {:ok, data} ->
-            %{
-              "uuid" => Ecto.UUID.generate(),
-              "data" => data,
-              "filename" => "#{Path.basename(upload.filename, ".wav")}.#{@stored_audio_extension}"
-            }
+    basename = Path.basename(upload.filename, Path.extname(upload.filename))
 
-          {:error, error} ->
-            Logger.warn("Error converting file #{upload.path}: #{error}")
-            params_from_upload(upload)
-        end
+    case Sox.convert(upload.path, @stored_audio_extension) do
+      {:ok, data} ->
+        %{
+          "uuid" => Ecto.UUID.generate(),
+          "data" => data,
+          "filename" => "#{basename}.#{@stored_audio_extension}"
+        }
 
-      ".#{@stored_audio_extension}" ->
+      {:error, error} ->
+        Logger.warn("Error converting file #{upload.path}: #{error}")
         params_from_upload(upload)
     end
   end
@@ -67,22 +79,25 @@ defmodule Ask.Audio do
     %{"uuid" => Ecto.UUID.generate(), "data" => data, "filename" => upload.filename}
   end
 
+  # FIXME: should only allow `.mp3` extensions.
   def validate_file_type(:filename, filename) do
-    valid_extensions = ~w(.mp3 .wav)
-    extension = Path.extname(filename)
-    valid_type = valid_extensions |> Enum.member?(extension)
-
-    if valid_type do
+    if Enum.member?(@valid_extensions, Path.extname(filename)) do
       []
     else
       [filename: "Invalid file type. Allowed types are MP3 and WAV."]
     end
   end
 
-  def validate_size(:size, size) do
-    mb_size = size / :math.pow(2, 20)
+  def validate_mime_type(:mime_type, mime_type) do
+    if Enum.member?(@valid_mime_types, mime_type) do
+      []
+    else
+      [filename: "Invalid file. Allowed types are MP3 and WAV."]
+    end
+  end
 
-    if mb_size < 16 do
+  def validate_size(:size, size) do
+    if size < 16 * 1024 * 1024 do
       []
     else
       [data: "The file is too big, please do not exceed 16MB."]

--- a/lib/ask/file_info.ex
+++ b/lib/ask/file_info.ex
@@ -1,0 +1,20 @@
+defmodule Ask.FileInfo do
+  @doc """
+    Retrieves informations about one or multiple files, using the `file` command
+    line tool which is shipped with most linux distributions.
+  """
+  @spec get_info(Path.t() | [Path.t()]) :: %{Path.t() => String.t()}
+  def get_info(names)
+  def get_info(name) when is_binary(name), do: get_info([name])
+
+  def get_info(names) when is_list(names) do
+    {result, 0} = System.cmd("file", ["--mime-type" | names])
+
+    result
+    |> String.split("\n", trim: true)
+    |> Stream.filter(&(&1 !== ""))
+    |> Stream.map(&String.split(&1, ": ", parts: 2, trim: true))
+    |> Stream.map(fn [path, line] -> {path, line} end)
+    |> Enum.into(%{})
+  end
+end

--- a/lib/ask/sox.ex
+++ b/lib/ask/sox.ex
@@ -1,18 +1,14 @@
 defmodule Ask.Sox do
-  def convert(from_type, from_filename, to_type) do
+  def convert(from_filename, to_type) do
     try do
       case System.cmd(sox_executable(), [
              "-V1",
-             "-t",
-             from_type,
+             "--magic",
              from_filename,
-             "-e",
-             "signed-integer",
-             "-r",
-             "44100",
-             "-t",
-             to_type,
-             "-c1",
+             "--encoding", "signed-integer",
+             "--channels", "1",
+             "--rate", "44100",
+             "--type", to_type,
              "-"
            ]) do
         {output, 0} -> {:ok, output}

--- a/lib/ask/sox.ex
+++ b/lib/ask/sox.ex
@@ -5,10 +5,14 @@ defmodule Ask.Sox do
              "-V1",
              "--magic",
              from_filename,
-             "--encoding", "signed-integer",
-             "--channels", "1",
-             "--rate", "44100",
-             "--type", to_type,
+             "--encoding",
+             "signed-integer",
+             "--channels",
+             "1",
+             "--rate",
+             "44100",
+             "--type",
+             to_type,
              "-"
            ]) do
         {output, 0} -> {:ok, output}

--- a/lib/mix/tasks/ask.convert_wav_files_to_mp3_in_db.ex
+++ b/lib/mix/tasks/ask.convert_wav_files_to_mp3_in_db.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Ask.ConvertWavFilesToMp3InDb do
     File.write(path, audio.data, [:binary])
     mp3_filename = "#{Path.basename(audio.filename, ".wav")}.mp3"
 
-    case Sox.convert("wav", path, "mp3") do
+    case Sox.convert(path, "mp3") do
       {:ok, mp3} ->
         case Repo.update(Audio.changeset(audio, %{"data" => mp3, "filename" => mp3_filename})) do
           {:ok, _} ->

--- a/test/ask_web/controllers/audio_controller_test.exs
+++ b/test/ask_web/controllers/audio_controller_test.exs
@@ -29,7 +29,7 @@ defmodule AskWeb.AudioControllerTest do
 
       audio = Repo.one(Audio)
       assert audio.filename == "test1.mp3"
-      assert AudioChecker.get_audio_format(audio.data, "mp3") == "mp3"
+      assert AudioChecker.get_audio_format(audio.data, "mp3") == "audio/mpeg"
     end
 
     test "MP3: when data is valid returns its uuid", %{conn: conn} do
@@ -61,7 +61,7 @@ defmodule AskWeb.AudioControllerTest do
 
       audio = Repo.one(Audio)
       assert audio.filename == "test1.mp3"
-      assert AudioChecker.get_audio_format(audio.data, "mp3") == "mp3"
+      assert AudioChecker.get_audio_format(audio.data, "mp3") == "audio/mpeg"
     end
 
     test "WAV: when data is valid returns its uuid", %{conn: conn} do

--- a/test/ask_web/controllers/audio_controller_test.exs
+++ b/test/ask_web/controllers/audio_controller_test.exs
@@ -42,6 +42,7 @@ defmodule AskWeb.AudioControllerTest do
 
     test "MP3 with WAV extension: saves as MP3", %{conn: conn} do
       File.copy("test/fixtures/audio.mp3", "test/fixtures/mpeg.wav")
+
       try do
         file = %Plug.Upload{path: "test/fixtures/mpeg.wav", filename: "mpeg.wav"}
         conn = post conn, audio_path(conn, :create), file: file
@@ -49,6 +50,7 @@ defmodule AskWeb.AudioControllerTest do
       after
         File.rm("test/fixtures/mpeg.wav")
       end
+
       %{filename: "mpeg.mp3"} = Repo.one(Audio)
     end
 
@@ -72,6 +74,7 @@ defmodule AskWeb.AudioControllerTest do
 
     test "WAV with MP3 extension: saves as MP3", %{conn: conn} do
       File.copy("test/fixtures/audio.wav", "test/fixtures/wave.mp3")
+
       try do
         file = %Plug.Upload{path: "test/fixtures/wave.mp3", filename: "wave.mp3"}
         conn = post conn, audio_path(conn, :create), file: file
@@ -79,6 +82,7 @@ defmodule AskWeb.AudioControllerTest do
       after
         File.rm("test/fixtures/wave.mp3")
       end
+
       %{filename: "wave.mp3"} = Repo.one(Audio)
     end
 

--- a/test/support/audio_checker.ex
+++ b/test/support/audio_checker.ex
@@ -3,9 +3,7 @@ defmodule Ask.AudioChecker do
     path = "test/tmp/#{Ecto.UUID.generate()}.#{ext}"
     File.write(path, data, [:binary])
 
-    case System.cmd("soxi", ["-t", path]) do
-      {output, 0} -> output |> String.trim()
-      {_, _code} -> nil
-    end
+    %{^path => mime_type} = Ask.FileInfo.get_info(path)
+    mime_type
   end
 end


### PR DESCRIPTION
Relies on magic numbers to detect the actual file type of uploaded audio files, instead of relying on the file extensions (`.wav` and `.mp3`) that may be wrong. Validates the file types using the `file` command line tool, made to return the actual mime type (see `Ask.FileInfo`). Tells `sox` to identify the input file types using magic numbers (see `Ask.Sox`).

Transcodes all audio files to MP3 with a single channel at 44.1khz (even MP3 files) to make sure that the stored MP3 file is proper and not some weirdly encoded MP3 file. That should improve the portability of the audio files.

fixes #2175