### PR TITLE
Stop sending cookies in mobile web

### DIFF
--- a/lib/ask/respondent.ex
+++ b/lib/ask/respondent.ex
@@ -110,7 +110,6 @@ defmodule Ask.Respondent do
     # * ["mobileweb", "ivr"] -> Mobileweb as primary mode, IVR as fallback mode
     field :mode, JSON
     field :effective_modes, JSON
-    field :mobile_web_cookie_code, :string
     field :language, :string
     belongs_to :questionnaire, Questionnaire
     belongs_to :survey, Ask.Survey
@@ -144,7 +143,6 @@ defmodule Ask.Respondent do
       :questionnaire_id,
       :mode,
       :disposition,
-      :mobile_web_cookie_code,
       :language,
       :effective_modes,
       :stats,
@@ -234,10 +232,6 @@ defmodule Ask.Respondent do
       -12,
       12
     )
-  end
-
-  def mobile_web_cookie_name(respondent_id) do
-    "mobile_web_code_#{respondent_id}"
   end
 
   def completed_dispositions(count_partial_results \\ false)

--- a/lib/ask_web/controllers/mobile_survey_controller.ex
+++ b/lib/ask_web/controllers/mobile_survey_controller.ex
@@ -76,10 +76,7 @@ defmodule AskWeb.MobileSurveyController do
 
   def get_step(conn, %{"respondent_id" => respondent_id, "token" => token}) do
     authorize(conn, respondent_id, token, fn ->
-      # Cookies disabled for now, see #2241
-      # check_cookie(conn, respondent_id, fn conn ->
       sync_step(conn, respondent_id, :answer)
-      # end)
     end)
   end
 
@@ -90,10 +87,7 @@ defmodule AskWeb.MobileSurveyController do
         "step_id" => step_id
       }) do
     authorize(conn, respondent_id, token, fn ->
-      # Cookies disabled for now, see #2241
-      # check_cookie(conn, respondent_id, fn conn ->
       sync_step(conn, respondent_id, {:reply_with_step_id, value, step_id})
-      # end)
     end)
   end
 
@@ -178,34 +172,6 @@ defmodule AskWeb.MobileSurveyController do
       )
     end
   end
-
-  # defp check_cookie(conn, respondent_id, success_fn) do
-  #   respondent = Repo.get!(Respondent, respondent_id)
-  #   cookie_name = Respondent.mobile_web_cookie_name(respondent_id)
-  #   respondent_cookie = respondent.mobile_web_cookie_code
-
-  #   if respondent_cookie do
-  #     request_cookie = fetch_cookies(conn).req_cookies[cookie_name]
-
-  #     if request_cookie == respondent_cookie do
-  #       success_fn.(conn)
-  #     else
-  #       raise AskWeb.UnauthorizedError
-  #     end
-  #   else
-  #     cookie_value = Ecto.UUID.generate()
-
-  #     respondent
-  #     |> Respondent.changeset(%{mobile_web_cookie_code: cookie_value})
-  #     |> Repo.update!()
-
-  #     conn =
-  #       conn
-  #       |> put_resp_cookie(cookie_name, cookie_value)
-
-  #     success_fn.(conn)
-  #   end
-  # end
 
   def unauthorized_error(conn, %{"id" => respondent_id}) do
     color_style = color_style_for(respondent_id)

--- a/lib/ask_web/controllers/mobile_survey_controller.ex
+++ b/lib/ask_web/controllers/mobile_survey_controller.ex
@@ -76,9 +76,10 @@ defmodule AskWeb.MobileSurveyController do
 
   def get_step(conn, %{"respondent_id" => respondent_id, "token" => token}) do
     authorize(conn, respondent_id, token, fn ->
-      check_cookie(conn, respondent_id, fn conn ->
-        sync_step(conn, respondent_id, :answer)
-      end)
+      # Cookies disabled for now, see #2241
+      # check_cookie(conn, respondent_id, fn conn ->
+      sync_step(conn, respondent_id, :answer)
+      # end)
     end)
   end
 
@@ -89,9 +90,10 @@ defmodule AskWeb.MobileSurveyController do
         "step_id" => step_id
       }) do
     authorize(conn, respondent_id, token, fn ->
-      check_cookie(conn, respondent_id, fn conn ->
-        sync_step(conn, respondent_id, {:reply_with_step_id, value, step_id})
-      end)
+      # Cookies disabled for now, see #2241
+      # check_cookie(conn, respondent_id, fn conn ->
+      sync_step(conn, respondent_id, {:reply_with_step_id, value, step_id})
+      # end)
     end)
   end
 

