### PR TITLE
Migrate Poison to Jason

### DIFF
--- a/lib/ask/ecto_types/day_of_week.ex
+++ b/lib/ask/ecto_types/day_of_week.ex
@@ -1,6 +1,7 @@
 defmodule Ask.DayOfWeek do
   alias __MODULE__
 
+  @derive Jason.Encoder
   defstruct [:sun, :mon, :tue, :wed, :thu, :fri, :sat]
 
   def cast(%DayOfWeek{} = day_of_week) do

--- a/lib/ask/ecto_types/json.ex
+++ b/lib/ask/ecto_types/json.ex
@@ -2,6 +2,6 @@ defmodule Ask.Ecto.Type.JSON do
   use Ecto.Type
   def type, do: :longtext
   def cast(any), do: {:ok, any}
-  def load(string) when is_binary(string), do: Poison.decode(string)
-  def dump(json), do: Poison.encode(json)
+  def load(string) when is_binary(string), do: Jason.decode(string)
+  def dump(json), do: Jason.encode(json)
 end

--- a/lib/ask/ecto_types/schedule.ex
+++ b/lib/ask/ecto_types/schedule.ex
@@ -11,6 +11,7 @@ defmodule Ask.Schedule do
   alias __MODULE__
   alias Ask.{DayOfWeek, ScheduleError, SystemTime}
 
