### PR TITLE
Terminate ChannelBroker process after every unit test run

### DIFF
--- a/lib/ask/runtime/channel_broker_supervisor.ex
+++ b/lib/ask/runtime/channel_broker_supervisor.ex
@@ -67,6 +67,13 @@ defmodule Ask.Runtime.ChannelBrokerSupervisor do
     end
   end
 
+  def terminate_children() do
+    DynamicSupervisor.which_children(__MODULE__)
+    |> Enum.each(fn {_, pid, _, _} ->
+      terminate_child(pid)
+    end)
+  end
+
   defp lookup_child(channel_id) do
     case Registry.lookup(:channel_broker_registry, channel_id) do
       [{pid, nil}] ->

--- a/test/ask/runtime/channel_broker_test.exs
+++ b/test/ask/runtime/channel_broker_test.exs
@@ -13,6 +13,10 @@ defmodule Ask.Runtime.ChannelBrokerTest do
   alias Ask.{Config, Channel}
 
   setup %{conn: conn} do
+    on_exit(fn ->
+      ChannelBrokerSupervisor.terminate_children()
+    end)
+
     {:ok, _} = ChannelStatusServer.start_link()
     {:ok, _} = ChannelBrokerAgent.start_link()
     {:ok, conn: conn}

--- a/test/ask/runtime/channel_status_server_test.exs
+++ b/test/ask/runtime/channel_status_server_test.exs
@@ -8,6 +8,10 @@ defmodule Ask.Runtime.ChannelStatusServerTest do
   alias Ask.Runtime.ChannelBrokerAgent
 
   setup do
+    on_exit(fn ->
+      ChannelBrokerSupervisor.terminate_children()
+    end)
+
     {:ok, _} = ChannelBrokerAgent.start_link()
     :ok
   end

--- a/test/ask/runtime/nuntium_channel_test.exs
+++ b/test/ask/runtime/nuntium_channel_test.exs
@@ -16,6 +16,10 @@ defmodule Ask.Runtime.NuntiumChannelTest do
   require Ask.Runtime.ReplyHelper
 
   setup %{conn: conn} do
+    on_exit(fn ->
+      ChannelBrokerSupervisor.terminate_children()
+    end)
+
     GenServer.start_link(SurveyStub, [], name: SurveyStub.server_ref())
     ChannelStatusServer.start_link()
     ChannelBrokerAgent.start_link()

--- a/test/ask/runtime/retries_histogram_test.exs
+++ b/test/ask/runtime/retries_histogram_test.exs
@@ -25,6 +25,10 @@ defmodule Ask.Runtime.RetriesHistogramTest do
   @moduletag :time_mock
 
   setup do
+    on_exit(fn ->
+      ChannelBrokerSupervisor.terminate_children()
+    end)
+
     {:ok, _} = ChannelStatusServer.start_link()
     {:ok, _} = ChannelBrokerAgent.start_link()
     :ok

--- a/test/ask/runtime/survey_broker_test.exs
+++ b/test/ask/runtime/survey_broker_test.exs
@@ -29,6 +29,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
   require Ask.Runtime.ReplyHelper
 
   setup do
+    on_exit(fn ->
+      ChannelBrokerSupervisor.terminate_children()
+    end)
+
     {:ok, _} = ChannelBrokerAgent.start_link()
     {:ok, channel_status_server} = ChannelStatusServer.start_link()
     {:ok, channel_status_server: channel_status_server}

--- a/test/ask/runtime/survey_test.exs
+++ b/test/ask/runtime/survey_test.exs
@@ -33,6 +33,10 @@ defmodule Ask.Runtime.SurveyTest do
   require Ask.Runtime.ReplyHelper
 
   setup do
+    on_exit(fn ->
+      ChannelBrokerSupervisor.terminate_children()
+    end)
+
     {:ok, _} = ChannelStatusServer.start_link()
     ChannelBrokerAgent.start_link()
     :ok

--- a/test/ask/runtime/verboice_channel_test.exs
+++ b/test/ask/runtime/verboice_channel_test.exs
@@ -26,6 +26,10 @@ defmodule Ask.Runtime.VerboiceChannelTest do
   end
 
   setup %{conn: conn} do
+    on_exit(fn ->
+      ChannelBrokerSupervisor.terminate_children()
+    end)
+
     GenServer.start_link(SurveyStub, [], name: SurveyStub.server_ref())
     {:ok, _} = ChannelStatusServer.start_link()
     {:ok, _} = ChannelBrokerAgent.start_link()

--- a/test/ask_web/controllers/channel_controller_test.exs
+++ b/test/ask_web/controllers/channel_controller_test.exs
@@ -4,6 +4,10 @@ defmodule AskWeb.ChannelControllerTest do
   alias Ask.Runtime.ChannelBrokerAgent
 
   setup %{conn: conn} do
+    on_exit(fn ->
+      ChannelBrokerSupervisor.terminate_children()
+    end)
+
     user = insert(:user)
 
     conn =

--- a/test/ask_web/controllers/mobile_survey_controller_test.exs
+++ b/test/ask_web/controllers/mobile_survey_controller_test.exs
@@ -8,6 +8,10 @@ defmodule AskWeb.MobileSurveyControllerTest do
   require Ask.Runtime.ReplyHelper
 
   setup %{conn: conn} do
+    on_exit(fn ->
+      ChannelBrokerSupervisor.terminate_children()
+    end)
+
     conn =
       conn
       |> put_req_header("accept", "application/json")

--- a/test/ask_web/controllers/survey_controller_test.exs
+++ b/test/ask_web/controllers/survey_controller_test.exs
@@ -356,6 +356,8 @@ defmodule AskWeb.SurveyControllerTest do
 
       assert t2
       assert code
+
+      ChannelBrokerSupervisor.terminate_children()
     end
 
     test "returns 404 when the project does not exist", %{conn: conn} do
@@ -812,6 +814,8 @@ defmodule AskWeb.SurveyControllerTest do
 
       assert t1
       assert t2
+
+      ChannelBrokerSupervisor.terminate_children()
     end
 
     test "renders page not found when id is nonexistent", %{conn: conn} do


### PR DESCRIPTION
Close #2139.

Hundreds of `ChannelBroker` processes were initiated on unit tests without being terminated. 

The proposed solution: a new method `terminate_children` in the `ChannelBrokerSupervisor` that will terminate each child alive, to be called `on_exit` for each unit test, on those specs files that on `setup` do a `start_link` for `ChannelStatusServer`. 