--- a/lib/ask_web/controllers/mobile_survey_controller.ex
+++ b/lib/ask_web/controllers/mobile_survey_controller.ex
@@ -179,33 +179,33 @@ defmodule AskWeb.MobileSurveyController do
     end
   end
 
-  defp check_cookie(conn, respondent_id, success_fn) do
-    respondent = Repo.get!(Respondent, respondent_id)
-    cookie_name = Respondent.mobile_web_cookie_name(respondent_id)
-    respondent_cookie = respondent.mobile_web_cookie_code
+  # defp check_cookie(conn, respondent_id, success_fn) do
+  #   respondent = Repo.get!(Respondent, respondent_id)
+  #   cookie_name = Respondent.mobile_web_cookie_name(respondent_id)
+  #   respondent_cookie = respondent.mobile_web_cookie_code
 
-    if respondent_cookie do
-      request_cookie = fetch_cookies(conn).req_cookies[cookie_name]
+  #   if respondent_cookie do
+  #     request_cookie = fetch_cookies(conn).req_cookies[cookie_name]
 
-      if request_cookie == respondent_cookie do
-        success_fn.(conn)
-      else
-        raise AskWeb.UnauthorizedError
-      end
-    else
-      cookie_value = Ecto.UUID.generate()
+  #     if request_cookie == respondent_cookie do
+  #       success_fn.(conn)
+  #     else
+  #       raise AskWeb.UnauthorizedError
+  #     end
+  #   else
+  #     cookie_value = Ecto.UUID.generate()
 
-      respondent
-      |> Respondent.changeset(%{mobile_web_cookie_code: cookie_value})
-      |> Repo.update!()
+  #     respondent
+  #     |> Respondent.changeset(%{mobile_web_cookie_code: cookie_value})
+  #     |> Repo.update!()
 
-      conn =
-        conn
-        |> put_resp_cookie(cookie_name, cookie_value)
+  #     conn =
+  #       conn
+  #       |> put_resp_cookie(cookie_name, cookie_value)
 
-      success_fn.(conn)
-    end
-  end
+  #     success_fn.(conn)
+  #   end
+  # end
 
   def unauthorized_error(conn, %{"id" => respondent_id}) do
     color_style = color_style_for(respondent_id)

