### PR TITLE
Main chart interactive

### DIFF
--- a/assets/css/_charts.scss
+++ b/assets/css/_charts.scss
@@ -40,6 +40,10 @@
   align-items: center;
 }
 
+.clicked-line {
+  stroke-width: 4px !important;
+}
+
 .forecasts .line {
   fill: none;
   stroke-width: 2px;
@@ -341,6 +345,17 @@
 
 .double > * {
   width: 50%;
+}
+
+.forecast-tooltip {
+  position: absolute;
+  z-index: 10;
+  background: white;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px;
+  border-style: solid;
+  border-color: black;
 }
 
 .tooltip {

--- a/assets/js/components/charts/Forecasts.jsx
+++ b/assets/js/components/charts/Forecasts.jsx
@@ -154,7 +154,7 @@ export default class Forecasts extends Component<Props> {
 
     const lineClick = function (d) {
       d3.selectAll(".line").classed("clicked-line", false)
-      d3.selectAll("#" + d3.select(this).attr("id")).classed("clicked-line", true)
+      d3.selectAll(`[data-line-id='${this.dataset["lineId"]}']`).classed("clicked-line", true)
     }
 
     d3.select(this.refs.values)
@@ -164,7 +164,7 @@ export default class Forecasts extends Component<Props> {
       .append("path")
       .merge(d3.select(this.refs.values).selectAll("path"))
       .attr("class", "line")
-      .attr("id", (d) => "line-" + d.id)
+      .attr("data-line-id", (d) => d.id)
       .attr("stroke", (d) => d.color)
       .datum((d) => d.values)
       .attr("d", line)
@@ -177,7 +177,7 @@ export default class Forecasts extends Component<Props> {
       .append("path")
       .merge(d3.select(this.refs.forecasts).selectAll("path"))
       .attr("class", "dotted line")
-      .attr("id", (d) => "line-" + d.id)
+      .attr("data-line-id", (d) => d.id)
       .attr("stroke", (d) => d.color)
       .datum((d) => {
         return d.forecast

--- a/assets/js/components/charts/Forecasts.jsx
+++ b/assets/js/components/charts/Forecasts.jsx
@@ -103,7 +103,10 @@ export default class Forecasts extends Component<Props> {
       initialTime = new Date()
       lastTime = d3.timeMonth.offset(initialTime, 1)
     } else {
-      initialTime = d3.min(flatten, (d) => d.time)
+      initialTime = d3.timeDay.offset(
+        d3.min(flatten, (d) => d.time),
+        -1
+      )
       lastTime = d3.timeMonth.offset(initialTime, 1)
       lastTime = d3.max([d3.max(flatten, (d) => d.time), lastTime])
     }
@@ -124,35 +127,34 @@ export default class Forecasts extends Component<Props> {
       .classed("forecast-tooltip", true)
       .style("visibility", "hidden")
 
-    for (var i = 0; i <= data.length; i++) {
-      if (data[i]) {
-        for (var j = 0; j <= data[i].values.length; j++) {
-          if (
-            data[i].values[j] &&
-            y(data[i].values[j].value) != 0 &&
-            x(data[i].values[j].time) != 0
-          ) {
-            d3.select(this.refs.circles)
-              .selectAll("path")
-              .data([data[i].values[j]])
-              .enter()
-              .append("circle")
-              .attr("cx", (d) => x(d.time))
-              .attr("cy", (d) => y(d.value))
-              .attr("r", "3px")
-              .style("fill", data[i].color)
-              .style("stroke", data[i].color)
-              .on("mouseover", (d) =>
-                tooltip
-                  .text(d.value)
-                  .style("top", d3.event.pageY - 10 + "px")
-                  .style("left", d3.event.pageX + 10 + "px")
-                  .style("visibility", "visible")
-              )
-              .on("mouseout", () => tooltip.style("visibility", "hidden"))
-          }
+    for (var i = 0; i < data.length; i++) {
+      for (var j = 0; j < data[i].values.length; j++) {
+        if (y(data[i].values[j].value) != 0 && x(data[i].values[j].time) != 0) {
+          d3.select(this.refs.circles)
+            .selectAll("path")
+            .data([data[i].values[j]])
+            .enter()
+            .append("circle")
+            .attr("cx", (d) => x(d.time))
+            .attr("cy", (d) => y(d.value))
+            .attr("r", "3px")
+            .style("fill", data[i].color)
+            .style("stroke", data[i].color)
+            .on("mouseover", (d) =>
+              tooltip
+                .text(d.value)
+                .style("top", d3.event.pageY - 10 + "px")
+                .style("left", d3.event.pageX + 10 + "px")
+                .style("visibility", "visible")
+            )
+            .on("mouseout", () => tooltip.style("visibility", "hidden"))
         }
       }
+    }
+
+    const lineClick = function (d) {
+      d3.selectAll(".line").classed("clicked-line", false)
+      d3.selectAll("#" + d3.select(this).attr("id")).classed("clicked-line", true)
     }
 
     d3.select(this.refs.values)
@@ -166,10 +168,7 @@ export default class Forecasts extends Component<Props> {
       .attr("stroke", (d) => d.color)
       .datum((d) => d.values)
       .attr("d", line)
-      .on("click", function (d) {
-        d3.selectAll(".line").classed("clicked-line", false)
-        d3.selectAll("#" + d3.select(this).attr("id")).classed("clicked-line", true)
-      })
+      .on("click", lineClick)
 
     d3.select(this.refs.forecasts)
       .selectAll("path")
@@ -184,10 +183,7 @@ export default class Forecasts extends Component<Props> {
         return d.forecast
       })
       .attr("d", line)
-      .on("click", function (d) {
-        d3.selectAll(".line").classed("clicked-line", false)
-        d3.selectAll("#" + d3.select(this).attr("id")).classed("clicked-line", true)
-      })
+      .on("click", lineClick)
 
     d3.select(this.refs.x)
       .attr("class", "axis")

--- a/assets/js/components/charts/Forecasts.jsx
+++ b/assets/js/components/charts/Forecasts.jsx
@@ -118,6 +118,43 @@ export default class Forecasts extends Component<Props> {
       .x((d) => x(d.time))
       .y((d) => y(d.value))
 
+    var tooltip = d3
+      .select("body")
+      .append("div")
+      .classed("forecast-tooltip", true)
+      .style("visibility", "hidden")
+
+    for (var i = 0; i <= data.length; i++) {
+      if (data[i]) {
+        for (var j = 0; j <= data[i].values.length; j++) {
+          if (
+            data[i].values[j] &&
+            y(data[i].values[j].value) != 0 &&
+            x(data[i].values[j].time) != 0
+          ) {
+            d3.select(this.refs.circles)
+              .selectAll("path")
+              .data([data[i].values[j]])
+              .enter()
+              .append("circle")
+              .attr("cx", (d) => x(d.time))
+              .attr("cy", (d) => y(d.value))
+              .attr("r", "3px")
+              .style("fill", data[i].color)
+              .style("stroke", data[i].color)
+              .on("mouseover", (d) =>
+                tooltip
+                  .text(d.value)
+                  .style("top", d3.event.pageY - 10 + "px")
+                  .style("left", d3.event.pageX + 10 + "px")
+                  .style("visibility", "visible")
+              )
+              .on("mouseout", () => tooltip.style("visibility", "hidden"))
+          }
+        }
+      }
+    }
+
     d3.select(this.refs.values)
       .selectAll("path")
       .data(data)
@@ -125,9 +162,14 @@ export default class Forecasts extends Component<Props> {
       .append("path")
       .merge(d3.select(this.refs.values).selectAll("path"))
       .attr("class", "line")
+      .attr("id", (d) => "line-" + d.id)
       .attr("stroke", (d) => d.color)
       .datum((d) => d.values)
       .attr("d", line)
+      .on("click", function (d) {
+        d3.selectAll(".line").classed("clicked-line", false)
+        d3.selectAll("#" + d3.select(this).attr("id")).classed("clicked-line", true)
+      })
 
     d3.select(this.refs.forecasts)
       .selectAll("path")
@@ -136,11 +178,16 @@ export default class Forecasts extends Component<Props> {
       .append("path")
       .merge(d3.select(this.refs.forecasts).selectAll("path"))
       .attr("class", "dotted line")
+      .attr("id", (d) => "line-" + d.id)
       .attr("stroke", (d) => d.color)
       .datum((d) => {
         return d.forecast
       })
       .attr("d", line)
+      .on("click", function (d) {
+        d3.selectAll(".line").classed("clicked-line", false)
+        d3.selectAll("#" + d3.select(this).attr("id")).classed("clicked-line", true)
+      })
 
     d3.select(this.refs.x)
       .attr("class", "axis")
@@ -187,6 +234,7 @@ export default class Forecasts extends Component<Props> {
         >
           <g transform={`translate(${margin.left},${margin.top})`}>
             <g ref="grid" />
+            <g ref="circles" />
             <g ref="values" />
             <g ref="forecasts" />
             <g ref="x" transform={`translate(0,${height})`} />

--- a/assets/js/components/charts/Forecasts.jsx
+++ b/assets/js/components/charts/Forecasts.jsx
@@ -154,7 +154,7 @@ export default class Forecasts extends Component<Props> {
 
     const lineClick = function (d) {
       d3.selectAll(".line").classed("clicked-line", false)
-      d3.selectAll(`[data-line-id='${this.dataset["lineId"]}']`).classed("clicked-line", true)
+      d3.selectAll(`[data-line-id='${this.dataset.lineId}']`).classed("clicked-line", true)
     }
 
     d3.select(this.refs.values)


### PR DESCRIPTION
Close #2178.

Implemented features required: 

- onClick get the line highlighted
- onHover get the details of that data point

Screenshot:

![chrome-capture-2023-2-3](https://user-images.githubusercontent.com/13782680/222687884-92b43ca8-8914-404d-9d22-7a0d9a41d24c.gif)

Small code comment:

```
  .on("click", function (d) {
        d3.selectAll(".line").classed("clicked-line", false)
        d3.selectAll("#" + d3.select(this).attr("id")).classed("clicked-line", true)
      })
```

Neither if I extract the function nor if I change it to the `(d) =>` fashion would it work, so I left it like that in both places. 
