### PR TITLE
Fix to don't display success rate chart if not present in forecasts

### DIFF
--- a/assets/js/components/charts/SuccessRateLine.jsx
+++ b/assets/js/components/charts/SuccessRateLine.jsx
@@ -53,6 +53,9 @@ export default class SuccessRateLine extends Component<Props> {
     const { width, height, data } = this.state
 
     let srData = data.filter((d) => d.label === "Success rate")
+    if (!srData[0].values.length) {
+      return
+    }
     srData[0].values.unshift({ time: srData[0].values[0].time, value: 0 })
     srData[0].values.push({ time: srData[0].values[srData[0].values.length - 1].time, value: 0 })
 

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -397,6 +397,17 @@ class SurveyShow extends Component<any, State> {
               </div>
               <Stats data={stats} />
               <Forecasts data={forecasts} ceil={100} />
+              {forecasts.filter((d) => d.id == "successRate").length ? (
+                <div>
+                  <div className="header" style={{ marginTop: "40px", marginBottom: "0" }}>
+                    <div className="title">{t("Success Rate")}</div>
+                    <div className="description">
+                      {t("Estimated by combining initial and current values")}
+                    </div>
+                  </div>
+                  <SuccessRateLine data={forecasts} />
+                </div>
+              ) : null}
               <div className="header" style={{ marginTop: "40px", marginBottom: "0" }}>
                 <div className="title">{t("Success Rate")}</div>
                 <div className="description">


### PR DESCRIPTION
Small fix to an error reported by Muhammad: the success rate section won't display if there is no success rate data. 