### PR TITLE
Added batch_limit_per_minute to project settings

### DIFF
--- a/assets/js/components/projects/ProjectSettings.jsx
+++ b/assets/js/components/projects/ProjectSettings.jsx
@@ -37,6 +37,7 @@ class ProjectSettings extends Component {
       responseRate: project.responseRate || "",
       validRespondentRate: project.validRespondentRate || "",
       detailedRates: project.eligibilityRate != null,
+      batchLimitPerMinute: project.batchLimitPerMinute || "",
       archiveAction: project.readOnly ? "unarchive" : "archive",
     }
     this.initialState = JSON.parse(JSON.stringify(state))
@@ -58,6 +59,7 @@ class ProjectSettings extends Component {
       eligibilityRate: parseFloat(this.state.eligibilityRate, 10) || null,
       responseRate: parseFloat(this.state.responseRate, 10) || null,
       validRespondentRate: parseFloat(this.state.validRespondentRate, 10) || null,
+      batchLimitPerMinute: parseInt(this.state.batchLimitPerMinute) || null,
     })
     dispatch(projectActions.updateProject(changes))
   }
@@ -156,8 +158,15 @@ class ProjectSettings extends Component {
       return <div>{t("Loading project...")}</div>
     }
 
-    const { name, timezone, colourScheme, initialSuccessRate, detailedRates, archiveAction } =
-      this.state
+    const {
+      name,
+      timezone,
+      colourScheme,
+      initialSuccessRate,
+      batchLimitPerMinute,
+      detailedRates,
+      archiveAction,
+    } = this.state
 
     const inputProjectName = (
       <div>
@@ -259,6 +268,27 @@ class ProjectSettings extends Component {
       </div>
     )
 
+    const inputBatchLimitPerMinute = (
+      <div>
+        <div className="row">
+          <div className="col s3" id="batchLimitPerMinute">
+            <label className="gray-text">Batch limit per minute</label>
+            <input
+              type="number"
+              step="1"
+              min="0"
+              value={batchLimitPerMinute}
+              disabled={readOnly}
+              readOnly={readOnly}
+              onInput={(e) => this.setState({ batchLimitPerMinute: e.target.value })}
+              onChange={(e) => this.setState({ batchLimitPerMinute: e.target.value })}
+            />
+            {this.spanErrors("batchLimitPerMinute")}
+          </div>
+        </div>
+      </div>
+    )
+
     const actionsButtons = (
       <div className="row">
         <div className="col">
@@ -299,6 +329,7 @@ class ProjectSettings extends Component {
             {inputTimeZone}
             {inputColourScheme}
             {inputRates}
+            {inputBatchLimitPerMinute}
             {actionsButtons}
           </div>
         </div>
@@ -315,6 +346,7 @@ class ProjectSettings extends Component {
       "eligibilityRate",
       "validRespondentRate",
       "detailedRates",
+      "batchLimitPerMinute",
     ]
     return (
       JSON.stringify(pick(this.state, fields)) !== JSON.stringify(pick(this.initialState, fields))

--- a/lib/ask/project.ex
+++ b/lib/ask/project.ex
@@ -10,6 +10,7 @@ defmodule Ask.Project do
     field :eligibility_rate, :float
     field :response_rate, :float
     field :valid_respondent_rate, :float
+    field :batch_limit_per_minute, :integer
     field :archived, :boolean, default: false
 
     has_many :questionnaires, Ask.Questionnaire
@@ -39,13 +40,15 @@ defmodule Ask.Project do
       :initial_success_rate,
       :eligibility_rate,
       :response_rate,
-      :valid_respondent_rate
+      :valid_respondent_rate,
+      :batch_limit_per_minute
     ])
     |> validate_colour_scheme
     |> validate_rate(:initial_success_rate)
     |> validate_rate(:eligibility_rate)
     |> validate_rate(:response_rate)
     |> validate_rate(:valid_respondent_rate)
+    |> validate_positive
   end
 
   def touch!(project) do
@@ -76,6 +79,18 @@ defmodule Ask.Project do
     cond do
       rate_field && (rate_field < 0 || rate_field > 1) ->
         add_error(changeset, rate, "value has to be between 0 and 1")
+
+      true ->
+        changeset
+    end
+  end
+
+  defp validate_positive(changeset) do
+    batch_limit_per_minute = get_field(changeset, :batch_limit_per_minute)
+
+    cond do
+      batch_limit_per_minute && batch_limit_per_minute < 0 ->
+        add_error(changeset, :batch_limit_per_minute, "value has to be positive")
 
       true ->
         changeset

--- a/lib/ask/project.ex
+++ b/lib/ask/project.ex
@@ -48,7 +48,7 @@ defmodule Ask.Project do
     |> validate_rate(:eligibility_rate)
     |> validate_rate(:response_rate)
     |> validate_rate(:valid_respondent_rate)
-    |> validate_positive
+    |> validate_positive_number(:batch_limit_per_minute)
   end
 
   def touch!(project) do
@@ -85,12 +85,12 @@ defmodule Ask.Project do
     end
   end
 
-  defp validate_positive(changeset) do
-    batch_limit_per_minute = get_field(changeset, :batch_limit_per_minute)
+  defp validate_positive_number(changeset, field) do
+    field_value = get_field(changeset, field)
 
     cond do
-      batch_limit_per_minute && batch_limit_per_minute < 0 ->
-        add_error(changeset, :batch_limit_per_minute, "value has to be positive")
+      field_value && field_value < 0 ->
+        add_error(changeset, field, "value has to be positive")
 
       true ->
         changeset

--- a/lib/ask_web/views/project_view.ex
+++ b/lib/ask_web/views/project_view.ex
@@ -96,7 +96,8 @@ defmodule AskWeb.ProjectView do
       initial_success_rate: project.initial_success_rate,
       eligibility_rate: project.eligibility_rate,
       response_rate: project.response_rate,
-      valid_respondent_rate: project.valid_respondent_rate
+      valid_respondent_rate: project.valid_respondent_rate,
+      batch_limit_per_minute: project.batch_limit_per_minute
     }
   end
 end

--- a/priv/repo/migrations/20230317094712_add_batch_limit_per_minute_to_projects.exs
+++ b/priv/repo/migrations/20230317094712_add_batch_limit_per_minute_to_projects.exs
@@ -1,0 +1,9 @@
+defmodule Ask.Repo.Migrations.AddSettingsToProjects do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :batch_limit_per_minute, :integer
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.19  Distrib 10.3.36-MariaDB, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.16  Distrib 10.1.48-MariaDB, for debian-linux-gnu (x86_64)
 --
 -- Host: db    Database: ask_dev
 -- ------------------------------------------------------
--- Server version	5.7.40
+-- Server version	5.7.37
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -61,6 +61,48 @@ CREATE TABLE `audios` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `id` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `channel_broker_history`
+--
+
+DROP TABLE IF EXISTS `channel_broker_history`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `channel_broker_history` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `channel_id` bigint(20) unsigned DEFAULT NULL,
+  `instruction` varchar(255) DEFAULT NULL,
+  `parameters` json DEFAULT NULL,
+  `active_contacts` json DEFAULT NULL,
+  `contacts_queue_ids` json DEFAULT NULL,
+  `inserted_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `channel_broker_history_channel_id_fkey` (`channel_id`),
+  CONSTRAINT `channel_broker_history_channel_id_fkey` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `channel_broker_recovery`
+--
+
+DROP TABLE IF EXISTS `channel_broker_recovery`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `channel_broker_recovery` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `channel_id` bigint(20) unsigned DEFAULT NULL,
+  `active_contacts` json DEFAULT NULL,
+  `contacts_queue_ids` json DEFAULT NULL,
+  `inserted_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `channel_broker_recovery_channel_id_index` (`channel_id`),
+  CONSTRAINT `channel_broker_recovery_channel_id_fkey` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -288,6 +330,7 @@ CREATE TABLE `projects` (
   `eligibility_rate` double DEFAULT NULL,
   `response_rate` double DEFAULT NULL,
   `valid_respondent_rate` double DEFAULT NULL,
+  `batch_limit_per_minute` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `id` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -946,6 +989,28 @@ CREATE TABLE `translations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `user_channels`
+--
+
+DROP TABLE IF EXISTS `user_channels`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `user_channels` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned DEFAULT NULL,
+  `channel_id` bigint(20) unsigned DEFAULT NULL,
+  `patterns` text,
+  `inserted_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `user_channels_user_id_fkey` (`user_id`),
+  KEY `user_channels_channel_id_fkey` (`channel_id`),
+  CONSTRAINT `user_channels_channel_id_fkey` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`),
+  CONSTRAINT `user_channels_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `users`
 --
 
@@ -987,7 +1052,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2023-02-27 13:27:15
+-- Dump completed on 2023-03-17  8:48:46
 INSERT INTO `schema_migrations` (version) VALUES (20160812145257);
 INSERT INTO `schema_migrations` (version) VALUES (20160816183915);
 INSERT INTO `schema_migrations` (version) VALUES (20160830200454);
@@ -1200,4 +1265,9 @@ INSERT INTO `schema_migrations` (version) VALUES (20210629170410);
 INSERT INTO `schema_migrations` (version) VALUES (20211125141835);
 INSERT INTO `schema_migrations` (version) VALUES (20211213094856);
 INSERT INTO `schema_migrations` (version) VALUES (20220131103226);
+INSERT INTO `schema_migrations` (version) VALUES (20220801181201);
+INSERT INTO `schema_migrations` (version) VALUES (20220819144948);
+INSERT INTO `schema_migrations` (version) VALUES (20220916123648);
 INSERT INTO `schema_migrations` (version) VALUES (20230217143550);
+INSERT INTO `schema_migrations` (version) VALUES (20230315104750);
+INSERT INTO `schema_migrations` (version) VALUES (20230317094712);

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -64,48 +64,6 @@ CREATE TABLE `audios` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `channel_broker_history`
---
-
-DROP TABLE IF EXISTS `channel_broker_history`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `channel_broker_history` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `channel_id` bigint(20) unsigned DEFAULT NULL,
-  `instruction` varchar(255) DEFAULT NULL,
-  `parameters` json DEFAULT NULL,
-  `active_contacts` json DEFAULT NULL,
-  `contacts_queue_ids` json DEFAULT NULL,
-  `inserted_at` datetime NOT NULL,
-  `updated_at` datetime NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `channel_broker_history_channel_id_fkey` (`channel_id`),
-  CONSTRAINT `channel_broker_history_channel_id_fkey` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `channel_broker_recovery`
---
-
-DROP TABLE IF EXISTS `channel_broker_recovery`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `channel_broker_recovery` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `channel_id` bigint(20) unsigned DEFAULT NULL,
-  `active_contacts` json DEFAULT NULL,
-  `contacts_queue_ids` json DEFAULT NULL,
-  `inserted_at` datetime NOT NULL,
-  `updated_at` datetime NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `channel_broker_recovery_channel_id_index` (`channel_id`),
-  CONSTRAINT `channel_broker_recovery_channel_id_fkey` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
 -- Table structure for table `channels`
 --
 
@@ -989,28 +947,6 @@ CREATE TABLE `translations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `user_channels`
---
-
-DROP TABLE IF EXISTS `user_channels`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `user_channels` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `user_id` bigint(20) unsigned DEFAULT NULL,
-  `channel_id` bigint(20) unsigned DEFAULT NULL,
-  `patterns` text,
-  `inserted_at` datetime NOT NULL,
-  `updated_at` datetime NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `user_channels_user_id_fkey` (`user_id`),
-  KEY `user_channels_channel_id_fkey` (`channel_id`),
-  CONSTRAINT `user_channels_channel_id_fkey` FOREIGN KEY (`channel_id`) REFERENCES `channels` (`id`),
-  CONSTRAINT `user_channels_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
 -- Table structure for table `users`
 --
 
@@ -1265,9 +1201,5 @@ INSERT INTO `schema_migrations` (version) VALUES (20210629170410);
 INSERT INTO `schema_migrations` (version) VALUES (20211125141835);
 INSERT INTO `schema_migrations` (version) VALUES (20211213094856);
 INSERT INTO `schema_migrations` (version) VALUES (20220131103226);
-INSERT INTO `schema_migrations` (version) VALUES (20220801181201);
-INSERT INTO `schema_migrations` (version) VALUES (20220819144948);
-INSERT INTO `schema_migrations` (version) VALUES (20220916123648);
 INSERT INTO `schema_migrations` (version) VALUES (20230217143550);
-INSERT INTO `schema_migrations` (version) VALUES (20230315104750);
 INSERT INTO `schema_migrations` (version) VALUES (20230317094712);

--- a/test/ask_web/controllers/project_controller_test.exs
+++ b/test/ask_web/controllers/project_controller_test.exs
@@ -56,7 +56,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "initial_success_rate" => nil,
                  "response_rate" => nil,
                  "timezone" => nil,
-                 "valid_respondent_rate" => nil
+                 "valid_respondent_rate" => nil,
+                 "batch_limit_per_minute" => nil
                },
                %{
                  "id" => project2.id,
@@ -71,7 +72,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "initial_success_rate" => nil,
                  "response_rate" => nil,
                  "timezone" => nil,
-                 "valid_respondent_rate" => nil
+                 "valid_respondent_rate" => nil,
+                 "batch_limit_per_minute" => nil
                }
              ]
     end
