### PR TITLE
Add batch-size-to-project-settings

### DIFF
--- a/assets/js/components/projects/ProjectSettings.jsx
+++ b/assets/js/components/projects/ProjectSettings.jsx
@@ -38,6 +38,7 @@ class ProjectSettings extends Component {
       validRespondentRate: project.validRespondentRate || "",
       detailedRates: project.eligibilityRate != null,
       batchLimitPerMinute: project.batchLimitPerMinute || "",
+      batchSize: project.batchSize || "",
       archiveAction: project.readOnly ? "unarchive" : "archive",
     }
     this.initialState = JSON.parse(JSON.stringify(state))
@@ -60,6 +61,7 @@ class ProjectSettings extends Component {
       responseRate: parseFloat(this.state.responseRate, 10) || null,
       validRespondentRate: parseFloat(this.state.validRespondentRate, 10) || null,
       batchLimitPerMinute: parseInt(this.state.batchLimitPerMinute) || null,
+      batchSize: parseInt(this.state.batchSize) || null,
     })
     dispatch(projectActions.updateProject(changes))
   }
@@ -164,6 +166,7 @@ class ProjectSettings extends Component {
       colourScheme,
       initialSuccessRate,
       batchLimitPerMinute,
+      batchSize,
       detailedRates,
       archiveAction,
     } = this.state
@@ -289,6 +292,27 @@ class ProjectSettings extends Component {
       </div>
     )
 
+    const inputBatchSize = (
+      <div>
+        <div className="row">
+          <div className="col s3" id="batchSize">
+            <label className="gray-text">Batch size</label>
+            <input
+              type="number"
+              step="1"
+              min="0"
+              value={batchSize}
+              disabled={readOnly}
+              readOnly={readOnly}
+              onInput={(e) => this.setState({ batchSize: e.target.value })}
+              onChange={(e) => this.setState({ batchSize: e.target.value })}
+            />
+            {this.spanErrors("batchSize")}
+          </div>
+        </div>
+      </div>
+    )
+
     const actionsButtons = (
       <div className="row">
         <div className="col">
@@ -330,6 +354,7 @@ class ProjectSettings extends Component {
             {inputColourScheme}
             {inputRates}
             {inputBatchLimitPerMinute}
+            {inputBatchSize}
             {actionsButtons}
           </div>
         </div>
@@ -347,6 +372,7 @@ class ProjectSettings extends Component {
       "validRespondentRate",
       "detailedRates",
       "batchLimitPerMinute",
+      "batchSize",
     ]
     return (
       JSON.stringify(pick(this.state, fields)) !== JSON.stringify(pick(this.initialState, fields))

--- a/lib/ask/project.ex
+++ b/lib/ask/project.ex
@@ -11,6 +11,7 @@ defmodule Ask.Project do
     field :response_rate, :float
     field :valid_respondent_rate, :float
     field :batch_limit_per_minute, :integer
+    field :batch_size, :integer
     field :archived, :boolean, default: false
 
     has_many :questionnaires, Ask.Questionnaire
@@ -41,7 +42,8 @@ defmodule Ask.Project do
       :eligibility_rate,
       :response_rate,
       :valid_respondent_rate,
-      :batch_limit_per_minute
+      :batch_limit_per_minute,
+      :batch_size
     ])
     |> validate_colour_scheme
     |> validate_rate(:initial_success_rate)
@@ -49,6 +51,7 @@ defmodule Ask.Project do
     |> validate_rate(:response_rate)
     |> validate_rate(:valid_respondent_rate)
     |> validate_positive_number(:batch_limit_per_minute)
+    |> validate_positive_number(:batch_size)
   end
 
   def touch!(project) do

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -326,7 +326,7 @@ defmodule Ask.Runtime.Broker do
   defp batch_size(survey, respondents_by_state) do
     case Survey.completed_respondents_needed_by(survey) do
       :all ->
-        default_batch_size()
+        survey.project.batch_limit_per_minute || default_batch_size()
 
       respondents_target when is_integer(respondents_target) ->
         successful = Survey.completed_state_respondents(survey, respondents_by_state)

--- a/lib/ask_web/views/project_view.ex
+++ b/lib/ask_web/views/project_view.ex
@@ -97,7 +97,8 @@ defmodule AskWeb.ProjectView do
       eligibility_rate: project.eligibility_rate,
       response_rate: project.response_rate,
       valid_respondent_rate: project.valid_respondent_rate,
-      batch_limit_per_minute: project.batch_limit_per_minute
+      batch_limit_per_minute: project.batch_limit_per_minute,
+      batch_size: project.batch_size
     }
   end
 end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -289,6 +289,7 @@ CREATE TABLE `projects` (
   `response_rate` double DEFAULT NULL,
   `valid_respondent_rate` double DEFAULT NULL,
   `batch_limit_per_minute` int(11) DEFAULT NULL,
+  `batch_size` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `id` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -988,7 +989,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2023-03-17  8:48:46
+-- Dump completed on 2023-04-03  7:13:11
 INSERT INTO `schema_migrations` (version) VALUES (20160812145257);
 INSERT INTO `schema_migrations` (version) VALUES (20160816183915);
 INSERT INTO `schema_migrations` (version) VALUES (20160830200454);
@@ -1203,3 +1204,4 @@ INSERT INTO `schema_migrations` (version) VALUES (20211213094856);
 INSERT INTO `schema_migrations` (version) VALUES (20220131103226);
 INSERT INTO `schema_migrations` (version) VALUES (20230217143550);
 INSERT INTO `schema_migrations` (version) VALUES (20230317094712);
+INSERT INTO `schema_migrations` (version) VALUES (20230402091100);

--- a/test/ask_web/controllers/project_controller_test.exs
+++ b/test/ask_web/controllers/project_controller_test.exs
@@ -57,7 +57,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "response_rate" => nil,
                  "timezone" => nil,
                  "valid_respondent_rate" => nil,
-                 "batch_limit_per_minute" => nil
+                 "batch_limit_per_minute" => nil,
+                 "batch_size" => nil
                },
                %{
                  "id" => project2.id,
@@ -73,7 +74,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "response_rate" => nil,
                  "timezone" => nil,
                  "valid_respondent_rate" => nil,
-                 "batch_limit_per_minute" => nil
+                 "batch_limit_per_minute" => nil,
+                 "batch_size" => nil
                }
              ]
     end
