### PR TITLE
Showing running surveys count in folder card

### DIFF
--- a/assets/css/_global.scss
+++ b/assets/css/_global.scss
@@ -437,18 +437,21 @@ path.respondentsData.referenceStrokeColor15 {
     }
 
     .folder-card-running-surveys {
-      // black background and rounded corners
-      @extend .grey-text;
+      @extend .green-text;
       border-radius: 12px;
-      padding: 4px 7px;
+      border: 1px solid color("grey", "lighten-2");
+      padding: 0px 8px 0px 5px;
       margin-left: 10px;
-      //black background
-      background-color: black;
       font-size: 0.8rem;
       font-weight: 600;
       line-height: 1.2rem;
       text-align: center;
-      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+
+      .material-icons {
+        padding: 0px;
+      }
     }
   }
 

--- a/assets/css/_global.scss
+++ b/assets/css/_global.scss
@@ -435,6 +435,21 @@ path.respondentsData.referenceStrokeColor15 {
       display: flex;
       width: 100%;
     }
+
+    .folder-card-running-surveys {
+      // black background and rounded corners
+      @extend .grey-text;
+      border-radius: 12px;
+      padding: 4px 7px;
+      margin-left: 10px;
+      //black background
+      background-color: black;
+      font-size: 0.8rem;
+      font-weight: 600;
+      line-height: 1.2rem;
+      text-align: center;
+      text-transform: uppercase;
+    }
   }
 
   .folder-card-error {

--- a/assets/js/components/folders/FolderCard.jsx
+++ b/assets/js/components/folders/FolderCard.jsx
@@ -41,6 +41,8 @@ class FolderCard extends PureComponent {
       </Dropdown>
     )
 
+    const runningSurveys = this.props.surveys.filter((survey) => survey.state === "running").length
+
     return (
       <Card>
         <div className="folder-card">
@@ -49,6 +51,9 @@ class FolderCard extends PureComponent {
               <i className="material-icons">folder</i>
               {name}
             </Link>
+            {runningSurveys ? (
+              <div className="folder-card-running-surveys">{runningSurveys}</div>
+            ) : null}
             {readOnly || options}
           </div>
         </div>

--- a/assets/js/components/folders/FolderCard.jsx
+++ b/assets/js/components/folders/FolderCard.jsx
@@ -17,7 +17,7 @@ class FolderCard extends PureComponent {
   }
 
   render() {
-    const { name, projectId, id, t, onDelete, onRename, readOnly } = this.props
+    const { name, projectId, id, runningSurveys, t, onDelete, onRename, readOnly } = this.props
     const options = (
       <Dropdown
         className="options"
@@ -41,8 +41,6 @@ class FolderCard extends PureComponent {
         </DropdownItem>
       </Dropdown>
     )
-
-    const runningSurveys = this.props.surveys.filter((survey) => survey.state === "running").length
 
     return (
       <Card>

--- a/assets/js/components/folders/FolderCard.jsx
+++ b/assets/js/components/folders/FolderCard.jsx
@@ -9,7 +9,7 @@ class FolderCard extends PureComponent {
     projectId: PropTypes.number,
     id: PropTypes.number,
     name: PropTypes.string,
-    surveys: PropTypes.array,
+    runningSurveys: PropTypes.number,
     t: PropTypes.func,
     onDelete: PropTypes.func,
     onRename: PropTypes.func,

--- a/assets/js/components/folders/FolderCard.jsx
+++ b/assets/js/components/folders/FolderCard.jsx
@@ -51,7 +51,10 @@ class FolderCard extends PureComponent {
               {name}
             </Link>
             {runningSurveys ? (
-              <div className="folder-card-running-surveys">{runningSurveys}</div>
+              <div className="folder-card-running-surveys">
+                <i className="material-icons">play_arrow</i>
+                {runningSurveys}
+              </div>
             ) : null}
             {readOnly || options}
           </div>

--- a/assets/js/components/folders/FolderCard.jsx
+++ b/assets/js/components/folders/FolderCard.jsx
@@ -9,6 +9,7 @@ class FolderCard extends PureComponent {
     projectId: PropTypes.number,
     id: PropTypes.number,
     name: PropTypes.string,
+    surveys: PropTypes.array,
     t: PropTypes.func,
     onDelete: PropTypes.func,
     onRename: PropTypes.func,

--- a/lib/ask_web/controllers/folder_controller.ex
+++ b/lib/ask_web/controllers/folder_controller.ex
@@ -49,23 +49,15 @@ defmodule AskWeb.FolderController do
   def count_running_surveys(folder_id) do
     surveys =
       from(s in Survey,
-        where: s.folder_id == ^folder_id,
-        where: s.state == ^:running,
-        select: count(s.id)
-      )
-      |> Repo.one()
-
-    pannel_surveys =
-      from(s in Survey,
-        join: ps in PanelSurvey,
+        left_join: ps in PanelSurvey,
         on: s.panel_survey_id == ps.id,
-        where: ps.folder_id == ^folder_id,
+        where: (ps.folder_id == ^folder_id or s.folder_id == ^folder_id),
         where: s.state == ^:running,
         select: count(s.id)
       )
       |> Repo.one()
 
-    surveys + pannel_surveys
+    surveys
   end
 
   def show(conn, %{"project_id" => project_id, "id" => folder_id}) do

--- a/lib/ask_web/controllers/folder_controller.ex
+++ b/lib/ask_web/controllers/folder_controller.ex
@@ -1,7 +1,7 @@
 defmodule AskWeb.FolderController do
   use AskWeb, :api_controller
 
-  alias Ask.{Folder, Logger, ActivityLog, Project}
+  alias Ask.{Folder, Logger, ActivityLog, Project, Survey}
   alias Ecto.Multi
 
   def create(conn, %{"project_id" => project_id, "folder" => %{"name" => name}}) do
@@ -41,10 +41,21 @@ defmodule AskWeb.FolderController do
         where: f.project_id == ^project.id
       )
       |> Repo.all()
-      |> Repo.preload(:surveys)
 
     conn
     |> render("index.json", folders: folders)
+  end
+
+  def running_surveys(folder_id) do
+    surveys =
+      from(s in Survey,
+        where: s.folder_id == ^folder_id,
+        where: s.state == ^:running,
+        select: count(s.id)
+      )
+      |> Repo.one()
+
+    surveys
   end
 
   def show(conn, %{"project_id" => project_id, "id" => folder_id}) do

--- a/lib/ask_web/controllers/folder_controller.ex
+++ b/lib/ask_web/controllers/folder_controller.ex
@@ -41,6 +41,7 @@ defmodule AskWeb.FolderController do
         where: f.project_id == ^project.id
       )
       |> Repo.all()
+      |> Repo.preload(:surveys)
 
     conn
     |> render("index.json", folders: folders)

--- a/lib/ask_web/views/folder_view.ex
+++ b/lib/ask_web/views/folder_view.ex
@@ -22,7 +22,7 @@ defmodule AskWeb.FolderView do
       id: folder.id,
       name: folder.name,
       project_id: folder.project_id,
-      running_surveys: FolderController.running_surveys(folder.id)
+      running_surveys: FolderController.count_running_surveys(folder.id)
     }
     |> put_if(Ecto.assoc_loaded?(panel_surveys), :panel_surveys, fn ->
       render_many(panel_surveys, AskWeb.PanelSurveyView, "panel_survey.json")

--- a/lib/ask_web/views/folder_view.ex
+++ b/lib/ask_web/views/folder_view.ex
@@ -1,6 +1,8 @@
 defmodule AskWeb.FolderView do
   use AskWeb, :view
 
+  alias AskWeb.FolderController
+
   def render("index.json", %{folders: folders}) do
     %{data: render_many(folders, AskWeb.FolderView, "folder.json")}
   end
@@ -19,7 +21,8 @@ defmodule AskWeb.FolderView do
     %{
       id: folder.id,
       name: folder.name,
-      project_id: folder.project_id
+      project_id: folder.project_id,
+      running_surveys: FolderController.running_surveys(folder.id)
     }
     |> put_if(Ecto.assoc_loaded?(panel_surveys), :panel_surveys, fn ->
       render_many(panel_surveys, AskWeb.PanelSurveyView, "panel_survey.json")

--- a/test/ask_web/controllers/folder_controller_test.exs
+++ b/test/ask_web/controllers/folder_controller_test.exs
@@ -104,7 +104,12 @@ defmodule AskWeb.FolderControllerTest do
       conn = get(conn, project_folder_path(conn, :index, project))
 
       assert json_response(conn, 200)["data"] == [
-               %{"id" => folder.id, "name" => folder.name, "project_id" => project.id}
+               %{
+                 "id" => folder.id,
+                 "name" => folder.name,
+                 "project_id" => project.id,
+                 "surveys" => []
+               }
              ]
     end
 

--- a/test/ask_web/controllers/folder_controller_test.exs
+++ b/test/ask_web/controllers/folder_controller_test.exs
@@ -108,7 +108,7 @@ defmodule AskWeb.FolderControllerTest do
                  "id" => folder.id,
                  "name" => folder.name,
                  "project_id" => project.id,
-                 "surveys" => []
+                 "running_surveys" => 0
                }
              ]
     end
@@ -150,7 +150,8 @@ defmodule AskWeb.FolderControllerTest do
       assert base == %{
                "id" => folder.id,
                "name" => folder.name,
-               "project_id" => project.id
+               "project_id" => project.id,
+               "running_surveys" => 0
              }
 
       assert data["panel_surveys"] == [


### PR DESCRIPTION
Close #2196 & #2222.

Running surveys count in folders (if any). 

Awaiting for designs @manumoreira, its functionally implemented and looks like this:

![image](https://user-images.githubusercontent.com/13782680/226313308-f4c848b0-6deb-4ade-9574-fd72fd34bb7f.png)