@@ -97,7 +99,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "initial_success_rate" => nil,
                  "response_rate" => nil,
                  "timezone" => nil,
-                 "valid_respondent_rate" => nil
+                 "valid_respondent_rate" => nil,
+                 "batch_limit_per_minute" => nil
                }
              ]
     end
@@ -122,7 +125,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "initial_success_rate" => nil,
                  "response_rate" => nil,
                  "timezone" => nil,
-                 "valid_respondent_rate" => nil
+                 "valid_respondent_rate" => nil,
+                 "batch_limit_per_minute" => nil
                }
              ]
     end
@@ -147,7 +151,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "initial_success_rate" => nil,
                  "response_rate" => nil,
                  "timezone" => nil,
-                 "valid_respondent_rate" => nil
+                 "valid_respondent_rate" => nil,
+                 "batch_limit_per_minute" => nil
                },
                %{
                  "id" => active_project.id,
@@ -162,7 +167,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "initial_success_rate" => nil,
                  "response_rate" => nil,
                  "timezone" => nil,
-                 "valid_respondent_rate" => nil
+                 "valid_respondent_rate" => nil,
+                 "batch_limit_per_minute" => nil
                }
              ]
     end
@@ -197,7 +203,8 @@ defmodule AskWeb.ProjectControllerTest do
         "initial_success_rate" => nil,
         "response_rate" => nil,
         "timezone" => nil,
