### PR TITLE
Fixing x axis labels in respondents chart

### DIFF
--- a/assets/js/components/respondents/RespondentsChart.jsx
+++ b/assets/js/components/respondents/RespondentsChart.jsx
@@ -85,7 +85,7 @@ class RespondentsChart extends PureComponent {
     const yaxis = d3.axisRight().scale(yScale).tickSize(this.width).ticks(4)
 
     xaxisContainer
-      .call(xaxis.ticks(3).tickFormat(d3.timeFormat("%b")))
+      .call(xaxis.ticks(3).tickFormat(d3.timeFormat("%d-%b")))
       .selectAll("text")
       .attr("dy", 7)
       .attr("x", 10)


### PR DESCRIPTION
Small fix to 2199, the x axis label now will look as was asked:

![image](https://user-images.githubusercontent.com/13782680/224064379-bf4dd2fe-0bc2-47ab-b23b-b0df43849fe9.png)