@@ -100,7 +102,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "response_rate" => nil,
                  "timezone" => nil,
                  "valid_respondent_rate" => nil,
-                 "batch_limit_per_minute" => nil
+                 "batch_limit_per_minute" => nil,
+                 "batch_size" => nil
                }
              ]
     end
@@ -126,7 +129,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "response_rate" => nil,
                  "timezone" => nil,
                  "valid_respondent_rate" => nil,
-                 "batch_limit_per_minute" => nil
+                 "batch_limit_per_minute" => nil,
+                 "batch_size" => nil
                }
              ]
     end
@@ -152,7 +156,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "response_rate" => nil,
                  "timezone" => nil,
                  "valid_respondent_rate" => nil,
-                 "batch_limit_per_minute" => nil
+                 "batch_limit_per_minute" => nil,
+                 "batch_size" => nil
                },
                %{
                  "id" => active_project.id,
@@ -168,7 +173,8 @@ defmodule AskWeb.ProjectControllerTest do
                  "response_rate" => nil,
                  "timezone" => nil,
                  "valid_respondent_rate" => nil,
-                 "batch_limit_per_minute" => nil
+                 "batch_limit_per_minute" => nil,
+                 "batch_size" => nil
                }
              ]
     end
@@ -204,7 +210,8 @@ defmodule AskWeb.ProjectControllerTest do
         "response_rate" => nil,
         "timezone" => nil,
         "valid_respondent_rate" => nil,
-        "batch_limit_per_minute" => nil
+        "batch_limit_per_minute" => nil,
+        "batch_size" => nil
       }
 
       project_map_2 = %{
@@ -221,7 +228,8 @@ defmodule AskWeb.ProjectControllerTest do
         "response_rate" => nil,
         "timezone" => nil,
         "valid_respondent_rate" => nil,
-        "batch_limit_per_minute" => nil
+        "batch_limit_per_minute" => nil,
+        "batch_size" => nil
       }
 
       project_map_3 = %{
@@ -238,7 +246,8 @@ defmodule AskWeb.ProjectControllerTest do
         "response_rate" => nil,
         "timezone" => nil,
         "valid_respondent_rate" => nil,
-        "batch_limit_per_minute" => nil
+        "batch_limit_per_minute" => nil,
+        "batch_size" => nil
       }
 
       assert json_response(conn, 200)["data"] == [project_map_1, project_map_2, project_map_3]
@@ -264,7 +273,8 @@ defmodule AskWeb.ProjectControllerTest do
                "response_rate" => nil,
                "timezone" => nil,
                "valid_respondent_rate" => nil,
-               "batch_limit_per_minute" => nil
+               "batch_limit_per_minute" => nil,
+               "batch_size" => nil
              }
     end
 
@@ -286,7 +296,8 @@ defmodule AskWeb.ProjectControllerTest do
                "response_rate" => nil,
                "timezone" => nil,
                "valid_respondent_rate" => nil,
-               "batch_limit_per_minute" => nil
+               "batch_limit_per_minute" => nil,
+               "batch_size" => nil
              }
     end
 
@@ -328,7 +339,8 @@ defmodule AskWeb.ProjectControllerTest do
                "response_rate" => nil,
                "timezone" => nil,
                "valid_respondent_rate" => nil,
-               "batch_limit_per_minute" => nil
+               "batch_limit_per_minute" => nil,
+               "batch_size" => nil
              }
     end
   end
@@ -343,7 +355,6 @@ defmodule AskWeb.ProjectControllerTest do
       assert Repo.get_by(Project, @valid_attrs)
     end
 
-
     test "creates and renders resource when data is valid and have timezone", %{conn: conn} do
       conn = post conn, project_path(conn, :create), project: @valid_attrs_with_timezone
       response = json_response(conn, 201)
@@ -353,7 +364,6 @@ defmodule AskWeb.ProjectControllerTest do
       assert response["data"]["timezone"] == "Europe/London"
       assert Repo.get_by(Project, @valid_attrs_with_timezone)
     end
-    
   end
 
   describe "update" do


### PR DESCRIPTION
Closes #2229.

A new setting was added to project settings, `batch_size`. In the form, it was added in a "new line" and not in the same line as `batch_limit_per_minute`, not sure if this should be changed (cc @manumoreira).

![image](https://user-images.githubusercontent.com/13782680/229442829-624acf09-3b17-42f3-912b-a37c45bb4f98.png)

Functionally, `batch_size` is used in the `Broker` and, if `completed_respondents_needed_by(survey)` returns `:all` then the `default_batch_size` given by the environment was used, and this was modified to use the `batch_size` of the project if it is defined. Otherwise, the `batch_size` is computed based using other rates, and then this was not modified. 


