### PR TITLE
Feature/2177 create success rate chart

### DIFF
--- a/assets/css/_charts.scss
+++ b/assets/css/_charts.scss
@@ -70,6 +70,12 @@
   opacity: 0.1;
 }
 
+.area {
+  stroke-width: 2px;
+  shape-rendering: auto;
+  opacity: 0.25;
+}
+
 /*QueueSize*/
 .queueSize {
   font-family: "Roboto", sans-serif;

--- a/assets/js/components/charts/Forecasts.jsx
+++ b/assets/js/components/charts/Forecasts.jsx
@@ -7,7 +7,7 @@ const margin = { left: 36, top: 18, right: 18, bottom: 36 }
 
 type Props = {
   ceil: number,
-  forecast: Array<Object>,
+  data: Array<Object>,
 }
 
 export default class Forecasts extends Component<Props> {
@@ -24,7 +24,7 @@ export default class Forecasts extends Component<Props> {
   }
 
   getForecastEndDate(props) {
-    const { data, ceil, forecast } = this.props
+    const { data, ceil } = this.props
     return d3.max(data, (d) => (d.forecast.length ? d.forecast[d.forecast.length - 1].time : null))
   }
 

--- a/assets/js/components/charts/Forecasts.jsx
+++ b/assets/js/components/charts/Forecasts.jsx
@@ -24,7 +24,7 @@ export default class Forecasts extends Component<Props> {
   }
 
   getForecastEndDate(props) {
-    const { data, ceil } = this.props
+    const { data } = this.props
     return d3.max(data, (d) => (d.forecast.length ? d.forecast[d.forecast.length - 1].time : null))
   }
 

--- a/assets/js/components/charts/SuccessRateLine.jsx
+++ b/assets/js/components/charts/SuccessRateLine.jsx
@@ -1,12 +1,10 @@
 import React, { Component } from "react"
 import * as d3 from "d3"
-import References from "./References"
-import TimeAgo from "react-timeago"
 
 const margin = { left: 36, top: 18, right: 18, bottom: 36 }
 
 type Props = {
-  forecast: Array<Object>,
+  data: Array<Object>,
 }
 
 export default class SuccessRateLine extends Component<Props> {
@@ -18,13 +16,7 @@ export default class SuccessRateLine extends Component<Props> {
       width: 0,
       height: 0,
       data: props.data,
-      forecastEndDate: this.getForecastEndDate(props),
     }
-  }
-
-  getForecastEndDate(props) {
-    const { data, forecast } = this.props
-    return d3.max(data, (d) => (d.forecast.length ? d.forecast[d.forecast.length - 1].time : null))
   }
 
   recalculate() {
@@ -50,7 +42,6 @@ export default class SuccessRateLine extends Component<Props> {
   componentWillReceiveProps(props) {
     this.setState({
       data: props.data,
-      forecastEndDate: this.getForecastEndDate(props),
     })
   }
 

--- a/assets/js/components/charts/SuccessRateLine.jsx
+++ b/assets/js/components/charts/SuccessRateLine.jsx
@@ -158,7 +158,6 @@ export default class SuccessRateLine extends Component<Props> {
   }
 
   render() {
-    const { data, forecastEndDate } = this.state
     const { width, height } = this.state
     const padding = 6
 

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -314,7 +314,6 @@ class SurveyShow extends Component<any, State> {
           forecast: this.getForecast(d.values[0], d.values[d.values.length - 1], 100),
         }
       } else {
-      else {
         return { ...d, forecast: [] }
       }
     })

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -308,7 +308,7 @@ class SurveyShow extends Component<any, State> {
     })
 
     forecasts = forecasts.map((d) => {
-      if (this.shouldForecast(d, 100, true)) {
+      if (this.shouldForecast(d, 100, survey.state == "running")) {
         return {
           ...d,
           forecast: this.getForecast(d.values[0], d.values[d.values.length - 1], 100),

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -21,6 +21,7 @@ import classNames from "classnames/bind"
 import QueueSize from "../charts/QueueSize"
 import SuccessRate from "../charts/SuccessRate"
 import Forecasts from "../charts/Forecasts"
+import SuccessRateLine from "../charts/SuccessRateLine"
 import Stats from "../charts/Stats"
 import { translate } from "react-i18next"
 import SurveyRetriesPanel from "./SurveyRetriesPanel"
@@ -149,6 +150,21 @@ class SurveyShow extends Component<any, State> {
   toggleLock(e) {
     const { dispatch } = this.props
     dispatch(actions.toggleLock())
+  }
+
+  shouldForecast(data, ceil, forecast) {
+    return (
+      forecast &&
+      data.values.length > 1 &&
+      ceil > data.values[data.values.length - 1].value &&
+      data.values[data.values.length - 1].value > data.values[0].value &&
+      data.values[0].time < data.values[data.values.length - 1].time
+    )
+  }
+
+  getForecast(firstValue, lastValue, ceil) {
+    const slope = (lastValue.value - firstValue.value) / (lastValue.time - firstValue.time)
+    return [lastValue, { value: ceil, time: new Date(firstValue.time.getTime() + ceil / slope) }]
   }
 
   render() {
@@ -291,6 +307,18 @@ class SurveyShow extends Component<any, State> {
       return { ...d, values }
     })
 
+    forecasts = forecasts.map((d) => {
+      if (this.shouldForecast(d, 100, true)) {
+        return {
+          ...d,
+          forecast: this.getForecast(d.values[0], d.values[d.values.length - 1], 100),
+        }
+      } else {
+      else {
+        return { ...d, forecast: [] }
+      }
+    })
+
     return (
       <div className="cockpit">
         <div className="row">
@@ -369,7 +397,14 @@ class SurveyShow extends Component<any, State> {
                 )}
               </div>
               <Stats data={stats} />
-              <Forecasts data={forecasts} ceil={100} forecast={survey.state == "running"} />
+              <Forecasts data={forecasts} ceil={100} />
+              <div className="header" style={{ marginTop: "40px", marginBottom: "0" }}>
+                <div className="title">{t("Success Rate")}</div>
+                <div className="description">
+                  {t("Estimated by combining initial and current values")}
+                </div>
+              </div>
+              <SuccessRateLine data={forecasts} />
               {this.showHistograms() ? (
                 <SurveyRetriesPanel projectId={projectId} surveyId={surveyId} />
               ) : null}


### PR DESCRIPTION
Close #2177 

New success rate line chart. It differs from the [mockup](https://projects.invisionapp.com/d/main#/console/8374235/266351230/preview) that each data point is marked to display a tooltip. It looks like this:

![image](https://user-images.githubusercontent.com/13782680/223654678-27c3326f-9dc8-480c-ae2c-c4a488d52c33.png)

To respect that in the mockup the x-axis, has to have the same range as the x-axis of the `Forecast` component:

![image](https://user-images.githubusercontent.com/13782680/223656141-c83e95bd-1166-4613-85db-ed9b257b1543.png)

To accomplish this, the computation of the forecasts was moved into the parent component (`SurveyShow`) and passed into each child component (`Forecast` & `SuccesRateLine`) 

Two comments:
- The new component (`SuccesRateLine`) could have been implemented by making a more flexible `Forecast` component but I decided even though make a new one since it will (I think) go against the code clarity and be less flexible to future changes to one plot in particular.
- The data with the forecast & the success rate is in the parent component (`SurveyShow`) and then data is filtered in each children component by comparing the keys equality to `"Success rate"` string. Since all the data should travel to both components to have the same x-axis range I decided not to split it into two objects.

