### PR TITLE
Speed up generation of respondent CSV files

### DIFF
--- a/lib/ask/time_util.ex
+++ b/lib/ask/time_util.ex
@@ -1,16 +1,41 @@
 defmodule Ask.TimeUtil do
+  @months %{
+    1 => "Jan",
+    2 => "Feb",
+    3 => "Mar",
+    4 => "Apr",
+    5 => "May",
+    6 => "Jun",
+    7 => "Jul",
+    8 => "Aug",
+    9 => "Sep",
+    10 => "Oct",
+    11 => "Nov",
+    12 => "Dec",
+  }
+
   def format(ecto_timestamp, offset_seconds, offset_label) do
+    {{year, month, day}, {hour, min, sec}} = to_ymdhms(ecto_timestamp, offset_seconds)
+    "#{year}-#{pad2(month)}-#{pad2(day)} #{pad2(hour)}:#{pad2(min)}:#{pad2(sec)} #{offset_label}"
+  end
+
+  # Applies offset and formats datetime as `Timex.format!("%b %e, %Y %H:%M #{tz_offset}", :strftime)`.
+  # There are no reasons to not use Timex.format unless you need raw performance and make lots of
+  # repeating calls in a tight loop (eg. exporting a CSV) which is sole reason that method exists.
+  def format2(ecto_timestamp, offset_seconds, offset_label) do
+    {{year, month, day}, {hour, min, sec}} = to_ymdhms(ecto_timestamp, offset_seconds)
+    "#{Map.get(@months, month)} #{pad2(day, " ")}, #{year} #{pad2(hour)}:#{pad2(min)} #{offset_label}"
+  end
+
+  defp to_ymdhms(ecto_timestamp, offset_seconds) do
     timestamp_in_seconds =
       ecto_timestamp
       |> Timex.to_erl()
       |> :calendar.datetime_to_gregorian_seconds()
 
-    {{year, month, day}, {hour, min, sec}} =
-      (timestamp_in_seconds + offset_seconds)
-      |> :calendar.gregorian_seconds_to_datetime()
-
-    "#{year}-#{pad2(month)}-#{pad2(day)} #{pad2(hour)}:#{pad2(min)}:#{pad2(sec)} #{offset_label}"
+    (timestamp_in_seconds + offset_seconds)
+    |> :calendar.gregorian_seconds_to_datetime()
   end
 
-  defp pad2(s), do: Integer.to_string(s) |> String.pad_leading(2, "0")
+  defp pad2(s, char \\ "0"), do: Integer.to_string(s) |> String.pad_leading(2, char)
 end

--- a/lib/ask/time_util.ex
+++ b/lib/ask/time_util.ex
@@ -23,7 +23,7 @@ defmodule Ask.TimeUtil do
   # There are no reasons to not use Timex.format unless you need raw performance and make lots of
   # repeating calls in a tight loop (eg. exporting a CSV) which is sole reason that method exists.
   def format2(ecto_timestamp, offset_seconds, offset_label) do
-    {{year, month, day}, {hour, min, sec}} = to_ymdhms(ecto_timestamp, offset_seconds)
+    {{year, month, day}, {hour, min, _sec}} = to_ymdhms(ecto_timestamp, offset_seconds)
     "#{Map.get(@months, month)} #{pad2(day, " ")}, #{year} #{pad2(hour)}:#{pad2(min)} #{offset_label}"
   end
 

--- a/lib/ask_web/controllers/respondent_controller.ex
+++ b/lib/ask_web/controllers/respondent_controller.ex
@@ -925,19 +925,14 @@ defmodule AskWeb.RespondentController do
         row = row ++ [respondent_group]
 
         questionnaire_id = respondent.questionnaire_id
+        questionnaire = questionnaires |> Enum.find(fn q -> q.id == questionnaire_id end)
         mode = respondent.mode
 
         row =
           if has_comparisons do
             variant =
