### PR TITLE
Fix: remove auto increment from ecto dumps

### DIFF
--- a/lib/mix/tasks/ecto_dump.ex
+++ b/lib/mix/tasks/ecto_dump.ex
@@ -5,9 +5,13 @@ defmodule Mix.Tasks.Ask.EctoDump do
   use Mix.Task
 
   @impl Mix.Task
-  def run(args) do
+  def run(_args) do
     if Mix.env() == :dev do
-      Mix.Tasks.Ecto.Dump.run(args)
+      Mix.Tasks.Ecto.Dump.run([])
+
+      sql = File.read!("priv/repo/structure.sql")
+      sql = String.replace(sql, ~r/ AUTO_INCREMENT=\d+ /, " ", [global: true])
+      File.write!("priv/repo/structure.sql", sql)
     end
   end
 end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1,8 +1,8 @@
--- MariaDB dump 10.19  Distrib 10.5.13-MariaDB, for Linux (x86_64)
+-- MySQL dump 10.19  Distrib 10.3.36-MariaDB, for debian-linux-gnu (x86_64)
 --
 -- Host: db    Database: ask_dev
 -- ------------------------------------------------------
--- Server version	5.7.22
+-- Server version	5.7.40
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -39,7 +39,7 @@ CREATE TABLE `activity_log` (
   KEY `activity_log_user_id_fkey` (`user_id`),
   CONSTRAINT `activity_log_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `activity_log_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=441 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -60,7 +60,7 @@ CREATE TABLE `audios` (
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `id` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -85,7 +85,7 @@ CREATE TABLE `channels` (
   UNIQUE KEY `id` (`id`),
   KEY `channels_user_id_index` (`user_id`),
   CONSTRAINT `channels_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -153,7 +153,7 @@ CREATE TABLE `folders` (
   UNIQUE KEY `folders_name_project_id_index` (`name`,`project_id`),
   KEY `folders_project_id_index` (`project_id`),
   CONSTRAINT `folders_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -197,7 +197,7 @@ CREATE TABLE `oauth_tokens` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `id` (`id`),
   UNIQUE KEY `oauth_tokens_user_id_provider_base_url_index` (`user_id`,`provider`,`base_url`)
-) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -220,7 +220,7 @@ CREATE TABLE `panel_surveys` (
   KEY `panel_surveys_folder_id_fkey` (`folder_id`),
   CONSTRAINT `panel_surveys_folder_id_fkey` FOREIGN KEY (`folder_id`) REFERENCES `folders` (`id`),
   CONSTRAINT `panel_surveys_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -242,7 +242,7 @@ CREATE TABLE `project_channels` (
   KEY `project_channels_project_id_fkey` (`project_id`),
   CONSTRAINT `project_channels_channel_id_fkey` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`) ON DELETE CASCADE,
   CONSTRAINT `project_channels_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -265,7 +265,7 @@ CREATE TABLE `project_memberships` (
   KEY `project_memberships_project_id_fkey` (`project_id`),
   CONSTRAINT `project_memberships_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`) ON DELETE CASCADE,
   CONSTRAINT `project_memberships_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -285,7 +285,7 @@ CREATE TABLE `projects` (
   `archived` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `id` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -308,7 +308,7 @@ CREATE TABLE `questionnaire_variables` (
   KEY `questionnaire_variables_questionnaire_id_index` (`questionnaire_id`),
   CONSTRAINT `questionnaire_variables_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `questionnaire_variables_questionnaire_id_fkey` FOREIGN KEY (`questionnaire_id`) REFERENCES `questionnaires` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=92 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -342,7 +342,7 @@ CREATE TABLE `questionnaires` (
   KEY `questionnaires_snapshot_of_fkey` (`snapshot_of`),
   CONSTRAINT `questionnaires_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `questionnaires_snapshot_of_fkey` FOREIGN KEY (`snapshot_of`) REFERENCES `questionnaires` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -414,7 +414,7 @@ CREATE TABLE `respondent_disposition_history` (
   KEY `respondent_disposition_history_survey_id_id_index` (`survey_id`,`id`),
   CONSTRAINT `respondent_disposition_history_respondent_id_fkey` FOREIGN KEY (`respondent_id`) REFERENCES `respondents` (`id`) ON DELETE CASCADE,
   CONSTRAINT `respondent_disposition_history_survey_id_fkey` FOREIGN KEY (`survey_id`) REFERENCES `surveys` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -437,7 +437,7 @@ CREATE TABLE `respondent_group_channels` (
   KEY `respondent_group_channels_channel_id_index` (`channel_id`),
   CONSTRAINT `respondent_group_channels_channel_id_fkey` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`),
   CONSTRAINT `respondent_group_channels_respondent_group_id_fkey` FOREIGN KEY (`respondent_group_id`) REFERENCES `respondent_groups` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=40 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -459,7 +459,7 @@ CREATE TABLE `respondent_groups` (
   UNIQUE KEY `id` (`id`),
   KEY `respondent_groups_survey_id_fkey` (`survey_id`),
   CONSTRAINT `respondent_groups_survey_id_fkey` FOREIGN KEY (`survey_id`) REFERENCES `surveys` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=27 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -531,7 +531,7 @@ CREATE TABLE `respondents` (
   CONSTRAINT `respondents_respondent_group_id_fkey` FOREIGN KEY (`respondent_group_id`) REFERENCES `respondent_groups` (`id`) ON DELETE CASCADE,
   CONSTRAINT `respondents_retry_stat_id_fkey` FOREIGN KEY (`retry_stat_id`) REFERENCES `retry_stats` (`id`) ON DELETE CASCADE,
   CONSTRAINT `respondents_survey_id_fkey` FOREIGN KEY (`survey_id`) REFERENCES `surveys` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=28 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!50003 SET @saved_cs_client      = @@character_set_client */ ;
 /*!50003 SET @saved_cs_results     = @@character_set_results */ ;
@@ -732,7 +732,7 @@ CREATE TABLE `responses` (
   UNIQUE KEY `id` (`id`),
   KEY `responses_respondent_id_index` (`respondent_id`),
   CONSTRAINT `responses_respondent_id_fkey` FOREIGN KEY (`respondent_id`) REFERENCES `respondents` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -757,7 +757,7 @@ CREATE TABLE `retry_stats` (
   UNIQUE KEY `retry_stats_mode_attempt_retry_time_ivr_active_survey_id_index` (`mode`,`attempt`,`retry_time`,`ivr_active`,`survey_id`),
   KEY `retry_stats_survey_id_fkey` (`survey_id`),
   CONSTRAINT `retry_stats_survey_id_fkey` FOREIGN KEY (`survey_id`) REFERENCES `surveys` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=33 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -792,7 +792,7 @@ CREATE TABLE `sessions` (
   UNIQUE KEY `id` (`id`),
   UNIQUE KEY `sessions_token_index` (`token`),
   KEY `sessions_user_id_index` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -837,7 +837,7 @@ CREATE TABLE `survey_log_entries` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `id` (`id`),
   KEY `survey_log_entries_survey_id_respondent_hashed_number_id_index` (`survey_id`,`respondent_hashed_number`,`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=59 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -859,7 +859,7 @@ CREATE TABLE `survey_questionnaires` (
   KEY `survey_questionnaires_questionnaire_id_index` (`questionnaire_id`),
   CONSTRAINT `survey_questionnaires_questionnaire_id_fkey` FOREIGN KEY (`questionnaire_id`) REFERENCES `questionnaires` (`id`),
   CONSTRAINT `survey_questionnaires_survey_id_fkey` FOREIGN KEY (`survey_id`) REFERENCES `surveys` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=54 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -909,7 +909,7 @@ CREATE TABLE `surveys` (
   CONSTRAINT `surveys_folder_id_fkey` FOREIGN KEY (`folder_id`) REFERENCES `folders` (`id`),
   CONSTRAINT `surveys_panel_survey_id_fkey` FOREIGN KEY (`panel_survey_id`) REFERENCES `panel_surveys` (`id`),
   CONSTRAINT `surveys_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=34 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -937,7 +937,7 @@ CREATE TABLE `translations` (
   KEY `translations_questionnaire_id_index` (`questionnaire_id`),
   CONSTRAINT `translations_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`),
   CONSTRAINT `translations_questionnaire_id_fkey` FOREIGN KEY (`questionnaire_id`) REFERENCES `questionnaires` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=39 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -966,7 +966,7 @@ CREATE TABLE `users` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `id` (`id`),
   UNIQUE KEY `users_email_index` (`email`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -982,7 +982,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2022-01-31 10:39:36
+-- Dump completed on 2023-02-27 11:22:23
 INSERT INTO `schema_migrations` (version) VALUES (20160812145257);
 INSERT INTO `schema_migrations` (version) VALUES (20160816183915);
 INSERT INTO `schema_migrations` (version) VALUES (20160830200454);


### PR DESCRIPTION
This will avoid lots of useless changes (we dump the schema only, we don't care about each devs's local database auto increment series) and potential conflicts in concurrent pull requests (same reasons).