### PR TITLE
Fix/2233 unique project user pair

### DIFF
--- a/lib/ask/project_membership.ex
+++ b/lib/ask/project_membership.ex
@@ -106,7 +106,7 @@ defmodule Ask.ProjectMembership do
         })
 
       Repo.transaction(fn ->
-        Repo.insert_or_update(membership)
+        Repo.insert(membership)
         Repo.delete!(invite)
       end)
     end)

--- a/priv/repo/migrations/20230405111657_remove_project_memberships_duplicates.exs
+++ b/priv/repo/migrations/20230405111657_remove_project_memberships_duplicates.exs
@@ -1,0 +1,32 @@
+defmodule Ask.Repo.Migrations.RemoveProjectMembershipsDuplicates do
+  use Ecto.Migration
+
+  def up do
+    # Remove duplicates and keep max level in column level for each user and project in project_membnerships
+    execute("""
+      DELETE t1
+      FROM project_memberships t1
+      INNER JOIN (
+          SELECT user_id, project_id, MAX(
+              CASE level 
+                  WHEN 'owner' THEN 4 
+                  WHEN 'admin' THEN 3 
+                  WHEN 'editor' THEN 2 
+                  WHEN 'reader' THEN 1 
+                  ELSE 0 
+              END) AS max_level
+          FROM project_memberships
+          GROUP BY user_id, project_id
+      ) t2 
+      ON t1.user_id = t2.user_id 
+      AND t1.project_id = t2.project_id 
+      AND CASE t1.level 
+              WHEN 'owner' THEN 4 
+              WHEN 'admin' THEN 3 
+              WHEN 'editor' THEN 2 
+              WHEN 'reader' THEN 1 
+              ELSE 0 
+          END < t2.max_level;
+    """)
+  end
+end


### PR DESCRIPTION
Close #2233.

After studying `Invite` and `ProjectMembership` and trying many things, this is the one that worked better, no 100% sure this is the way to go though.
Because I'm using `get_change` and not `get_field` the validation function added will allow for updating the role of the users in the project with no problem. 
When inviting a user already in the project, the modal will close and no error will be displayed; the user will be listed in the collaborators' index already, then I took it as correct behavior. A more complex one would be to validate inputted email to be in the project on typing and inform that in the modal but I don't think it deserved to be done. 