-        "valid_respondent_rate" => nil
+        "valid_respondent_rate" => nil,
+        "batch_limit_per_minute" => nil
       }
 
       project_map_2 = %{
@@ -213,7 +220,8 @@ defmodule AskWeb.ProjectControllerTest do
         "initial_success_rate" => nil,
         "response_rate" => nil,
         "timezone" => nil,
-        "valid_respondent_rate" => nil
+        "valid_respondent_rate" => nil,
+        "batch_limit_per_minute" => nil
       }
 
       project_map_3 = %{
@@ -229,7 +237,8 @@ defmodule AskWeb.ProjectControllerTest do
         "initial_success_rate" => nil,
         "response_rate" => nil,
         "timezone" => nil,
-        "valid_respondent_rate" => nil
+        "valid_respondent_rate" => nil,
+        "batch_limit_per_minute" => nil
       }
 
       assert json_response(conn, 200)["data"] == [project_map_1, project_map_2, project_map_3]
@@ -254,7 +263,8 @@ defmodule AskWeb.ProjectControllerTest do
                "initial_success_rate" => nil,
                "response_rate" => nil,
                "timezone" => nil,
-               "valid_respondent_rate" => nil
+               "valid_respondent_rate" => nil,
+               "batch_limit_per_minute" => nil
              }
     end
 