+  @derive Jason.Encoder
   defstruct [
     :day_of_week,
     :start_time,
@@ -96,7 +97,7 @@ defmodule Ask.Schedule do
 
   defp cast_blocked_days(_), do: []
 
-  def load(string) when is_binary(string), do: cast(Poison.decode!(string))
+  def load(string) when is_binary(string), do: cast(Jason.decode!(string))
   def load(nil), do: {:ok, always()}
   def load(_), do: :error
 
@@ -110,7 +111,7 @@ defmodule Ask.Schedule do
   def dump(%Schedule{day_of_week: day_of_week} = schedule) do
     {:ok, day_of_week} = DayOfWeek.dump(day_of_week)
     schedule = %{schedule | day_of_week: day_of_week, blocked_days: schedule.blocked_days || []}
-    Poison.encode(schedule)
+    Jason.encode(schedule)
   end
 
   def dump(_), do: :error

--- a/lib/ask/ecto_types/stats.ex
+++ b/lib/ask/ecto_types/stats.ex
@@ -2,6 +2,7 @@ defmodule Ask.Stats do
   use Ecto.Type
   alias __MODULE__
 
+  @derive Jason.Encoder
   defstruct total_received_sms: 0,
             total_sent_sms: 0,
             total_call_time: nil,
@@ -52,10 +53,10 @@ defmodule Ask.Stats do
   def cast(nil), do: {:ok, %Stats{}}
   def cast(_), do: :error
 
-  def load(string) when is_binary(string), do: cast(Poison.decode!(string))
+  def load(string) when is_binary(string), do: cast(Jason.decode!(string))
   def load(_), do: :error
 
-  def dump(%Stats{} = stats), do: Poison.encode(stats)
+  def dump(%Stats{} = stats), do: Jason.encode(stats)
   def dump(_), do: :error
 
   def total_received_sms(%Stats{total_received_sms: count}), do: count

--- a/lib/ask/ecto_types/steps.ex
+++ b/lib/ask/ecto_types/steps.ex
@@ -16,14 +16,14 @@ defmodule Ask.Ecto.Type.Steps do
   end
 
   def load(string) when is_binary(string) do
-    case Poison.decode(string) do
+    case Jason.decode(string) do
       {:ok, steps} -> {:ok, transform(steps)}
       any -> any
     end
   end
 
   def dump(json) do
-    Poison.encode(json)
+    Jason.encode(json)
   end
 
   defp transform(steps) when is_nil(steps), do: nil

--- a/lib/ask/floip_pusher.ex
+++ b/lib/ask/floip_pusher.ex
@@ -128,7 +128,7 @@ defmodule Ask.FloipPusher do
   end
 
   def create_package(survey, endpoint, responses_uri) do
-    {:ok, body} = FloipPackage.descriptor(survey, responses_uri) |> Poison.encode()
+    {:ok, body} = FloipPackage.descriptor(survey, responses_uri) |> Jason.encode()
 
     endpoint_uri = String.to_charlist("#{endpoint.uri}/flow-results/packages")
 
@@ -150,7 +150,7 @@ defmodule Ask.FloipPusher do
   end
 
   defp push_responses(endpoint, responses) do
-    {:ok, body} = Poison.encode(responses)
+    {:ok, body} = Jason.encode(responses)
 
     endpoint_uri =
       String.to_charlist(

--- a/lib/ask/json_schema.ex
+++ b/lib/ask/json_schema.ex
@@ -67,7 +67,7 @@ defmodule Ask.JsonSchema do
 
   defp load_schema(schema_path) do
     File.read!(schema_path)
-    |> Poison.decode!()
+    |> Jason.decode!()
     |> ExJsonSchema.Schema.resolve()
   end
 

--- a/lib/ask/metrics/respondent_stats_metrics.ex
+++ b/lib/ask/metrics/respondent_stats_metrics.ex
@@ -67,7 +67,7 @@ defmodule Ask.RespondentStatsMetrics do
   end
 
   defp parse_mode(key, value) when key == :mode and value != "" do
-    {key, Poison.decode!(value) |> Enum.join(",")}
+    {key, Jason.decode!(value) |> Enum.join(",")}
   end
 
   defp parse_mode(key, value), do: {key, value}

--- a/lib/ask/number_translator.ex
+++ b/lib/ask/number_translator.ex
@@ -4,7 +4,7 @@ defmodule Ask.NumberTranslator.Macros do
     |> Enum.map(fn filename ->
       filename = filename |> Path.basename(".json")
 
-      data = Poison.decode!(File.read!("#{__DIR__}/numbers/#{filename}.json"))
+      data = Jason.decode!(File.read!("#{__DIR__}/numbers/#{filename}.json"))
       data = {:%{}, [], data |> Enum.to_list()}
 
       quote do

--- a/lib/ask/runtime/questionnaire_action.ex
+++ b/lib/ask/runtime/questionnaire_action.ex
@@ -87,7 +87,7 @@ defmodule Ask.Runtime.QuestionnaireExport do
         manifest: manifest,
         audio_entries: audio_entries
       }) do
-    {:ok, json} = Poison.encode(manifest)
+    {:ok, json} = Jason.encode(manifest)
 
     json_entry =
       Stream.map([json], fn json ->

--- a/lib/ask/runtime/reply.ex
+++ b/lib/ask/runtime/reply.ex
@@ -54,6 +54,7 @@ defmodule Ask.Runtime.Reply do
 end
 
 defmodule Ask.Runtime.ReplyStep do
+  @derive Jason.Encoder
   defstruct prompts: [],
             id: nil,
             title: nil,

--- a/lib/ask/runtime/respondent_group_action.ex
+++ b/lib/ask/runtime/respondent_group_action.ex
@@ -142,11 +142,13 @@ defmodule Ask.Runtime.RespondentGroupAction do
       zip =
         canonical_numbers
         |> Enum.zip(phone_numbers)
-        |> List.foldl(%{}, fn ({k, v}, zip) -> Map.put(zip, k, v) end)
+        |> List.foldl(%{}, fn {k, v}, zip -> Map.put(zip, k, v) end)
 
       existing_numbers
-      |> List.foldl(zip, fn (n, zip) -> Map.delete(zip, n) end) # remove duplicates (using canonical number)
-      |> Map.values() # return the de-duplicated list of phone numbers
+      # remove duplicates (using canonical number)
+      |> List.foldl(zip, fn n, zip -> Map.delete(zip, n) end)
+      # return the de-duplicated list of phone numbers
+      |> Map.values()
     end
   end
 

--- a/lib/ask/url_shortener.ex
+++ b/lib/ask/url_shortener.ex
@@ -41,7 +41,7 @@ defmodule Ask.UrlShortener do
   end
 
   def build_short_url(host, response_body) do
-    "#{host}/#{Poison.decode!(response_body)["key"]}"
+    "#{host}/#{Jason.decode!(response_body)["key"]}"
   end
 
   defp get_api_key, do: ConfigHelper.get_config(__MODULE__, :url_shortener_api_key)

--- a/lib/ask_web/controllers/folder_controller.ex
+++ b/lib/ask_web/controllers/folder_controller.ex
@@ -51,7 +51,7 @@ defmodule AskWeb.FolderController do
       from(s in Survey,
         left_join: ps in PanelSurvey,
         on: s.panel_survey_id == ps.id,
-        where: (ps.folder_id == ^folder_id or s.folder_id == ^folder_id),
+        where: ps.folder_id == ^folder_id or s.folder_id == ^folder_id,
         where: s.state == ^:running,
         select: count(s.id)
       )

--- a/lib/ask_web/controllers/questionnaire_controller.ex
+++ b/lib/ask_web/controllers/questionnaire_controller.ex
@@ -345,7 +345,7 @@ defmodule AskWeb.QuestionnaireController do
       |> Enum.into(%{})
 
     json = files |> Map.get("manifest.json")
-    {:ok, manifest} = Poison.decode(json)
+    {:ok, manifest} = Jason.decode(json)
 
     audio_files = manifest |> Map.get("audio_files")
 

--- a/lib/ask_web/controllers/respondent_controller.ex
+++ b/lib/ask_web/controllers/respondent_controller.ex
@@ -611,7 +611,7 @@ defmodule AskWeb.RespondentController do
     |> Enum.map(fn {state, disposition, questionnaire_id, mode, count} ->
       reference_id =
         if mode && questionnaire_id do
-          "#{questionnaire_id}#{mode |> Poison.decode!() |> Enum.join("")}"
+          "#{questionnaire_id}#{mode |> Jason.decode!() |> Enum.join("")}"
         else
           nil
         end
@@ -652,7 +652,7 @@ defmodule AskWeb.RespondentController do
           {r.questionnaire_id, r.mode, r.date, fragment("CAST(? AS UNSIGNED)", sum(r.count))}
     )
     |> Enum.map(fn {questionnaire_id, mode, completed_at, count} ->
-      {"#{questionnaire_id}#{mode |> Poison.decode!() |> Enum.join("")}", completed_at, count}
+      {"#{questionnaire_id}#{mode |> Jason.decode!() |> Enum.join("")}", completed_at, count}
     end)
   end
 
@@ -665,7 +665,7 @@ defmodule AskWeb.RespondentController do
         select: {r.mode, r.date, fragment("CAST(? AS UNSIGNED)", sum(r.count))}
     )
     |> Enum.map(fn {mode, completed_at, count} ->
-      {mode |> Poison.decode!() |> Enum.join(""), completed_at, count}
+      {mode |> Jason.decode!() |> Enum.join(""), completed_at, count}
     end)
   end
 

--- a/lib/ask_web/endpoint.ex
+++ b/lib/ask_web/endpoint.ex
@@ -20,7 +20,7 @@ defmodule AskWeb.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Poison,
+    json_decoder: Jason,
     length: 1_073_741_824,
     read_timeout: 60_000
 

--- a/lib/ask_web/templates/mobile_survey/index.html.eex
+++ b/lib/ask_web/templates/mobile_survey/index.html.eex
@@ -1,5 +1,5 @@
 <body>
-  <div id="root" role="main" data-config="<%= Poison.encode!(%{introMessage: @mobile_web_intro_message, colorStyle: @color_style}) %>"></div>
+  <div id="root" role="main" data-config="<%= Jason.encode!(%{introMessage: @mobile_web_intro_message, colorStyle: @color_style}) %>"></div>
   <script>
     window.mixEnv = "<%= Mix.env %>"
     window.respondentId = <%= @respondent_id %>

--- a/lib/ask_web/templates/mobile_survey_simulation/index.html.eex
+++ b/lib/ask_web/templates/mobile_survey_simulation/index.html.eex
@@ -1,5 +1,5 @@
 <body>
-  <div id="root" role="main" data-config="<%= Poison.encode!(%{introMessage: @mobile_web_intro_message, colorStyle: @color_style}) %>"></div>
+  <div id="root" role="main" data-config="<%= Jason.encode!(%{introMessage: @mobile_web_intro_message, colorStyle: @color_style}) %>"></div>
   <script>
     window.mixEnv = "<%= Mix.env %>"
     window.respondentId = "<%= @respondent_id %>"

--- a/lib/ask_web/views/layout_view.ex
+++ b/lib/ask_web/views/layout_view.ex
@@ -40,7 +40,7 @@ defmodule AskWeb.LayoutView do
       intercom_app_id: Ask.Intercom.intercom_app_id()
     }
 
