### PR TITLE
Fix/2133 simplify channel broker state persistence

### DIFF
--- a/lib/ask/config.ex
+++ b/lib/ask/config.ex
@@ -64,7 +64,8 @@ defmodule Ask.Config do
       # High values: the state of the process will be save less frequently. More contacts can be
       # lost in case of errors or unexpected resets. A too high value risks too many contacts
       # lost.
-      to_db_operations: env_to_int("CHNL_BKR_TO_DB_OPERATIONS", 100),
+      # To disable saving to DB, set this value to 0.
+      to_db_operations: env_to_int("CHNL_BKR_TO_DB_OPERATIONS", 0),
       # How many minutes the ChannelBroker garbage collector will wait between rounds. Default: 10
       # minutes.
       # Two situations brings the need of running the GC frequently:

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -398,16 +398,20 @@ defmodule Ask.Runtime.ChannelBroker do
       ) do
     Logger.debug("CHNL_BRK save_to_agent: #{inspect(binding())}")
 
-    new_op_count =
-      if op_count <= 1 do
-        # If counter reached, persist
-        ChannelBrokerAgent.save_channel_state(channel_id, state, true)
-        to_db_operations
-      else
-        # else, just save in memory
-        ChannelBrokerAgent.save_channel_state(channel_id, state, false)
-        op_count - 1
-      end
+    # Save to agent and persist to DB is disabled for now
+    # new_op_count =
+    #  if op_count <= 1 do
+    #    # If counter reached, persist
+    #    ChannelBrokerAgent.save_channel_state(channel_id, state, true)
+    #    to_db_operations
+    #  else
+    #    # else, just save in memory
+    #    ChannelBrokerAgent.save_channel_state(channel_id, state, false)
+    #    op_count - 1
+    #  end
+
+    # Only save in memory
+    ChannelBrokerAgent.save_channel_state(channel_id, state, false)
 
     state = Map.put(state, :op_count, new_op_count)
     Logger.debug("CHNL_BRK state: #{inspect(state)}")
@@ -884,7 +888,8 @@ defmodule Ask.Runtime.ChannelBroker do
   @impl true
   def handle_info(:timeout, %{channel_id: channel_id} = state) do
     Logger.debug("CHN_BRK timeout: #{inspect(binding())}")
-    ChannelBrokerAgent.save_channel_state(channel_id, state, true)
+    # Save the state to the agent but not in DB since is disabled for now
+    ChannelBrokerAgent.save_channel_state(channel_id, state, false)
     ChannelBrokerSupervisor.terminate_child(channel_id)
     Logger.debug("CHNL_BRK state: #{inspect(state)}")
   end


### PR DESCRIPTION
Close #2133.

Adding the option to disable `ChannelBroker` state persistence into DB by setting `to_db_operations` option to 0. Disabling it by default. 