### PR TITLE
Fix for callbacks bypassed by nuntium channel

### DIFF
--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -102,10 +102,10 @@ defmodule Ask.Runtime.ChannelBroker do
     )
   end
 
-  def force_activate_respondent(channel_id, respondent_id, provider) do
+  def force_activate_respondent(channel_id, respondent_id) do
     call_gen_server(
       channel_id,
-      {:force_activate_respondent, respondent_id, provider}
+      {:force_activate_respondent, respondent_id}
     )
   end
 
@@ -834,7 +834,7 @@ defmodule Ask.Runtime.ChannelBroker do
 
   @impl true
   def handle_call(
-        {:force_activate_respondent, respondent_id, provider},
+        {:force_activate_respondent, respondent_id},
         _from,
         %{
           active_contacts: active_contacts,

--- a/lib/ask/runtime/nuntium_channel.ex
+++ b/lib/ask/runtime/nuntium_channel.ex
@@ -192,6 +192,19 @@ defmodule Ask.Runtime.NuntiumChannel do
       end
 
     json_reply = reply_to_messages(reply, from, respondent_id, channel_id)
+
+    case json_reply do
+      [] ->
+        :ok
+
+      _ ->
+        ChannelBroker.force_active_respondent(
+          channel_id,
+          Repo.get(Respondent, respondent_id),
+          "nuntium"
+        )
+    end
+
     SurvedaMetrics.increment_counter(:surveda_nuntium_incoming)
     Phoenix.Controller.json(conn, json_reply)
   end

--- a/lib/ask/runtime/nuntium_channel.ex
+++ b/lib/ask/runtime/nuntium_channel.ex
@@ -198,9 +198,9 @@ defmodule Ask.Runtime.NuntiumChannel do
         :ok
 
       _ ->
-        ChannelBroker.force_active_respondent(
+        ChannelBroker.force_activate_respondent(
           channel_id,
-          Repo.get(Respondent, respondent_id),
+          respondent_id,
           "nuntium"
         )
     end

--- a/lib/ask/runtime/nuntium_channel.ex
+++ b/lib/ask/runtime/nuntium_channel.ex
@@ -200,8 +200,7 @@ defmodule Ask.Runtime.NuntiumChannel do
       _ ->
         ChannelBroker.force_activate_respondent(
           channel_id,
-          respondent_id,
-          "nuntium"
+          respondent_id
         )
     end
 


### PR DESCRIPTION
close #2150.

In the `callback` function in `NuntiumChannel` if there is an answer upon calling `reply_to_messages` they will be sent bypassing the `ChannelBroker`. 
To avoid this, a new method `force_active_respondent` in the `ChannelBroker` put the respondent within the `activeContacts`. 

Tests were performed to see that this is working, and also that they are added and later deactivated. A small survey of 5 respondents was run. 

In the following plots, you will see in the x-axis the time when a `Logger` event was logged, in the y-axis you will see the number of active contacts, and in the tooltip, you will see the function executed to obtain this result (plot not available in this branch, but in the console output you should be able to see the same):

1) At the beginning, the contacts are normally activated through the `activate_contacts` method, reaching a contact from the queue:

![image](https://user-images.githubusercontent.com/13782680/225730042-c40e6b90-cea4-47df-b9d8-0c7126f58391.png)

2) When a callback is received from the method indicated in the issue, now the respondent is forced to be active (here called `activate_contact_by_force`):

![image](https://user-images.githubusercontent.com/13782680/225730899-64b32d7f-0a8a-4dd9-9054-ebcea10abf0a.png)

Other callback, another forced activation:

![image](https://user-images.githubusercontent.com/13782680/225731321-8a6f250d-c451-4609-a990-e2fe0fd4c0f7.png)

3) Contacts are then normally deactivated (as if they were activated with the `activate_contacts` function of **1)**)

![image](https://user-images.githubusercontent.com/13782680/225731564-cbc34a26-628f-416d-924f-10c809906ee6.png)