--- a/priv/repo/migrations/20230413101342_remove_mobile_web_cookie_code_from_respondents.exs
+++ b/priv/repo/migrations/20230413101342_remove_mobile_web_cookie_code_from_respondents.exs
@@ -1,0 +1,15 @@
+defmodule Ask.Repo.Migrations.RemoveMobileWebCookieCodeFromRespondents do
+  use Ecto.Migration
+
+  def up do
+    alter table(:respondents) do
+      remove :mobile_web_cookie_code
+    end
+  end
+
+  def down do
+    alter table(:respondents) do
+      add :mobile_web_cookie_code, :string
+    end
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -514,7 +514,6 @@ CREATE TABLE `respondents` (
   `hashed_number` varchar(255) DEFAULT NULL,
   `disposition` varchar(255) DEFAULT NULL,
   `lock_version` int(11) DEFAULT '1',
-  `mobile_web_cookie_code` varchar(255) DEFAULT NULL,
   `language` varchar(255) DEFAULT NULL,
   `effective_modes` varchar(255) DEFAULT NULL,
   `stats` longtext NOT NULL,
@@ -989,7 +988,7 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2023-04-03  7:13:11
+-- Dump completed on 2023-04-13  8:17:16
 INSERT INTO `schema_migrations` (version) VALUES (20160812145257);
 INSERT INTO `schema_migrations` (version) VALUES (20160816183915);
 INSERT INTO `schema_migrations` (version) VALUES (20160830200454);
@@ -1205,3 +1204,4 @@ INSERT INTO `schema_migrations` (version) VALUES (20220131103226);
 INSERT INTO `schema_migrations` (version) VALUES (20230217143550);
 INSERT INTO `schema_migrations` (version) VALUES (20230317094712);
 INSERT INTO `schema_migrations` (version) VALUES (20230402091100);
+INSERT INTO `schema_migrations` (version) VALUES (20230413101342);

--- a/test/ask_web/controllers/mobile_survey_controller_test.exs
+++ b/test/ask_web/controllers/mobile_survey_controller_test.exs
@@ -146,7 +146,7 @@ defmodule AskWeb.MobileSurveyControllerTest do
       get(conn, mobile_survey_path(conn, :get_step, respondent.id))
     end
 
-    original_conn = conn
+    # original_conn = conn
 
     conn = get(conn, mobile_survey_path(conn, :get_step, respondent.id, %{token: token}))
     json = json_response(conn, 200)

--- a/test/ask_web/controllers/mobile_survey_controller_test.exs
+++ b/test/ask_web/controllers/mobile_survey_controller_test.exs
@@ -114,7 +114,6 @@ defmodule AskWeb.MobileSurveyControllerTest do
     respondent = insert(:respondent, survey: survey, respondent_group: group)
     phone_number = respondent.sanitized_phone_number
     token = Respondent.token(respondent.id)
-    # cookie_name = Respondent.mobile_web_cookie_name(respondent.id)
 
     {:ok, broker} = Broker.start_link()
     Broker.poll()
@@ -146,19 +145,8 @@ defmodule AskWeb.MobileSurveyControllerTest do
       get(conn, mobile_survey_path(conn, :get_step, respondent.id))
     end
 
-    # original_conn = conn
-
     conn = get(conn, mobile_survey_path(conn, :get_step, respondent.id, %{token: token}))
     json = json_response(conn, 200)
-
-    # A cookie should have been generated
-    # %{value: mobile_web_code} = conn.resp_cookies[cookie_name]
-    # assert mobile_web_code
-
-    # Check again without a cookie
-    # assert_error_sent :forbidden, fn ->
-    #  get(original_conn, mobile_survey_path(conn, :get_step, respondent.id, %{token: token}))
-    # end
 
     assert %{
              "choices" => [],
@@ -188,18 +176,6 @@ defmodule AskWeb.MobileSurveyControllerTest do
         mobile_survey_path(conn, :send_reply, respondent.id, %{value: "", step_id: "s1"})
       )
     end
-
-    # Check without a cookie
-    # assert_error_sent :forbidden, fn ->
-    #  post(
-    #    original_conn,
-    #    mobile_survey_path(conn, :send_reply, respondent.id, %{
-    #      token: token,
-    #      value: "",
-    #      step_id: "s1"
-    #    })
-    #  )
-    # end
 
     conn =
       post(

--- a/test/ask_web/controllers/mobile_survey_controller_test.exs
+++ b/test/ask_web/controllers/mobile_survey_controller_test.exs
@@ -114,7 +114,7 @@ defmodule AskWeb.MobileSurveyControllerTest do
     respondent = insert(:respondent, survey: survey, respondent_group: group)
     phone_number = respondent.sanitized_phone_number
     token = Respondent.token(respondent.id)
-    cookie_name = Respondent.mobile_web_cookie_name(respondent.id)
+    # cookie_name = Respondent.mobile_web_cookie_name(respondent.id)
 
     {:ok, broker} = Broker.start_link()
     Broker.poll()
@@ -152,13 +152,13 @@ defmodule AskWeb.MobileSurveyControllerTest do
     json = json_response(conn, 200)
 
     # A cookie should have been generated
-    %{value: mobile_web_code} = conn.resp_cookies[cookie_name]
-    assert mobile_web_code
+    # %{value: mobile_web_code} = conn.resp_cookies[cookie_name]
+    # assert mobile_web_code
 
     # Check again without a cookie
-    assert_error_sent :forbidden, fn ->
-      get(original_conn, mobile_survey_path(conn, :get_step, respondent.id, %{token: token}))
-    end
+    # assert_error_sent :forbidden, fn ->
+    #  get(original_conn, mobile_survey_path(conn, :get_step, respondent.id, %{token: token}))
+    # end
 
     assert %{
              "choices" => [],
@@ -190,16 +190,16 @@ defmodule AskWeb.MobileSurveyControllerTest do
     end
 
     # Check without a cookie
-    assert_error_sent :forbidden, fn ->
-      post(
-        original_conn,
-        mobile_survey_path(conn, :send_reply, respondent.id, %{
-          token: token,
-          value: "",
-          step_id: "s1"
-        })
-      )
-    end
+    # assert_error_sent :forbidden, fn ->
+    #  post(
+    #    original_conn,
+    #    mobile_survey_path(conn, :send_reply, respondent.id, %{
+    #      token: token,
+    #      value: "",
+    #      step_id: "s1"
+    #    })
+    #  )
+    # end
 
     conn =
       post(


### PR DESCRIPTION
Closes #2241 

Removed the use of cookies for `MobileWeb` mode. 

Functionally, the function `check_cookie` in the `MobileSurveyController` was checking if the cookie was valid for the respondent session or creating it otherwise persisting it to DB. The function and its calls were removed, as well as the column in the database.

When entering to take a survey, there are no cookies used and the survey can be completed normally:

![image](https://user-images.githubusercontent.com/13782680/231710443-efcb09bd-8c56-4214-8754-f006f3794acb.png)

Tests were modified accordingly.