@@ -275,7 +285,8 @@ defmodule AskWeb.ProjectControllerTest do
                "initial_success_rate" => nil,
                "response_rate" => nil,
                "timezone" => nil,
-               "valid_respondent_rate" => nil
+               "valid_respondent_rate" => nil,
+               "batch_limit_per_minute" => nil
              }
     end
 
@@ -316,7 +327,8 @@ defmodule AskWeb.ProjectControllerTest do
                "initial_success_rate" => nil,
                "response_rate" => nil,
                "timezone" => nil,
-               "valid_respondent_rate" => nil
+               "valid_respondent_rate" => nil,
+               "batch_limit_per_minute" => nil
              }
     end
   end


### PR DESCRIPTION
Close #2206 

Project settings now include a new field, `batch_limit_per_minute`. It's added to the settings tab following the issue's mockup:

![image](https://user-images.githubusercontent.com/13782680/225969015-16fe31e0-fa00-4372-a935-1573fdf6e5c3.png)

In order to make it functional, the `batch_limit_per_minute\0` was modified to `batch_limit_per_minute\1` taking the parameter and returning the global setting if it's `nil` on the project.

The two functions using `batch_limit_per_minute` are `retry_respondents` & `start_some`. In the latter, the `survey` is a parameter, then we can easily access the project. For `retry_respondents`, all projects where exists respondents to retry are iterated and they are retried respecting the project's `batch_limit_per_minute`.