-    {:ok, config_json} = client_config |> Poison.encode()
+    {:ok, config_json} = client_config |> Jason.encode()
     config_json
   end
 

--- a/priv/repo/migrations/20161124171612_multilingual_questionnaires.exs
+++ b/priv/repo/migrations/20161124171612_multilingual_questionnaires.exs
@@ -24,9 +24,9 @@ defmodule Ask.Repo.Migrations.MultilingualQuestionnaires do
 
   def upgrade(steps) do
     steps
-    |> Poison.decode!()
+    |> Jason.decode!()
     |> Enum.map(&upgrade_step/1)
-    |> Poison.encode!()
+    |> Jason.encode!()
   end
 
   def upgrade_step(step) do

--- a/priv/repo/migrations/20161205182833_add_ranges_to_numeric_steps.exs
+++ b/priv/repo/migrations/20161205182833_add_ranges_to_numeric_steps.exs
@@ -24,9 +24,9 @@ defmodule Ask.Repo.Migrations.AddRangesToNumericSteps do
 
   def upgrade(steps) do
     steps
-    |> Poison.decode!()
+    |> Jason.decode!()
     |> Enum.map(&upgrade_step/1)
-    |> Poison.encode!()
+    |> Jason.encode!()
   end
 
   def upgrade_step(step) do

