### PR TITLE
Feature/2240 pause surveys

### DIFF
--- a/assets/js/actions/survey.js
+++ b/assets/js/actions/survey.js
@@ -27,6 +27,8 @@ export const CHANGE_MODE_COMPARISON = "SURVEY_CHANGE_MODE_COMPARISON"
 export const CHANGE_QUESTIONNAIRE_COMPARISON = "SURVEY_CHANGE_QUESTIONNAIRE_COMPARISON"
 export const UPDATE_RESPONDENTS_COUNT = "SURVEY_UPDATE_RESPONDENTS_COUNT"
 export const SET_STATE = "SURVEY_SURVEY_SET_STATE"
+export const PAUSE = "SURVEY_PAUSE"
+export const RESUME = "SURVEY_RESUME"
 export const UPDATE_LOCK = "SURVEY_UPDATE_LOCK"
 export const FETCH = "FETCH_SURVEY"
 export const RECEIVE = "RECEIVE_SURVEY"
@@ -162,6 +164,10 @@ export const setState = (state: string) => ({
   type: SET_STATE,
   state,
 })
+
+export const pauseSurvey = () => ({ type: SET_STATE, state: "paused" })
+
+export const resumeSurvey = () => ({ type: SET_STATE, state: "running" })
 
 export const toggleLock = () => (dispatch: Function, getState: () => Store) => {
   const survey = getState().survey.data

--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -386,6 +386,14 @@ export const stopSurvey = (projectId, surveyId) => {
   return apiPostJSON(`projects/${projectId}/surveys/${surveyId}/stop`, surveySchema)
 }
 
+export const pauseSurvey = (projectId, surveyId) => {
+  return apiPostJSON(`projects/${projectId}/surveys/${surveyId}/pause`, surveySchema)
+}
+
+export const resumeSurvey = (projectId, surveyId) => {
+  return apiPostJSON(`projects/${projectId}/surveys/${surveyId}/resume`, surveySchema)
+}
+
 export const newWave = (projectId, panelSurveyId) => {
   return apiPostJSON(`projects/${projectId}/panel_surveys/${panelSurveyId}/new_wave`, surveySchema)
 }

--- a/assets/js/components/surveys/SurveyForm.jsx
+++ b/assets/js/components/surveys/SurveyForm.jsx
@@ -175,7 +175,8 @@ class SurveyForm extends Component {
     // However, for the respondents step we distinguish between "read only" and "survey started",
     // because a non-reader user can still add more respondents to an existing survey, though
     // she can, for example, change their channel.
-    const surveyStarted = survey.state == "running" || survey.state == "terminated"
+    const surveyStarted =
+      survey.state == "running" || survey.state == "paused" || survey.state == "terminated"
 
     const cutoffRulesStep = () => (
       <div>

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -76,7 +76,7 @@ class SurveyShow extends Component<any, State> {
   }
 
   componentWillMount() {
-    const { dispatch, projectId, surveyId, survey } = this.props
+    const { dispatch, projectId, surveyId } = this.props
     dispatch(actions.fetchSurveyIfNeeded(projectId, surveyId)).then((response) => {
       this.setState({ paused: response.state == "paused" })
     })
@@ -97,7 +97,7 @@ class SurveyShow extends Component<any, State> {
   }
 
   pauseOrResumeSurvey() {
-    const { dispatch, survey, projectId, surveyId, router } = this.props
+    const { dispatch, survey, projectId, surveyId } = this.props
     if (survey && survey.state == "running") {
       pauseSurvey(projectId, surveyId).then(() => {
         dispatch(actions.pauseSurvey())

--- a/assets/js/components/surveys/SurveyStatus.jsx
+++ b/assets/js/components/surveys/SurveyStatus.jsx
@@ -105,6 +105,7 @@ class SurveyStatus extends PureComponent {
         text = t("Ready to launch", { context: "survey" })
         break
 
+      case "paused":
       case "running":
         const endsOnMessage = this.endsOnMessage()
         scheduleClarificationMessage = `${this.startedOnMessage()}${
@@ -124,13 +125,15 @@ class SurveyStatus extends PureComponent {
               text = this.nextCallDescription(survey, date)
             }
           } else {
-            icon = "play_arrow"
+            icon = survey.state == "running" ? "play_arrow" : "pause"
             if (survey.firstWindowStartedAt) {
               text = short
                 ? this.startedOnMessage()
                 : // On the survey overview, the "started on" message is included in the
-                  // scheduleClarification message, above the main message.
-                  t("Running")
+                // scheduleClarification message, above the main message.
+                survey.state == "running"
+                ? t("Running")
+                : t("Paused")
             } else {
               // When the survey will start immediately (there will be no distance between
               // started_at and first_window_started_at) there is a little time window while

--- a/assets/js/components/surveys/SurveyWizardRespondentsStep.jsx
+++ b/assets/js/components/surveys/SurveyWizardRespondentsStep.jsx
@@ -154,8 +154,8 @@ class SurveyWizardRespondentsStep extends Component {
 
     const { survey, t } = this.props
 
-    // If the survey is running, the only option is to add more respondents
-    if (survey.state == "running") {
+    // If the survey is running or paused, the only option is to add more respondents
+    if (survey.state == "running" || survey.state == "paused") {
       this.addMoreRespondents(group.id, file)
       return
     }

--- a/assets/js/store/autosave.js
+++ b/assets/js/store/autosave.js
@@ -13,6 +13,13 @@ export default (storeProvider, actions) => (store) => (next) => (action) => {
   const result = next(action)
   const state = storeProvider(store.getState())
 
+  if (
+    action.type == "SURVEY_SURVEY_SET_STATE" &&
+    (action.state == "paused" || action.state == "running")
+  ) {
+    return result
+  }
+
   switch (action.type) {
     case actions.RECEIVE:
       store.dispatch(autoSaveStatusActions.receive(result.data))

--- a/lib/ask/activity_log.ex
+++ b/lib/ask/activity_log.ex
@@ -45,6 +45,8 @@ defmodule Ask.ActivityLog do
       "repeat",
       "request_cancel",
       "completed_cancel",
+      "pause",
+      "resume",
       "download",
       "enable_public_link",
       "regenerate_public_link",
@@ -293,6 +295,14 @@ defmodule Ask.ActivityLog do
 
   def repeat(project, conn, survey) do
     create("repeat", project, conn, survey, %{survey_name: survey.name})
+  end
+
+  def pause(project, conn, survey) do
+    create("pause", project, conn, survey, %{survey_name: survey.name})
+  end
+
+  def resume(project, conn, survey) do
+    create("resume", project, conn, survey, %{survey_name: survey.name})
   end
 
   def request_cancel(project, conn, survey) do

--- a/lib/ask/channel.ex
+++ b/lib/ask/channel.ex
@@ -50,7 +50,7 @@ defmodule Ask.Channel do
 
   # Deletes a channel and:
   # - marks related :ready surveys as :not_ready
-  # - marks related :running surveys as :terminated with exit code 3
+  # - marks related :running and :paused surveys as :terminated with exit code 3
   def delete(channel) do
     surveys =
       Repo.all(
@@ -69,7 +69,7 @@ defmodule Ask.Channel do
           |> Ask.Survey.changeset(%{state: :not_ready})
           |> Repo.update!()
 
-        :running ->
+        s when s == :running or s == :paused ->
           Ask.Survey.cancel_respondents(survey)
 
           survey

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -78,7 +78,7 @@ defmodule Ask.Runtime.SurveyAction do
         # UI open with the cancel button, and meanwhile the survey finished
         {:ok, %{survey: survey}}
 
-      [:running, false] ->
+      [s, l] when l == false and (s == :running or s == :paused) ->
         changeset =
           Survey.changeset(survey, %{
             state: "cancelling",

--- a/lib/ask_web/router.ex
+++ b/lib/ask_web/router.ex
@@ -101,6 +101,8 @@ defmodule AskWeb.Router do
           post "/set_description", SurveyController, :set_description
           post "/launch", SurveyController, :launch
           post "/stop", SurveyController, :stop
+          post "/pause", SurveyController, :pause
+          post "/resume", SurveyController, :resume
           post "/config", SurveyController, :config
 
           put "/update_locked_status", SurveyController, :update_locked_status,

--- a/test/ask/runtime/broker_test.exs
+++ b/test/ask/runtime/broker_test.exs
@@ -1151,6 +1151,19 @@ defmodule Ask.Runtime.BrokerTest do
       :ok = broker |> GenServer.stop()
       :ok = channel_status_server |> GenServer.stop()
     end
+
+    test "doesn't poll surveys which are paused" do
+      survey1 = insert(:survey, %{schedule: Schedule.always(), state: :running})
+
+      survey2 = insert(:survey, %{schedule: Schedule.always(), state: :paused})
+
+      Broker.handle_info(:poll, nil)
+
+      survey1 = Repo.get(Ask.Survey, survey1.id)
+      survey2 = Repo.get(Ask.Survey, survey2.id)
+      assert Ask.Survey.completed?(survey1)
+      assert survey2.state == :paused
+    end
   end
 
   describe "after 1 hour" do

--- a/test/ask_web/controllers/oauth_client_controller_test.exs
+++ b/test/ask_web/controllers/oauth_client_controller_test.exs
@@ -148,6 +148,38 @@ defmodule AskWeb.OAuthClientControllerTest do
     refute Ask.Channel |> Repo.get(channel.id)
   end
 
+  test "delete channels and marks related paused surveys as terminated", %{
+    conn: conn,
+    user: user
+  } do
+    insert(:oauth_token, user: user, provider: "provider", base_url: "http://test.com")
+    channel = insert(:channel, user: user, provider: "provider", base_url: "http://test.com")
+
+    survey = insert(:survey, state: :running)
+    respondent_group = insert(:respondent_group, survey: survey)
+
+    respondent =
+      insert(:respondent, respondent_group: respondent_group, survey: survey, state: "active")
+
+    insert(:respondent_group_channel,
+      respondent_group: respondent_group,
+      channel: channel,
+      mode: "sms"
+    )
+
+    delete(conn, o_auth_client_path(conn, :delete, "provider", base_url: "http://test.com"))
+
+    survey = Repo.get!(Ask.Survey, survey.id)
+    assert survey.state == :terminated
+    assert survey.exit_code == 3
+    assert survey.exit_message == "Channel '#{channel.name}' no longer exists"
+
+    respondent = Repo.get!(Ask.Respondent, respondent.id)
+    assert respondent.state == :cancelled
+
+    refute Ask.Channel |> Repo.get(channel.id)
+  end
+
   test "synchronize channels", %{conn: conn, user: user} do
     insert(:oauth_token, user: user, provider: "test")
     get(conn, o_auth_client_path(conn, :synchronize))


### PR DESCRIPTION
Close #2240 

ccing @manumoreira & @matiasgarciaisaia here to check functionality is as expected and to have your opinion about the design and redirect to Jony if needed.

Now the surveys can be paused. Functionally, that means that the `Broker` won't poll new respondents. Polled respondents will continue with their normal behavior as if the survey is running.

First, some screenshots: 

- Paused surveys are displayed as paused within the survey detail:
![image](https://user-images.githubusercontent.com/13782680/233404319-0952d886-3c79-4b49-bfcd-6781497f5df7.png)

- And in the survey cards:
![image](https://user-images.githubusercontent.com/13782680/233405474-62bdcf0d-1001-4f8b-9d4e-00c4666ad76d.png)

- Paused surveys won't be counted as running surveys in the project index:
![image](https://user-images.githubusercontent.com/13782680/233406450-7d5953b5-1344-4fec-a6eb-3fba7adcb532.png)

- The pause/play button was added next to the stop button (should it be green? Switch from green to orange depending on the state?), and will be shown and locked/unlocked with the same permission criteria:
![image](https://user-images.githubusercontent.com/13782680/233407112-ca7cbeaa-a07e-4de3-b612-1e4fba9afd17.png)
![image](https://user-images.githubusercontent.com/13782680/233407005-a2a0bdb0-5a65-4def-8313-08ff47dec33f.png)
![image](https://user-images.githubusercontent.com/13782680/233407238-7ece5255-e3fb-45fb-8f3b-48786a905524.png)

I've tested the following:
- Pausing won't poll new respondents.
- Resuming works properly (with the simulators) 
- Resuming the day after works properly (with the simulators)
- Respondents completing paused surveys will follow its flow as if the survey is running.

**Important notes:**
- For the `ChannelStatusServer`, paused surveys are considered as part of the `Survey.running_channels()` set, the only thing we are preventing is polling new respondents, but things are still happening with the channels so paused surveys should have live channels to interact with. I've tested it and completed surveys ongoing for some respondents without any problem.
- **There is something that needs to be fixed**, please see the `autosave.js` modification that I had to introduce to get an idea: when I'm pausing or resuming a survey, it remains in `saving` state, product of the autosave, unless I do this trick. This is due to some wiring that I'm doing wrongly in the React code, but I couldn't devise what the problem is. I need your input here to help me understand what I'm doing differently with respect for example to `stop()` or `lock()` methods. The `pause` and `resume` functions in the `SurveyController` can be written better but I've left this verbose/redundant version to have the step-by-step very readable because they will need modifications to solve this issue. 
- I have scanned test files and have modified and introduced several tests. I think this covers the new functionality but please let me know if there is something you think I'm missing. 
