### PR TITLE
Fix of linechart on survey card

### DIFF
--- a/assets/js/components/respondents/RespondentsChart.jsx
+++ b/assets/js/components/respondents/RespondentsChart.jsx
@@ -53,18 +53,18 @@ class RespondentsChart extends PureComponent {
     if (!cumulativePercentages || totalQuestionnaires < 1) {
       initialDate = new Date()
       lastDate = new Date()
-      lastDate.setDate(lastDate.getDate() + 90)
+      lastDate.setDate(lastDate.getDate() + 7)
     } else {
       // Uses random one because all questionnaires have the same range of dates.
       const randomQuestionnaireId = Object.keys(cumulativePercentages)[0]
       const randomQuestionnaireByDate = cumulativePercentages[randomQuestionnaireId]
       initialDate = new Date(Date.parse(randomQuestionnaireByDate[0].date))
-      const nextThreeMonths = new Date(Date.parse(randomQuestionnaireByDate[0].date))
-      nextThreeMonths.setDate(nextThreeMonths.getDate() + 90)
+      const nextWeek = new Date(Date.parse(randomQuestionnaireByDate[0].date))
+      nextWeek.setDate(nextWeek.getDate() + 7)
       lastDate = new Date(
         Math.max(
           Date.parse(randomQuestionnaireByDate[randomQuestionnaireByDate.length - 1].date),
-          nextThreeMonths
+          nextWeek
         )
       )
     }

--- a/assets/js/components/surveys/SurveyCard.jsx
+++ b/assets/js/components/surveys/SurveyCard.jsx
@@ -14,6 +14,7 @@ import MoveSurveyForm from "./MoveSurveyForm"
 import classNames from "classnames/bind"
 
 import { connect } from "react-redux"
+import { withRouter } from "react-router"
 
 class _SurveyCard extends Component<any> {
   props: {
@@ -299,7 +300,7 @@ class _PanelSurveyCard extends Component<any> {
   }
 }
 
-class InnerSurveyCard extends Component<any> {
+class _InnerSurveyCard extends Component<any> {
   props: {
     survey: Survey,
     actions: Array<Object>,
@@ -309,12 +310,20 @@ class InnerSurveyCard extends Component<any> {
     dispatch: Function,
   }
 
+  constructor(props) {
+    super(props)
+  }
+
   componentDidMount() {
     const { survey, dispatch } = this.props
 
     if (survey.state != "not_ready") {
-      fetchRespondentsStats(survey.projectId, survey.id)(dispatch)
+      dispatch(fetchRespondentsStats(survey.projectId, survey.id))
     }
+  }
+
+  componentWillReceiveProps(props) {
+    this.setState({ respondentsStats: props.respondentsStats })
   }
 
   render() {
@@ -489,5 +498,16 @@ class TwoStepsConfirmationModal extends Component<Props, State> {
   }
 }
 
+const mapStateToProps = (state, ownProps) => {
+  const { survey } = ownProps
+  const { respondentsStats } = state
+
+  return {
+    ...ownProps,
+    respondentsStats: respondentsStats[survey.id],
+  }
+}
+
 export const SurveyCard = translate()(connect()(_SurveyCard))
 export const PanelSurveyCard = translate()(connect()(_PanelSurveyCard))
+export const InnerSurveyCard = translate()(withRouter(connect(mapStateToProps)(_InnerSurveyCard)))

--- a/assets/js/components/surveys/SurveyCard.jsx
+++ b/assets/js/components/surveys/SurveyCard.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react"
 import { translate, Trans } from "react-i18next"
 
-import { Link } from "react-router"
+import { Link, withRouter } from "react-router"
 import * as routes from "../../routes"
 import * as surveyActions from "../../actions/survey"
 import * as panelSurveyActions from "../../actions/panelSurvey"
@@ -14,7 +14,6 @@ import MoveSurveyForm from "./MoveSurveyForm"
 import classNames from "classnames/bind"
 
 import { connect } from "react-redux"
-import { withRouter } from "react-router"
 
 class _SurveyCard extends Component<any> {
   props: {
@@ -308,10 +307,6 @@ class _InnerSurveyCard extends Component<any> {
     t: Function,
     respondentsStats: ?Object,
     dispatch: Function,
-  }
-
-  constructor(props) {
-    super(props)
   }
 
   componentDidMount() {


### PR DESCRIPTION
Close #2199 

Now the Survey Card will show the competition percentage and its evolution:

![image](https://user-images.githubusercontent.com/13782680/223731590-e1e23ebc-d827-4f09-9095-8bd62f4935ec.png)

The problem was that the `RECEIVE_RESPONDENTS_STATS` wasn't transmitted into the component properties. To accomplish this I've created a `mapStateToProps` function as there is in many other places on the project. 

Note for @manumoreira: the line plot will have in the x-axis a minimum 3 months (or more if the survey takes longer) that made me suspect that wasn't fulfilled in surveys of 2-3 days... Just for you to consider if you want to do something different there.