--- a/priv/repo/migrations/20161215165727_replace_empty_skip_logic_with_null.exs
+++ b/priv/repo/migrations/20161215165727_replace_empty_skip_logic_with_null.exs
@@ -24,9 +24,9 @@ defmodule Ask.Repo.Migrations.ReplaceEmptySkipLogicWithNull do
 
   def upgrade(steps) do
     steps
-    |> Poison.decode!()
+    |> Jason.decode!()
     |> Enum.map(&upgrade_step/1)
-    |> Poison.encode!()
+    |> Jason.encode!()
   end
 
   def upgrade_step(step) do

--- a/priv/repo/migrations/20161220202246_change_quiz_choice_responses_lang_mode_to_mode_lang.exs
+++ b/priv/repo/migrations/20161220202246_change_quiz_choice_responses_lang_mode_to_mode_lang.exs
@@ -32,9 +32,9 @@ defmodule Ask.Repo.Migrations.ChangeQuizChoiceResponsesLangModeToModeLang do
 
   def update(steps, update_function) do
     steps
-    |> Poison.decode!()
+    |> Jason.decode!()
     |> Enum.map(update_function)
-    |> Poison.encode!()
+    |> Jason.encode!()
   end
 
   def upgrade_step(step) do

--- a/priv/repo/migrations/20170213152812_delete_invalid_properties_from_steps.exs
+++ b/priv/repo/migrations/20170213152812_delete_invalid_properties_from_steps.exs
@@ -19,7 +19,7 @@ defmodule Ask.Repo.Migrations.DeleteInvalidPropertiesFromSteps do
   def up do
     json_schema =
       File.read!("#{Application.app_dir(:ask)}/priv/schema.json")
-      |> Poison.decode!()
+      |> Jason.decode!()
       |> Schema.resolve()
 
     Questionnaire

--- a/priv/repo/migrations/20171004213435_migrate_survey_schedule.exs
+++ b/priv/repo/migrations/20171004213435_migrate_survey_schedule.exs
@@ -208,14 +208,14 @@ defmodule Ask.Repo.Migrations.MigrateSurveySchedule do
     def cast(nil), do: {:ok, %Schedule{}}
     def cast(_), do: :error
 
-    def load(string) when is_binary(string), do: cast(Poison.decode!(string))
+    def load(string) when is_binary(string), do: cast(Jason.decode!(string))
     def load(nil), do: {:ok, %Schedule{}}
     def load(_), do: :error
 
     def dump(%Schedule{day_of_week: day_of_week} = schedule) do
       {:ok, day_of_week} = NewDayOfWeek.dump(day_of_week)
       schedule = %{schedule | day_of_week: day_of_week, blocked_days: schedule.blocked_days || []}
-      Poison.encode(schedule)
+      Jason.encode(schedule)
     end
 
     def dump(_), do: :error

--- a/priv/repo/migrations/20171118010654_rename_partial_disposition_to_interim_partial.exs
+++ b/priv/repo/migrations/20171118010654_rename_partial_disposition_to_interim_partial.exs
@@ -32,9 +32,9 @@ defmodule Ask.Repo.Migrations.RenamePartialDispositionToInterimPartial do
 
   def update(steps, update_function) do
     steps
-    |> Poison.decode!()
+    |> Jason.decode!()
     |> Enum.map(update_function)
-    |> Poison.encode!()
+    |> Jason.encode!()
   end
 
   def upgrade_step(step) do

