### PR TITLE
Set default timezone to browsers timezone on project creation

### DIFF
--- a/assets/js/components/projects/ProjectIndex.jsx
+++ b/assets/js/components/projects/ProjectIndex.jsx
@@ -29,6 +29,14 @@ class ProjectIndex extends Component {
     this.fetchProjects()
   }
 
+  getTimezone() {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone
+    } catch (ex) {
+      return null
+    }
+  }
+
   newProject(e) {
     e.preventDefault()
 
@@ -37,7 +45,7 @@ class ProjectIndex extends Component {
     this.creatingProject = true
 
     let theProject
-    createProject({ name: "" })
+    createProject({ name: "", timezone: this.getTimezone() })
       .then((response) => {
         theProject = response.entities.projects[response.result]
         this.props.projectActions.createProject(theProject)

--- a/test/ask_web/controllers/project_controller_test.exs
+++ b/test/ask_web/controllers/project_controller_test.exs
@@ -5,6 +5,7 @@ defmodule AskWeb.ProjectControllerTest do
 
   alias Ask.{Project, ActivityLog}
   @valid_attrs %{name: "some content"}
+  @valid_attrs_with_timezone %{name: "some content", timezone: "Europe/London"}
 
   setup %{conn: conn} do
     user = insert(:user)
@@ -329,6 +330,18 @@ defmodule AskWeb.ProjectControllerTest do
       assert response["data"]["owner"] == true
       assert Repo.get_by(Project, @valid_attrs)
     end
+
+
+    test "creates and renders resource when data is valid and have timezone", %{conn: conn} do
+      conn = post conn, project_path(conn, :create), project: @valid_attrs_with_timezone
+      response = json_response(conn, 201)
+      assert response["data"]["id"]
+      assert response["data"]["read_only"] == false
+      assert response["data"]["owner"] == true
+      assert response["data"]["timezone"] == "Europe/London"
+      assert Repo.get_by(Project, @valid_attrs_with_timezone)
+    end
+    
   end
 
   describe "update" do


### PR DESCRIPTION
Close #2194 

The `getTimeZone` function that was used to get the browsers' timezone was rescued to be used on project creation.

It was tested that:
- On creation it takes the browser timezone,
- that then this is used when created surveys, but if the survey's timezone is modified the modification remains,
- that modifying the project's timezone the original timezone taken from the browser was replaced and works properly.

If there is no browser timezone then `null` is passed and `UTC` will be used, but I wasn't able to test this. Any hint on how to do that is appreciated :)