-              if questionnaire_id && mode do
-                questionnaire = questionnaires |> Enum.find(fn q -> q.id == questionnaire_id end)
-
-                if questionnaire do
-                  experiment_name(questionnaire, mode)
-                else
-                  "-"
-                end
+              if questionnaire && mode do
+                experiment_name(questionnaire, mode)
               else
                 "-"
               end
@@ -949,7 +944,10 @@ defmodule AskWeb.RespondentController do
 
         row =
           if partial_relevant_enabled do
-            row ++ [Respondent.partial_relevant_answered_count(respondent, false)]
+            respondent_with_questionnaire = %{respondent | questionnaire: questionnaire}
+
+            row ++
+              [Respondent.partial_relevant_answered_count(respondent_with_questionnaire, false)]
           else
             row
           end

--- a/lib/ask_web/controllers/respondent_controller.ex
+++ b/lib/ask_web/controllers/respondent_controller.ex
@@ -1129,7 +1129,7 @@ defmodule AskWeb.RespondentController do
     project = load_project_for_owner(conn, project_id)
     survey = load_survey(project, survey_id)
 
-    channels = survey_respondent_channel_names(survey)
+    channels = survey_log_entry_channel_names(survey)
 
     log_entries =
       Stream.resource(
@@ -1190,7 +1190,7 @@ defmodule AskWeb.RespondentController do
     conn |> csv_stream(rows, filename)
   end
 
-  defp survey_respondent_channel_names(survey) do
+  defp survey_log_entry_channel_names(survey) do
     from(c in Ask.Channel,
       select: {c.id, c.name},
       where:

--- a/lib/ask_web/controllers/respondent_controller.ex
+++ b/lib/ask_web/controllers/respondent_controller.ex
@@ -874,9 +874,7 @@ defmodule AskWeb.RespondentController do
       end)
       |> Enum.uniq()
 
-    # timezone = survey.schedule.timezone
     tz_offset_in_seconds = Survey.timezone_offset_in_seconds(survey)
-    tz_offset = Survey.timezone_offset(survey)
 
     # Now traverse each respondent and create a row for it
     csv_rows =
@@ -956,7 +954,7 @@ defmodule AskWeb.RespondentController do
             row
           end
 
-        # # We traverse all fields and see if there's a response for this respondent
+        # We traverse all fields and see if there's a response for this respondent
         row =
           all_fields
           |> Enum.reduce(row, fn field_name, acc ->


### PR DESCRIPTION
The main bottleneck was the manipulation of datetimes to shift to the survey scheduled timezone, as well as formatting those datetimes, or repeatedly accessing `survey.schedule.timezone` when we could cache the values for the whole HTTP request.

That may not be the only bottleneck or optimization possible, but that's a first step that actually allows the CSV files to be generated faster. I don't have enough data to have a significant benchmark for the results and incentives CSV, and the disposition history CSV was already optimized, but the interactions CSV is now magnitudes faster:

- `results.csv` (60% faster):
  - main: 5s at 168 KB/s
  - patch: 2s at 431 KB/s

- `disposition_history.csv` (no improvement):
  - main: 2s at 1084 KB/s
  - patch: 2s at 1023 KB/s

- `incentives.csv` (66% faster):
  - main: 3s at 155 KB/s
  - patch: 1s 486 KB/s

- `interactions.csv` (93% faster):
  - main: 31s at 261 KB/s
  - patch: 2s at 1023 KB/s

@matiasgarciaisaia As far as I understand, SQL queries are negligible, the bottleneck is the Elixir/Erlang code that manipulates the data to generate the CSV files. The impact is _very_ noticeable.

I tried to replace the ugly serialization of DateTime to String, to use more readable functions now available in Elixir 1.10 such as `DateTime.add/4` or the legacy `Timex.format!/3` but they had too much of an impact (at least 2 or 3 times as slower). Newer versions of Elixir have a datetime formatter, maybe it will be faster, and it has been optimized since...

closes #2205 