--- a/test/ask/ecto_types/schedule_test.exs
+++ b/test/ask/ecto_types/schedule_test.exs
@@ -34,8 +34,10 @@ defmodule Ask.ScheduleTest do
 
   describe "dump:" do
     test "should dump weekdays" do
-      assert {:ok,
-              "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[]}"} ==
+      assert {
+               :ok,
+               "{\"blocked_days\":[],\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"end_date\":null,\"end_time\":\"18:00:00\",\"start_date\":null,\"start_time\":\"09:00:00\",\"timezone\":\"Etc/UTC\"}"
+             } ==
                Schedule.dump(%Schedule{
                  day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true},
                  start_time: ~T[09:00:00],
@@ -45,20 +47,26 @@ defmodule Ask.ScheduleTest do
     end
 
     test "should dump default" do
-      assert {:ok,
-              "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[],\"blocked_days\":[]}"} ==
+      assert {
+               :ok,
+               "{\"blocked_days\":[],\"day_of_week\":[],\"end_date\":null,\"end_time\":\"18:00:00\",\"start_date\":null,\"start_time\":\"09:00:00\",\"timezone\":\"Etc/UTC\"}"
+             } ==
                Schedule.dump(Schedule.default())
     end
 
     test "should dump always" do
-      assert {:ok,
-              "{\"timezone\":\"Etc/UTC\",\"start_time\":\"00:00:00\",\"start_date\":null,\"end_time\":\"23:59:59\",\"end_date\":null,\"day_of_week\":[\"sun\",\"mon\",\"tue\",\"wed\",\"thu\",\"fri\",\"sat\"],\"blocked_days\":[]}"} ==
+      assert {
+               :ok,
+               "{\"blocked_days\":[],\"day_of_week\":[\"sun\",\"mon\",\"tue\",\"wed\",\"thu\",\"fri\",\"sat\"],\"end_date\":null,\"end_time\":\"23:59:59\",\"start_date\":null,\"start_time\":\"00:00:00\",\"timezone\":\"Etc/UTC\"}"
+             } ==
                Schedule.dump(Schedule.always())
     end
 
     test "should dump blocked_days" do
-      assert {:ok,
-              "{\"timezone\":\"Etc/UTC\",\"start_time\":\"09:00:00\",\"start_date\":null,\"end_time\":\"18:00:00\",\"end_date\":null,\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"]}"} ==
+      assert {
+               :ok,
+               "{\"blocked_days\":[\"2016-01-01\",\"2017-02-03\"],\"day_of_week\":[\"mon\",\"tue\",\"wed\",\"thu\",\"fri\"],\"end_date\":null,\"end_time\":\"18:00:00\",\"start_date\":null,\"start_time\":\"09:00:00\",\"timezone\":\"Etc/UTC\"}"
+             } ==
                Schedule.dump(%Schedule{
                  day_of_week: %DayOfWeek{mon: true, tue: true, wed: true, thu: true, fri: true},
                  start_time: ~T[09:00:00],

--- a/test/ask/ecto_types/stats_test.exs
+++ b/test/ask/ecto_types/stats_test.exs
@@ -4,14 +4,18 @@ defmodule Ask.StatsTest do
 
   describe "dump:" do
     test "should dump empty" do
-      assert {:ok,
-              "{\"total_sent_sms\":0,\"total_received_sms\":0,\"total_call_time_seconds\":null,\"total_call_time\":null,\"pending_call\":false,\"call_durations\":{},\"attempts\":null}"} ==
+      assert {
+               :ok,
+               "{\"attempts\":null,\"call_durations\":{},\"pending_call\":false,\"total_call_time\":null,\"total_call_time_seconds\":null,\"total_received_sms\":0,\"total_sent_sms\":0}"
+             } ==
                Stats.dump(%Stats{})
     end
 
     test "should dump full" do
-      assert {:ok,
-              "{\"total_sent_sms\":3,\"total_received_sms\":2,\"total_call_time_seconds\":60,\"total_call_time\":1,\"pending_call\":true,\"call_durations\":{\"12345\":30},\"attempts\":{\"sms\":5,\"mobileweb\":7,\"ivr\":6}}"} ==
+      assert {
+               :ok,
+               "{\"attempts\":{\"ivr\":6,\"mobileweb\":7,\"sms\":5},\"call_durations\":{\"12345\":30},\"pending_call\":true,\"total_call_time\":1,\"total_call_time_seconds\":60,\"total_received_sms\":2,\"total_sent_sms\":3}"
+             } ==
                Stats.dump(%Stats{
                  total_received_sms: 2,
                  total_sent_sms: 3,

--- a/test/ask/floip_pusher_test.exs
+++ b/test/ask/floip_pusher_test.exs
@@ -203,7 +203,7 @@ defmodule Ask.FloipPusherTest do
     # Verify that the receiving mock gets the first 1000 responses
     Bypass.expect(server, fn conn ->
       {:ok, responses, _} = Plug.Conn.read_body(conn)
-      {:ok, responses} = Poison.decode(responses)
+      {:ok, responses} = Jason.decode(responses)
 
       assert length(responses["data"]["attributes"]["responses"]) == 1000
       Plug.Conn.resp(conn, 200, "")

--- a/test/ask/json_schema_test.exs
+++ b/test/ask/json_schema_test.exs
@@ -17,14 +17,14 @@ defmodule Ask.StepsValidatorTest do
 
   defp valid_thing(json_thing, thing_type) do
     json_thing
-    |> Poison.decode!()
+    |> Jason.decode!()
     |> JsonSchema.validate(thing_type)
     |> assert_ok
   end
 
   defp invalid_thing(json_thing, thing_type, case_desc) do
     json_thing
-    |> Poison.decode!()
+    |> Jason.decode!()
     |> JsonSchema.validate(thing_type)
     |> assert_invalid(case_desc, json_thing)
   end

--- a/test/ask/runtime/session_test.exs
+++ b/test/ask/runtime/session_test.exs
@@ -33,8 +33,8 @@ defmodule Ask.Runtime.SessionTest do
 
     session =
       %{session | schedule: nil}
-      |> Poison.encode!()
-      |> Poison.decode!()
+      |> Jason.encode!()
+      |> Jason.decode!()
       |> Session.load()
 
     assert session.schedule == Schedule.always()

--- a/test/ask_web/controllers/mobile_survey_controller_test.exs
+++ b/test/ask_web/controllers/mobile_survey_controller_test.exs
@@ -74,7 +74,7 @@ defmodule AskWeb.MobileSurveyControllerTest do
 
       assert String.contains?(
                response,
-               "<div id=\"root\" role=\"main\" data-config=\"{&quot;introMessage&quot;:&quot;My HTML escaped &amp; intro message&quot;,&quot;colorStyle&quot;:{&quot;secondary_color&quot;:&quot;#ae1&quot;,&quot;primary_color&quot;:&quot;#e21&quot;}}\"></div>\n"
+               "<div id=\"root\" role=\"main\" data-config=\"{&quot;colorStyle&quot;:{&quot;primary_color&quot;:&quot;#e21&quot;,&quot;secondary_color&quot;:&quot;#ae1&quot;},&quot;introMessage&quot;:&quot;My HTML escaped &amp; intro message&quot;}\"></div>\n"
              )
     end
   end

--- a/test/ask_web/views/layout_view_test.exs
+++ b/test/ask_web/views/layout_view_test.exs
@@ -10,7 +10,7 @@ defmodule AskWeb.LayoutViewTest do
     rendered_config =
       assign(build_conn(), :current_user, %{name: "John Doe", email: "john@doe.com", id: 3})
       |> AskWeb.LayoutView.config()
-      |> Poison.Parser.parse!()
+      |> Jason.decode!()
 
     assert rendered_config[json_root] != nil
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -50,6 +50,7 @@ defmodule Ask.Factory do
 
   def survey_factory do
     project = build(:project)
+
     %Ask.Survey{
       project: project,
       schedule: Ask.Schedule.always(project),


### PR DESCRIPTION
Close #2046.

Changed all references to `Poison` into references to `Jason`.

- For some structs, `@derive Jason.Encoder` has to be added since this needs to be explicit for Jason. 
- The hardcoded return values of some tests needs to be modified since now the keys of the JSON returned are sorted alphabetically.

**Just one replacement is missing:**

```
  #lib/ask/o_auth_token.ex:37
  def access_token(token) do
    Poison.Decode.decode(token.access_token, as: %OAuth2.AccessToken{})
  end
``` 

Don't know why but changing here `Poison.Decode.decode` to `Jason.decode` would break lots of tests, don't know if this has to do something with the external wiring of the project, or if this schema should have something similar to the `@derive` statement mentioned above.
Because of that, `Poison` was not removed from the mix file. `Jason` version (1.0) was kept in the mix file, while there are newer versions available.
