### PR TITLE
Rework GC of ChannelBroker

### DIFF
--- a/lib/ask/config.ex
+++ b/lib/ask/config.ex
@@ -66,6 +66,7 @@ defmodule Ask.Config do
       # lost.
       # To disable saving to DB, set this value to 0.
       to_db_operations: env_to_int("CHNL_BKR_TO_DB_OPERATIONS", 0),
+
       # How many minutes the ChannelBroker garbage collector will wait between rounds. Default: 10
       # minutes.
       # Two situations brings the need of running the GC frequently:
@@ -76,7 +77,8 @@ defmodule Ask.Config do
       # High values: the GC will run less frequently. A too high value could lead to unnecessary
       # stops of the survey by reaching the channel capacity because of failed contacts or
       # callback losses.
-      gc_interval_minutes: env_to_int("CHNL_BKR_GC_INTERVAL_MINUTES", 10),
+      gc_interval_minutes: env_to_int("CHNL_BKR_GC_INTERVAL_MINUTES", 2),
+
       # How many hours after the last contact the ChannelBroker waits until a contact is discarded
       # because it's considered outdated. Default: 24 h.
       # Low values: the GC will discard younger contacts. A too low value could lead to discard
@@ -85,7 +87,11 @@ defmodule Ask.Config do
       # High values: the GC will discard older contacts. A too high value could lead to keep
       # contacts that actually finished, wasting the channel capacity and slowing-down the
       # contact rate.
-      gc_outdate_hours: env_to_int("CHNL_BKR_GC_OUTDATE_HOURS", 24)
+      # gc_outdate_hours: env_to_int("CHNL_BKR_GC_OUTDATE_HOURS", 24),
+
+      # How long after a call/message has been left idle (no callbacks received)
+      # before the GC starts polling the remote channel for its actual state.
+      gc_active_idle_minutes: env_to_int("CHNL_BKR_GC_IDLE_MINUTES", 2)
     }
   end
 

--- a/lib/ask/runtime/channel.ex
+++ b/lib/ask/runtime/channel.ex
@@ -22,6 +22,10 @@ defprotocol Ask.Runtime.Channel do
   @spec ask(t(), Ask.Respondent.t(), any(), any(), integer()) :: any()
   def ask(channel, respondent, token, prompts, channel_id)
 
+  # Returns how many contacts will be queued on the remote channel.
+  @spec messages_count(t(), Ask.Respondent.t(), any(), [Ask.Runtime.Reply.t()], integer()) :: integer()
+  def messages_count(channel, respondent, to, reply, channel_id)
+
   # Verify if a message has already been queued. `channel_state` will contain
   @spec has_queued_message?(t(), map()) :: boolean
   def has_queued_message?(channel, channel_state)
@@ -42,7 +46,7 @@ defprotocol Ask.Runtime.Channel do
   # Returns the status of the channel.
   #
   # `:up | {:down, messages} | {:error, messages}`
-  @spec check_status(t()) :: :up | {:down, []}, {:error, []}
+  @spec(check_status(t()) :: :up | {:down, []}, {:error, []})
   def check_status(channel)
 end
 

--- a/lib/ask/runtime/channel.ex
+++ b/lib/ask/runtime/channel.ex
@@ -1,13 +1,48 @@
 defprotocol Ask.Runtime.Channel do
-  def prepare(channel)
-  def setup(channel, respondent, token, not_before, not_after)
+  # TODO: finish reverse-engineering the typespec definitions
+
+  @type t :: map()
+
+  # Returns whether the channel sends delivery confirmations callbacks or not.
+  @spec has_delivery_confirmation?(t()) :: boolean
   def has_delivery_confirmation?(channel)
+
+  # Configure the channel to start communicating with Surveda. For example setup
+  # the callback URL on the remote service.
+  @spec prepare(t()) :: any()
+  def prepare(channel)
+
+  # Queue a long running session. The survey will be responded when the remote
+  # channel callbacks into Surveda.
+  @spec setup(t(), Ask.Respondent.t(), any(), any(), any()) :: any()
+  def setup(channel, respondent, token, not_before, not_after)
+
+  # Queue one message or set of messages to be sent. The Survey shall be run one
+  # reply at a time.
+  @spec ask(t(), Ask.Respondent.t(), any(), any(), integer()) :: any()
   def ask(channel, respondent, token, prompts, channel_id)
+
+  # Verify if a message has already been queued. `channel_state` will contain
+  @spec has_queued_message?(t(), map()) :: boolean
   def has_queued_message?(channel, channel_state)
+
+  # Verify if the given message is still in an active state (e.g. queued or
+  # activate) or inactive (e.g. completed, failed).
+  @spec message_inactive?(t(), map()) :: boolean
   def message_inactive?(channel, channel_state)
+
+  # Cancel a previously sent message.
+  @spec cancel_message(t(), map()) :: boolean
   def cancel_message(channel, channel_state)
+
+  # Verify if a previously queued message has expired.
+  @spec message_expired?(t(), map()) :: boolean
   def message_expired?(channel, channel_state)
-  # :up | {:down, messages} | {:error, messages}
+
+  # Returns the status of the channel.
+  #
+  # `:up | {:down, messages} | {:error, messages}`
+  @spec check_status(t()) :: :up | {:down, []}, {:error, []}
   def check_status(channel)
 end
 

--- a/lib/ask/runtime/channel.ex
+++ b/lib/ask/runtime/channel.ex
@@ -4,6 +4,7 @@ defprotocol Ask.Runtime.Channel do
   def has_delivery_confirmation?(channel)
   def ask(channel, respondent, token, prompts, channel_id)
   def has_queued_message?(channel, channel_state)
+  def message_inactive?(channel, channel_state)
   def cancel_message(channel, channel_state)
   def message_expired?(channel, channel_state)
   # :up | {:down, messages} | {:error, messages}

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -1,11 +1,12 @@
 defmodule Ask.Runtime.ChannelBroker do
-  alias Ask.Runtime.{Channel, ChannelBrokerAgent, ChannelBrokerSupervisor, NuntiumChannel}
-  alias Ask.{Config, Logger}
+  alias Ask.Runtime.{ChannelBrokerAgent, ChannelBrokerSupervisor, NuntiumChannel}
+  alias Ask.Runtime.ChannelBrokerState, as: State
+  alias Ask.{Channel, Logger}
   import Ecto.Query
   alias Ask.Repo
   use GenServer
 
-  # Channels without channel_id (used in some unit tests) share a single process (channel_id: 0)
+  # Public interface
 
   def start_link(channel_id, channel_type, settings) do
     name = via_tuple(channel_id)
@@ -58,26 +59,18 @@ defmodule Ask.Runtime.ChannelBroker do
   end
 
   def on_channel_settings_change(channel_id, settings) do
-    call_gen_server(
-      channel_id,
-      {:on_channel_settings_change, settings}
-    )
+    call_gen_server(channel_id, {:on_channel_settings_change, settings})
   end
 
   def callback_received(channel_id, respondent, respondent_state, provider) do
-    call_gen_server(
-      channel_id,
-      {:callback_received, respondent, respondent_state, provider}
-    )
+    call_gen_server(channel_id, {:callback_received, respondent, respondent_state, provider})
   end
 
   def force_activate_respondent(channel_id, respondent_id) do
-    call_gen_server(
-      channel_id,
-      {:force_activate_respondent, respondent_id}
-    )
+    call_gen_server(channel_id, {:force_activate_respondent, respondent_id})
   end
 
+  # NOTE: channels without channel_id (used in some unit tests) share a single process (channel_id: 0)
   defp call_gen_server(nil, message) do
     if Mix.env() == :test do
       call_gen_server(0, message)
@@ -87,8 +80,8 @@ defmodule Ask.Runtime.ChannelBroker do
   end
 
   defp call_gen_server(channel_id, message) when is_integer(channel_id) do
-    pid = find_or_start_process(channel_id)
-    GenServer.call(pid, message)
+    find_or_start_process(channel_id)
+    |> GenServer.call(message)
   end
 
   defp call_gen_server(channel_id, message) do
@@ -108,11 +101,16 @@ defmodule Ask.Runtime.ChannelBroker do
     end
   end
 
+  # NOTE: what about IVR?
   defp set_channel(0), do: {"sms", %{}}
 
   defp set_channel(channel_id) do
-    query = from c in "channels", where: c.id == ^channel_id, select: [c.type, c.settings]
-    [channel_type, settings] = Repo.one!(query)
+    [channel_type, settings] =
+      from(c in "channels",
+        where: c.id == ^channel_id,
+        select: [c.type, c.settings]
+      )
+      |> Repo.one!()
 
     settings =
       if settings do
@@ -124,548 +122,111 @@ defmodule Ask.Runtime.ChannelBroker do
     {channel_type, settings}
   end
 
-  defp activate_contacts(%{channel_id: channel_id} = state, channel_type) do
-
-    if can_unqueue(state) do
-      {new_state, unqueued_item} = activate_contact(state)
-
-      new_state =
-        case channel_type do
-          "sms" ->
-            {unq_respondent, unq_token, unq_reply, unq_channel} = unqueued_item
-            channel_ask(unq_channel, unq_respondent, unq_token, unq_reply, channel_id)
-            state
-
-          "ivr" ->
-            {unq_respondent, unq_token, unq_not_before, unq_not_after, unq_channel} = unqueued_item
-            ivr_call(new_state, unq_channel, unq_respondent, unq_token, unq_not_before, unq_not_after)
-
-          _ ->
-            raise ArgumentError, message: "Unknown channel type: #{channel_type}."
-        end
-
-      if can_unqueue(new_state) do
-        activate_contacts(new_state, channel_type)
-      else
-        new_state
-      end
-    else
-      state
-    end
-  end
-
-  defp ivr_call(state, channel, respondent, token, not_before, not_after) do
-    case channel_setup(channel, respondent, token, not_before, not_after) do
-      {:ok, verboice_call_id} ->
-        set_verboice_call_id(state, respondent.id, verboice_call_id)
-
-      _ ->
-        state
-    end
-  end
-
-  defp schedule_GC(channel_type, interval) do
-    Logger.debug("CHNL_BRK schedule_GC: #{inspect(binding())}")
-    Process.send_after(self(), {:collect_garbage, channel_type}, interval)
-  end
-
-  defp timeout_from_config(%{shut_down_minutes: timeout_minutes} = _config) do
-    timeout_minutes * 60_000
-  end
-
-  defp gc_interval_from_config(%{gc_interval_minutes: gc_interval_minutes} = _config) do
-    gc_interval_minutes * 60_000
-  end
-
-  # Server (callbacks)
+  # Server (internal callbacks for public interface)
 
   @impl true
   def init([channel_id, channel_type, settings]) do
-    Logger.debug("CHNL_BRK init: #{inspect(binding())}")
-
-    %{to_db_operations: op_count} = config = Config.channel_broker_config()
-    gc_interval = gc_interval_from_config(config)
-    schedule_GC(channel_type, gc_interval)
-
-    state = {
-      :ok,
-      # The internal logic of the ChannelBroker relies on a state with the following shape:
-      %{
-        # Each ChannelBroker process manage the load of a single channel.
-        channel_id: channel_id,
-        # The maximum parallel contacts this channel shouldn't exceded.
-        capacity: Map.get(settings, "capacity", Config.default_channel_capacity()),
-        # A dictionary of active contacts with the following shape:
-        #   %{respondent_id: active_contact}
-        #     active_contact is a Map with the following keys:
-        #      - contacts: quantity of contactas being currently managed by the channel
-        #      - last_contact: timestamp of the last contact made
-        #      - verboice_call_id: an external id provided by Verboice to allow following up the
-        #         requested call.
-        active_contacts: Map.new(),
-        # A priority queue implemented using pqueue (https://github.com/okeuday/pqueue/).
-        #   When a contact is queued, the received params are stored to be used when the time
-        #     to make the contact comes.
-        #   Each element has one of the following shape:
-        #    - Verboice: {respondent, token, not_before, not_after, channel}
-        #    - Nuntium: {respondent, token, reply, channel}
-        contacts_queue: :pqueue.new(),
-        # See Config.channel_broker_config() comments
-        config: config,
-        # Counter of how many internal operations left until this state will be saved to the DB
-        op_count: op_count
-      },
-      timeout_from_config(config)
-    }
-
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    state
+    info("init (new)", channel_id: channel_id, channel_type: channel_type, settings: settings)
+    state = State.new(channel_id, settings)
+    schedule_GC(channel_type, state)
+    {:ok, state, State.process_timeout(state)}
   end
 
   @impl true
-  def init([_channel_id, channel_type, _settings, %{config: config} = status]) do
-    gc_interval = gc_interval_from_config(config)
-    schedule_GC(channel_type, gc_interval)
-
-    {
-      :ok,
-      status,
-      timeout_from_config(config)
-    }
-  end
-
-  def active_contacts(
-        %{
-          active_contacts: active_contacts
-        } = _state
-      ) do
-    Enum.reduce(active_contacts, 0, fn {_r, %{contacts: contacts}}, acc -> contacts + acc end)
-  end
-
-  def can_unqueue(
-        %{
-          capacity: capacity,
-          contacts_queue: contacts_queue
-        } = state
-      ) do
-    cond do
-      :pqueue.is_empty(contacts_queue) -> false
-      active_contacts(state) >= capacity -> false
-      true -> true
-    end
-  end
-
-  defp is_queued(%{contacts_queue: contacts_queue}, respondent_id) do
-    :pqueue.to_list(contacts_queue)
-    |> Enum.any?(fn [_, queued_item] -> queued_respondent_id(queued_item) == respondent_id end)
-  end
-
-  defp is_active(%{active_contacts: active_contacts}, respondent_id) do
-    Map.has_key?(active_contacts, respondent_id)
-  end
-
-  defp channel_setup(channel, respondent, token, not_before, not_after) do
-    try do
-      Ask.Runtime.Channel.setup(channel, respondent, token, not_before, not_after)
-    rescue
-      _ ->
-        Ask.Runtime.Channel.setup(
-          Ask.Channel.runtime_channel(channel),
-          respondent,
-          token,
-          not_before,
-          not_after
-        )
-    end
-  end
-
-  defp channel_ask(%Ask.Channel{} = channel, respondent, token, reply, channel_id) do
-    channel_ask(Ask.Channel.runtime_channel(channel), respondent, token, reply, channel_id)
-  end
-
-  defp channel_ask(runtime_channel, %{id: respondent_id} = respondent, token, reply, channel_id) do
-    %{id: ^respondent_id} =
-      Ask.Runtime.Channel.ask(runtime_channel, respondent, token, reply, channel_id)
-  end
-
-  defp queued_respondent_id(queued_item) do
-    # No matter the contact type, the first element of the
-    # unqueued item is the respondent
-    elem(queued_item, 0).id
-  end
-
-  # Respondents that failed could have active contacts waiting and don't exist
-  # anymore. Keep only the contacts for active respondents.
-  #
-  # FIXME: understand why the channel broker wasn't properly notified.
-  defp clean_inactive_respondents(%{active_contacts: active_contacts} = state) do
-    Logger.info("ChannelBroker.clean_inactive_respondents:")
-
-    query =
-      from r in "respondents",
-        where: r.id in ^Map.keys(active_contacts) and r.state == "active",
-        select: r.id
-    active_respondents = Repo.all(query)
-
-    # TODO: Elixir 1.13 has Map.filter/2
-    new_active_contacts =
-      :maps.filter(fn respondent_id, _ -> respondent_id in active_respondents end, active_contacts)
-
-    state
-    |> Map.put(:active_contacts, new_active_contacts)
-    |> save_to_agent()
-  end
-
-  # For leftover active contacts, we ask the remote channel for the IVR OR SMS
-  # SMS state. Keep only the contacts that are active or queued.
-  defp clean_outdated_respondents(%{active_contacts: active_contacts, config: config} = state, channel_type) do
-    Logger.info("ChannelBroker.clean_outdated_respondents:")
-
-    idle_time = config.gc_active_idle_minutes * 60
-    now = Ask.SystemTime.time().now
-
-    channel =
-      Ask.Channel
-      |> Repo.get(state.channel_id)
-      |> Ask.Channel.runtime_channel()
-
-    # TODO: Elixir 1.13 has Map.filter/2
-    new_active_contacts =
-      :maps.filter(
-        fn _, %{last_contact: last_contact} = active_contact ->
-          DateTime.diff(now, last_contact, :second) < idle_time ||
-            !Channel.message_inactive?(channel, get_channel_state(channel_type, active_contact))
-        end,
-        active_contacts
-      )
-
-    state
-    |> Map.put(:active_contacts, new_active_contacts)
-    |> save_to_agent()
-  end
-
-  def save_to_agent(
-        %{
-          channel_id: channel_id,
-          op_count: op_count,
-          config: %{to_db_operations: to_db_operations}
-        } = state
-      ) do
-    Logger.debug("CHNL_BRK save_to_agent: #{inspect(binding())}")
-
-    # Save to agent and persist to DB is disabled for now
-    new_op_count =
-      if op_count <= 1 and to_db_operations > 0 do
-        # If counter reached, persist
-        ChannelBrokerAgent.save_channel_state(channel_id, state, true)
-        to_db_operations
-      else
-        # else, just save in memory
-        ChannelBrokerAgent.save_channel_state(channel_id, state, false)
-        op_count - 1
-      end
-
-    state = Map.put(state, :op_count, new_op_count)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    state
-  end
-
-  def queue_contact(
-        %{
-          contacts_queue: contacts_queue
-        } = state,
-        contact,
-        size
-      ) do
-    Logger.debug("CHNL_BRK queue_contact: #{inspect(binding())}")
-    priority = if elem(contact, 0).disposition == :queued, do: 2, else: 1
-    new_contacts_queue = :pqueue.in([size, contact], priority, contacts_queue)
-
-    state =
-      Map.put(state, :contacts_queue, new_contacts_queue)
-      |> save_to_agent()
-
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    state
-  end
-
-  def activate_contact(
-        %{
-          contacts_queue: contacts_queue,
-          active_contacts: active_contacts
-        } = state
-      ) do
-    Logger.debug("CHNL_BRK activate_contact: #{inspect(binding())}")
-    {{_unqueue_res, [size, unqueued_item]}, new_contacts_queue} = :pqueue.out(contacts_queue)
-    state = Map.put(state, :contacts_queue, new_contacts_queue)
-
-    respondent_id = queued_respondent_id(unqueued_item)
-
-    respondent_contacts =
-      case Map.get(active_contacts, respondent_id) do
-        %{contacts: contacts} -> contacts
-        _ -> 0
-      end
-
-    active_contact = %{
-      contacts: respondent_contacts + size,
-      last_contact: Ask.SystemTime.time().now
-    }
-    new_active_contacts = Map.put(active_contacts, respondent_id, active_contact)
-
-    state =
-      Map.put(state, :active_contacts, new_active_contacts)
-      |> save_to_agent()
-
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    {state, unqueued_item}
-  end
-
-  def update_last_contact(
-        %{
-          active_contacts: active_contacts
-        } = state,
-        respondent_id
-      ) do
-    Logger.debug("CHNL_BRK update_last_contact: #{inspect(binding())}")
-
-    new_active_contacts =
-      if Map.has_key?(active_contacts, respondent_id) do
-        active_contact =
-          active_contacts
-          |> Map.get(respondent_id)
-          |> Map.put(:last_contact, Ask.SystemTime.time().now)
-
-        Map.put(active_contacts, respondent_id, active_contact)
-      else
-        active_contacts
-      end
-
-    state = Map.put(state, :active_contacts, new_active_contacts)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    state
-  end
-
-  defp set_verboice_call_id(state, respondent_id, %{verboice_call_id: verboice_call_id}) do
-    set_verboice_call_id(state, respondent_id, verboice_call_id)
-  end
-
-  defp set_verboice_call_id(%{active_contacts: active_contacts} = state, respondent_id, verboice_call_id) do
-
-    new_active_contacts =
-      if Map.has_key?(active_contacts, respondent_id) do
-        active_contact =
-          active_contacts
-          |> Map.get(respondent_id)
-          |> Map.put(:verboice_call_id, verboice_call_id)
-        Map.put(active_contacts, respondent_id, active_contact)
-      else
-        active_contacts
-      end
-
-    state = Map.put(state, :active_contacts, new_active_contacts)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    state
-  end
-
-  defp get_verboice_call_id(
-         %{
-           active_contacts: active_contacts
-         } = _state,
-         respondent_id
-       ) do
-    if Map.has_key?(active_contacts, respondent_id) do
-      active_contact = Map.get(active_contacts, respondent_id)
-      Map.get(active_contact, :verboice_call_id)
-    else
-      nil
-    end
-  end
-
-  defp get_verboice_call_id(active_contact) do
-    Map.get(active_contact, :verboice_call_id)
-  end
-
-  defp deactivate_contact(
-         %{
-           active_contacts: active_contacts
-         } = state,
-         respondent_id
-       ) do
-    Logger.debug("CHNL_BRK deactivate_contact: #{inspect(binding())}")
-
-    respondent_contacts =
-      if Map.has_key?(active_contacts, respondent_id) do
-        %{contacts: contacts} = Map.get(active_contacts, respondent_id)
-        contacts
-      else
-        0
-      end
-
-    new_active_contacts =
-      if respondent_contacts > 1 do
-        active_contact =
-          Map.get(active_contacts, respondent_id)
-          |> Map.put(:contacts, respondent_contacts - 1)
-          |> Map.put(:last_contact, Ask.SystemTime.time().now)
-
-        Map.put(
-          active_contacts,
-          respondent_id,
-          active_contact
-        )
-      else
-        Map.delete(active_contacts, respondent_id)
-      end
-
-    state =
-      Map.put(state, :active_contacts, new_active_contacts)
-      |> save_to_agent()
-
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    state
-  end
-
-  def remove_from_queue(
-        %{
-          contacts_queue: contacts_queue
-        } = state,
-        respondent_id
-      ) do
-    Logger.debug("CHNL_BRK remove_from_queue: #{inspect(binding())}")
-    new_contacts_queue = :pqueue.new()
-    n = :pqueue.len(contacts_queue)
-    new_contacts_queue = remove_r_contacts(contacts_queue, respondent_id, new_contacts_queue, n)
-    new_state = Map.put(state, :contacts_queue, new_contacts_queue)
-    Logger.debug("CHNL_BRK state: #{inspect(new_state)}")
-    new_state
-  end
-
-  defp remove_r_contacts(contacts_queue, respondent_id, new_contacts_queue, n) when n > 0 do
-    {{:value, [size, unqueued_item], priority}, contacts_queue} = :pqueue.pout(contacts_queue)
-
-    new_contacts_queue =
-      if respondent_id == queued_respondent_id(unqueued_item) do
-        new_contacts_queue
-      else
-        :pqueue.in([size, unqueued_item], priority, new_contacts_queue)
-      end
-
-    remove_r_contacts(contacts_queue, respondent_id, new_contacts_queue, n - 1)
-  end
-
-  defp remove_r_contacts(_contacts_queue, _respondent_id, new_contacts_queue, 0) do
-    new_contacts_queue
-  end
-
-  defp get_channel_state(channel_type, state, respondent_id) do
-    if channel_type == "ivr" and is_active(state, respondent_id) do
-      verboice_call_id = get_verboice_call_id(state, respondent_id)
-      %{"verboice_call_id" => verboice_call_id}
-    else
-      %{}
-    end
-  end
-
-  defp get_channel_state(channel_type, active_contact) do
-    if channel_type == "ivr" do
-      %{"verboice_call_id" => get_verboice_call_id(active_contact)}
-    else
-      %{}
-    end
+  def init([channel_id, channel_type, settings, state]) do
+    info("init (state)", channel_id: channel_id, channel_type: channel_type, settings: settings)
+    schedule_GC(channel_type, state)
+    {:ok, state, State.process_timeout(state)}
   end
 
   @impl true
-  def handle_call(
-        {:ask, "sms" = _channel_type, channel, %{id: respondent_id} = respondent, token, reply},
-        _from,
-        %{config: config, channel_id: channel_id} = state
-      ) do
-    Logger.debug("CHNL_BRK ask: #{inspect(binding())}")
+  def handle_call({:ask, "sms", channel, respondent, token, reply}, _from, state) do
+    info("handle_call[ask]",
+      channel_type: "sms",
+      channel_id: state.channel_id,
+      respondent_id: respondent.id,
+      token: token,
+      reply: reply
+    )
+
+    contact = {respondent, token, reply, channel}
+
+    size =
+      reply
+      |> NuntiumChannel.reply_to_messages(nil, respondent.id, state.channel_id)
+      |> length()
 
     new_state =
-      queue_contact(
-        state,
-        {respondent, token, reply, channel},
-        length(NuntiumChannel.reply_to_messages(reply, nil, respondent_id, channel_id))
-      )
+      state
+      |> State.queue_contact(contact, size)
+      |> try_activate_next_queued_contact()
+      |> save_to_agent()
+      |> debug()
 
-    end_state =
-      if can_unqueue(new_state) do
-        {new_state, unqueued_item} = activate_contact(new_state)
-        {unq_respondent, unq_token, unq_reply, unq_channel} = unqueued_item
-        channel_ask(unq_channel, unq_respondent, unq_token, unq_reply, channel_id)
-        new_state
-      else
-        new_state
-      end
-
-    Logger.debug("CHNL_BRK state: #{inspect(end_state)}")
-    {:reply, :ok, end_state, timeout_from_config(config)}
+    {:reply, :ok, new_state, State.process_timeout(state)}
   end
 
   @impl true
   def handle_call(
-        {
-          :setup,
-          channel_type,
-          channel,
-          respondent,
-          token,
-          not_before,
-          not_after
-        },
+        {:setup, "ivr", channel, respondent, token, not_before, not_after},
         _from,
-        %{config: config} = state
+        state
       ) do
-    Logger.debug("CHNL_BRK setup: #{inspect(binding())}")
-    new_state = state
+    info("handle_call[setup]",
+      channel_type: "ivr",
+      channel_id: state.channel_id,
+      respondent_id: respondent.id,
+      token: token,
+      not_before: not_before,
+      not_after: not_after
+    )
 
-    end_state =
-      if channel_type == "ivr" do
-        new_state =
-          queue_contact(new_state, {respondent, token, not_before, not_after, channel}, 1)
+    # queue contact and try to activate immediately
+    contact = {respondent, token, not_before, not_after, channel}
 
-        # Upon setup, we only setup an active contact for verboice
-        if can_unqueue(new_state) do
-          {new_state, unqueued_item} = activate_contact(new_state)
-          {unq_respondent, unq_token, unq_not_before, unq_not_after, unq_channel} = unqueued_item
+    new_state =
+      state
+      |> State.queue_contact(contact, 1)
+      |> try_activate_next_queued_contact()
+      |> save_to_agent()
+      |> debug()
 
-          ivr_call(
-            new_state,
-            unq_channel,
-            unq_respondent,
-            unq_token,
-            unq_not_before,
-            unq_not_after
-          )
-        else
-          new_state
-        end
-      else
-        # In nuntium, we just setup, the active contacts will increase upon :ask
-        channel_setup(channel, respondent, token, not_before, not_after)
-        new_state
-      end
-
-    Logger.debug("CHNL_BRK state: #{inspect(end_state)}")
-    {:reply, :ok, end_state, timeout_from_config(config)}
+    {:reply, :ok, new_state, State.process_timeout(state)}
   end
 
   @impl true
-  def handle_call({:prepare, channel}, _from, %{config: config} = state) do
-    Logger.debug("CHNL_BRK prepare: #{inspect(binding())}")
-    reply = Channel.prepare(channel)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    {:reply, reply, state, timeout_from_config(config)}
+  def handle_call(
+        {:setup, "sms", channel, respondent, token, not_before, not_after},
+        _from,
+        state
+      ) do
+    info("handle_call[setup]",
+      channel_type: "sms",
+      channel_id: state.channel_id,
+      respondent_id: respondent.id,
+      token: token,
+      not_before: not_before,
+      not_after: not_after
+    )
+
+    # only setup, contacts will be activated upon :ask
+    channel_setup(channel, respondent, token, not_before, not_after)
+
+    {:reply, :ok, state, State.process_timeout(state)}
   end
 
   @impl true
-  def handle_call({:has_delivery_confirmation?, channel}, _from, %{config: config} = state) do
-    Logger.debug("CHNL_BRK has_delivery_confirmation?: #{inspect(binding())}")
-    reply = Channel.has_delivery_confirmation?(channel)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    {:reply, reply, state, timeout_from_config(config)}
+  def handle_call({:prepare, channel}, _from, state) do
+    info("handle_call[prepare]", channel_id: state.channel_id)
+    reply = Ask.Runtime.Channel.prepare(channel)
+    {:reply, reply, state, State.process_timeout(state)}
+  end
+
+  @impl true
+  def handle_call({:has_delivery_confirmation?, channel}, _from, state) do
+    info("handle_call[has_delivery_confirmation?]", channel_id: state.channel_id)
+    reply = Ask.Runtime.Channel.has_delivery_confirmation?(channel)
+    {:reply, reply, state, State.process_timeout(state)}
   end
 
   # @impl true
@@ -673,166 +234,121 @@ defmodule Ask.Runtime.ChannelBroker do
         {:has_queued_message?, _channel_type, %{has_queued_message: has_queued_message},
          _respondent_id},
         _from,
-        %{config: config} = state
+        state
       ) do
-    Logger.debug("CHNL_BRK has_queued_message?: #{inspect(binding())}")
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    {:reply, has_queued_message, state, timeout_from_config(config)}
+    info("handle_call[has_queued_message?]", has_queued_message: has_queued_message)
+    {:reply, has_queued_message, state, State.process_timeout(state)}
   end
 
   @impl true
-  def handle_call(
-        {:has_queued_message?, _channel_type, _channel, respondent_id},
-        _from,
-        %{config: config} = state
-      ) do
-    Logger.debug("CHNL_BRK has_queued_message?: #{inspect(binding())}")
-    reply = is_active(state, respondent_id) || is_queued(state, respondent_id)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    {:reply, reply, state, timeout_from_config(config)}
+  def handle_call({:has_queued_message?, _channel_type, _channel, respondent_id}, _from, state) do
+    info("handle_call[has_queued_message?]", respondent_id: respondent_id)
+    reply = State.is_active(state, respondent_id) || State.is_queued(state, respondent_id)
+    {:reply, reply, state, State.process_timeout(state)}
   end
 
   @impl true
-  def handle_call(
-        {:cancel_message, channel_type, channel, respondent_id},
-        _from,
-        %{config: config} = state
-      ) do
-    Logger.debug("CHNL_BRK cancel_message: #{inspect(binding())}")
-    channel_state = get_channel_state(channel_type, state, respondent_id)
-    Channel.cancel_message(channel, channel_state)
-    state = deactivate_contact(state, respondent_id)
-    state = remove_from_queue(state, respondent_id)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    {:reply, :ok, state, timeout_from_config(config)}
-  end
+  def handle_call({:cancel_message, channel_type, channel, respondent_id}, _from, state) do
+    info("handle_call[cancel_message]",
+      channel_type: channel_type,
+      channel_id: state.channel_id,
+      respondent_id: respondent_id
+    )
 
-  @impl true
-  def handle_call(
-        {:message_expired?, channel_type, channel, respondent_id},
-        _from,
-        %{config: config} = state
-      ) do
-    Logger.debug("CHNL_BRK message_expired?: #{inspect(binding())}")
-    channel_state = get_channel_state(channel_type, state, respondent_id)
-    reply = Channel.message_expired?(channel, channel_state)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    {:reply, reply, state, timeout_from_config(config)}
-  end
+    channel_state = State.get_channel_state(channel_type, state, respondent_id)
+    Ask.Runtime.Channel.cancel_message(channel, channel_state)
 
-  @impl true
-  def handle_call({:check_status, channel}, _from, %{config: config} = state) do
-    Logger.debug("CHNL_BRK check_status: #{inspect(binding())}")
-    reply = Channel.check_status(channel)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
-    {:reply, reply, state, timeout_from_config(config)}
-  end
-
-  @impl true
-  def handle_call(
-        {:callback_received, respondent, respondent_state, provider},
-        _from,
-        %{config: config, channel_id: channel_id} = state
-      ) do
-    Logger.debug("CHN_BRK callback_received: #{inspect(binding())}")
-
-    end_state =
-      case provider do
-        "verboice" ->
-          case respondent_state do
-            rs when rs in ["failed", "busy", "no-answer", "expired", "completed"] ->
-              # If the callback tells that the contact finished we deactivate the contact
-              # and queue a new one if possible
-              new_state = deactivate_contact(state, respondent.id)
-
-              if can_unqueue(new_state) do
-                {new_state, unqueued_item} = activate_contact(new_state)
-
-                {unq_respondent, unq_token, unq_not_before, unq_not_after, unq_channel} =
-                  unqueued_item
-
-                ivr_call(
-                  new_state,
-                  unq_channel,
-                  unq_respondent,
-                  unq_token,
-                  unq_not_before,
-                  unq_not_after
-                )
-              else
-                new_state
-              end
-
-            _ ->
-              # If the callback tells something else, we update respondant last notice time
-              update_last_contact(state, respondent.id)
-          end
-
-        "nuntium" ->
-          new_state = deactivate_contact(state, respondent.id)
-
-          if can_unqueue(new_state) do
-            {new_state, unqueued_item} = activate_contact(new_state)
-            {unq_respondent, unq_token, unq_reply, unq_channel} = unqueued_item
-
-            channel_ask(unq_channel, unq_respondent, unq_token, unq_reply, channel_id)
-            new_state
-          else
-            new_state
-          end
-      end
-
-    Logger.debug("CHNL_BRK state: #{inspect(end_state)}")
-    {:reply, :ok, end_state, timeout_from_config(config)}
-  end
-
-  @impl true
-  def handle_call(
-        {:force_activate_respondent, respondent_id},
-        _from,
-        %{
-          active_contacts: active_contacts,
-          config: config
-        } = state
-      ) do
-    Logger.debug("CHN_BRK force_activate_respondent: #{inspect(binding())}")
-
-    respondent_contacts =
-      case Map.get(active_contacts, respondent_id) do
-        %{contacts: contacts} -> contacts
-        _ -> 0
-      end
-
-    new_active_contacts =
-      Map.put(
-        active_contacts,
-        respondent_id,
-        %{
-          contacts: respondent_contacts + 1,
-          last_contact: Ask.SystemTime.time().now
-        }
-      )
-
-    end_state =
-      Map.put(state, :active_contacts, new_active_contacts)
+    new_state =
+      state
+      |> State.deactivate_contact(respondent_id)
+      |> State.remove_from_queue(respondent_id)
       |> save_to_agent()
+      |> debug()
 
-    Logger.debug("CHNL_BRK state: #{inspect(end_state)}")
-
-    {:reply, :ok, end_state, timeout_from_config(config)}
+    {:reply, :ok, new_state, State.process_timeout(state)}
   end
 
   @impl true
-  def handle_call(
-        {:on_channel_settings_change, settings},
-        _from,
-        %{config: config} = state
-      ) do
-    Logger.debug("CHN_BRK on_channel_settings_change: #{inspect(binding())}")
-    new_capacity = Map.get(settings, "capacity", Config.default_channel_capacity())
-    new_state = Map.put(state, :capacity, new_capacity)
-    Logger.debug("CHNL_BRK state: #{inspect(new_state)}")
-    {:reply, :ok, new_state, timeout_from_config(config)}
+  def handle_call({:message_expired?, channel_type, channel, respondent_id}, _from, state) do
+    info("handle_call[message_expired?]",
+      channel_type: channel_type,
+      channel_id: state.channel_id,
+      respondent_id: respondent_id
+    )
+
+    channel_state = State.get_channel_state(channel_type, state, respondent_id)
+    reply = Ask.Runtime.Channel.message_expired?(channel, channel_state)
+    {:reply, reply, state, State.process_timeout(state)}
+  end
+
+  @impl true
+  def handle_call({:check_status, channel}, _from, state) do
+    info("handle_call[check_status]", channel_id: state.channel_id)
+    reply = Ask.Runtime.Channel.check_status(channel)
+    {:reply, reply, state, State.process_timeout(state)}
+  end
+
+  @impl true
+  def handle_call({:callback_received, respondent, respondent_state, "verboice"}, _from, state) do
+    info("handle_call[callback_received]",
+      respondent_id: respondent.id,
+      respondent_state: respondent_state,
+      provider: "verboice",
+      channel_id: state.channel_id
+    )
+
+    new_state =
+      if respondent_state in ["failed", "busy", "no-answer", "expired", "completed"] do
+        state
+        |> State.deactivate_contact(respondent.id)
+        |> try_activate_next_queued_contact()
+      else
+        state
+        |> State.touch_last_contact(respondent.id)
+      end
+      |> save_to_agent()
+      |> debug()
+
+    {:reply, :ok, new_state, State.process_timeout(state)}
+  end
+
+  @impl true
+  def handle_call({:callback_received, respondent, respondent_state, "nuntium"}, _from, state) do
+    info("handle_call[callback_received]",
+      respondent_id: respondent.id,
+      respondent_state: respondent_state,
+      provider: "nuntium",
+      channel_id: state.channel_id
+    )
+
+    new_state =
+      state
+      |> State.deactivate_contact(respondent.id)
+      |> try_activate_next_queued_contact()
+      |> save_to_agent()
+      |> debug()
+
+    {:reply, :ok, new_state, State.process_timeout(state)}
+  end
+
+  @impl true
+  def handle_call({:force_activate_respondent, respondent_id}, _from, state) do
+    info("handle_call[force_activate_respondent]", respondent_id: respondent_id)
+
+    new_state =
+      state
+      |> State.increment_respondents_contacts(respondent_id, 1)
+      |> save_to_agent()
+      |> debug()
+
+    {:reply, :ok, new_state, State.process_timeout(state)}
+  end
+
+  @impl true
+  def handle_call({:on_channel_settings_change, settings}, _from, state) do
+    info("handle_call[on_channel_settings_change]", settings: settings)
+    new_state = State.put_capacity(state, Map.get(settings, "capacity")) |> debug()
+    {:reply, :ok, new_state, State.process_timeout(state)}
   end
 
   @impl true
@@ -840,26 +356,160 @@ defmodule Ask.Runtime.ChannelBroker do
         :timeout,
         %{channel_id: channel_id, config: %{to_db_operations: to_db_operations}} = state
       ) do
-    Logger.debug("CHN_BRK timeout: #{inspect(binding())}")
-    # Save the state to the agent in DB only if it is enabled, otherwise just in memory
+    info("handle_info[timeout]", channel_id: channel_id, to_db_operations: to_db_operations)
+
+    # save the state to the agent in DB only if it is enabled, otherwise just in memory
     ChannelBrokerAgent.save_channel_state(channel_id, state, to_db_operations > 0)
     ChannelBrokerSupervisor.terminate_child(channel_id)
-    Logger.debug("CHNL_BRK state: #{inspect(state)}")
   end
 
-  def handle_info({:collect_garbage, channel_type}, %{config: config} = state) do
-    Logger.debug("CHN_BRK collect_garbage: #{inspect(binding())}")
-    # Remove the garbage contacts from active
-    # New versions of elixir has Maps.filter, replace when possible
+  def handle_info({:collect_garbage, channel_type}, state) do
+    info("handle_info[collect_garbage]", channel_type: channel_type, config: state.config)
+
+    active_respondents =
+      from(r in "respondents",
+        where: r.id in ^Map.keys(state.active_contacts) and r.state == "active",
+        select: r.id
+      )
+      |> Repo.all()
+
+    runtime_channel =
+      Channel
+      |> Repo.get(state.channel_id)
+      |> Channel.runtime_channel()
+
     new_state =
       state
-      |> clean_inactive_respondents()
-      |> clean_outdated_respondents(channel_type)
-      |> activate_contacts(channel_type)
+      |> State.clean_inactive_respondents(active_respondents)
+      |> State.clean_outdated_respondents(channel_type, runtime_channel)
+      |> activate_contacts()
+      |> save_to_agent()
+      |> debug()
 
-    # schedule next garbage collection
-    schedule_GC(channel_type, gc_interval_from_config(config))
+    # schedule next run
+    schedule_GC(channel_type, state)
 
     {:noreply, new_state}
+  end
+
+  # Internals
+
+  defp channel_setup(%Channel{} = channel, respondent, token, not_before, not_after) do
+    channel
+    |> Channel.runtime_channel()
+    |> channel_setup(respondent, token, not_before, not_after)
+  end
+
+  defp channel_setup(runtime_channel, respondent, token, not_before, not_after) do
+    runtime_channel
+    |> Ask.Runtime.Channel.setup(respondent, token, not_before, not_after)
+  end
+
+  # Activates has many queued contacts as possible, until either the queue is
+  # empty or the channel capacity is reached.
+  defp activate_contacts(state) do
+    info("activate_contacts", channel_id: state.channel_id)
+
+    if State.can_unqueue(state) do
+      state
+      |> activate_next_queued_contact()
+      |> activate_contacts()
+    else
+      state
+    end
+  end
+
+  # Activates one queued contact if possible: at least one contact is waiting in
+  # queue _and_ the channel capacity hasn't been reached, yet.
+  defp try_activate_next_queued_contact(state) do
+    if State.can_unqueue(state) do
+      activate_next_queued_contact(state)
+    else
+      state
+    end
+  end
+
+  # Activates the next queued contact. There must be one at least one contact in
+  # queue, and doesn't verify if the channel capacity has been reached!
+  defp activate_next_queued_contact(state) do
+    {new_state, unqueued_item} = State.activate_next_in_queue(state)
+
+    case unqueued_item do
+      {respondent, token, not_before, not_after, channel} ->
+        ivr_call(new_state, channel, respondent, token, not_before, not_after)
+
+      {respondent, token, reply, channel} ->
+        channel_ask(channel, respondent, token, reply, state.channel_id)
+        new_state
+    end
+  end
+
+  defp ivr_call(state, channel, respondent, token, not_before, not_after) do
+    case channel_setup(channel, respondent, token, not_before, not_after) do
+      {:ok, verboice_call_id} ->
+        info("set_verboice_call_id",
+          respondent_id: respondent.id,
+          verboice_call_id: verboice_call_id
+        )
+
+        state
+        |> State.set_verboice_call_id(respondent.id, verboice_call_id)
+
+      _ ->
+        # FIXME: what about failures to queue the call to verboice?
+        state
+    end
+  end
+
+  defp channel_ask(%Channel{} = channel, respondent, token, reply, channel_id) do
+    channel
+    |> Channel.runtime_channel()
+    |> channel_ask(respondent, token, reply, channel_id)
+  end
+
+  defp channel_ask(runtime_channel, %{id: respondent_id} = respondent, token, reply, channel_id) do
+    %{id: ^respondent_id} =
+      runtime_channel
+      |> Ask.Runtime.Channel.ask(respondent, token, reply, channel_id)
+  end
+
+  # NOTE: save to agent and persist to DB are disabled for now.
+  # FIXME: only persist to DB should be disabled!
+  defp save_to_agent(%{op_count: op_count, config: %{to_db_operations: to_db_operations}} = state) do
+    # only persist to DB when the counter is reached
+    new_op_count =
+      if op_count <= 1 and to_db_operations > 0 do
+        ChannelBrokerAgent.save_channel_state(state.channel_id, state, true)
+        to_db_operations
+      else
+        ChannelBrokerAgent.save_channel_state(state.channel_id, state, false)
+        op_count - 1
+      end
+
+    Map.put(state, :op_count, new_op_count)
+  end
+
+  # Don't schedule automatic GC runs in tests.
+  if Mix.env() == :test do
+    defp schedule_GC(_, _), do: nil
+  else
+    defp schedule_GC(channel_type, state) do
+      interval = State.gc_interval(state)
+      info("schedule_GC", channel_type: channel_type, interval: interval)
+      Process.send_after(self(), {:collect_garbage, channel_type}, interval)
+    end
+  end
+
+  defp info(name, options) do
+    Logger.info(
+      "ChannelBroker.#{name}:#{
+        Enum.map(options, fn {key, value} -> " #{key}=#{inspect(value)}" end)
+      }"
+    )
+  end
+
+  defp debug(state) do
+    Logger.debug("CHNL_BRK state: #{inspect(state)}")
+    state
   end
 end

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -1,5 +1,5 @@
 defmodule Ask.Runtime.ChannelBroker do
-  alias Ask.Runtime.{ChannelBrokerAgent, ChannelBrokerSupervisor, NuntiumChannel}
+  alias Ask.Runtime.{ChannelBrokerAgent, ChannelBrokerSupervisor}
   alias Ask.Runtime.ChannelBrokerState, as: State
   alias Ask.{Channel, Logger}
   import Ecto.Query
@@ -66,8 +66,8 @@ defmodule Ask.Runtime.ChannelBroker do
     call_gen_server(channel_id, {:callback_received, respondent, respondent_state, provider})
   end
 
-  def force_activate_respondent(channel_id, respondent_id) do
-    call_gen_server(channel_id, {:force_activate_respondent, respondent_id})
+  def force_activate_respondent(channel_id, respondent_id, size \\ 1) do
+    call_gen_server(channel_id, {:force_activate_respondent, respondent_id, size})
   end
 
   # NOTE: channels without channel_id (used in some unit tests) share a single process (channel_id: 0)
@@ -150,11 +150,7 @@ defmodule Ask.Runtime.ChannelBroker do
     )
 
     contact = {respondent, token, reply, channel}
-
-    size =
-      reply
-      |> NuntiumChannel.reply_to_messages(nil, respondent.id, state.channel_id)
-      |> length()
+    size = Ask.Runtime.Channel.messages_count(channel, respondent, nil, reply, state.channel_id)
 
     new_state =
       state
@@ -255,7 +251,7 @@ defmodule Ask.Runtime.ChannelBroker do
       respondent_id: respondent_id
     )
 
-    channel_state = State.get_channel_state(channel_type, state, respondent_id)
+    channel_state = State.get_channel_state(state, respondent_id)
     Ask.Runtime.Channel.cancel_message(channel, channel_state)
 
     new_state =
@@ -276,7 +272,7 @@ defmodule Ask.Runtime.ChannelBroker do
       respondent_id: respondent_id
     )
 
-    channel_state = State.get_channel_state(channel_type, state, respondent_id)
+    channel_state = State.get_channel_state(state, respondent_id)
     reply = Ask.Runtime.Channel.message_expired?(channel, channel_state)
     {:reply, reply, state, State.process_timeout(state)}
   end
@@ -323,7 +319,7 @@ defmodule Ask.Runtime.ChannelBroker do
 
     new_state =
       state
-      |> State.deactivate_contact(respondent.id)
+      |> State.decrement_respondents_contacts(respondent.id, 1)
       |> try_activate_next_queued_contact()
       |> save_to_agent()
       |> debug()
@@ -332,12 +328,12 @@ defmodule Ask.Runtime.ChannelBroker do
   end
 
   @impl true
-  def handle_call({:force_activate_respondent, respondent_id}, _from, state) do
-    info("handle_call[force_activate_respondent]", respondent_id: respondent_id)
+  def handle_call({:force_activate_respondent, respondent_id, size}, _from, state) do
+    info("handle_call[force_activate_respondent]", respondent_id: respondent_id, size: size)
 
     new_state =
       state
-      |> State.increment_respondents_contacts(respondent_id, 1)
+      |> State.increment_respondents_contacts(respondent_id, size)
       |> save_to_agent()
       |> debug()
 
@@ -381,7 +377,7 @@ defmodule Ask.Runtime.ChannelBroker do
     new_state =
       state
       |> State.clean_inactive_respondents(active_respondents)
-      |> State.clean_outdated_respondents(channel_type, runtime_channel)
+      |> State.clean_outdated_respondents(runtime_channel)
       |> activate_contacts()
       |> save_to_agent()
       |> debug()
@@ -439,38 +435,38 @@ defmodule Ask.Runtime.ChannelBroker do
         ivr_call(new_state, channel, respondent, token, not_before, not_after)
 
       {respondent, token, reply, channel} ->
-        channel_ask(channel, respondent, token, reply, state.channel_id)
-        new_state
+        channel_ask(new_state, channel, respondent, token, reply, state.channel_id)
     end
   end
 
   defp ivr_call(state, channel, respondent, token, not_before, not_after) do
-    case channel_setup(channel, respondent, token, not_before, not_after) do
-      {:ok, verboice_call_id} ->
-        info("set_verboice_call_id",
-          respondent_id: respondent.id,
-          verboice_call_id: verboice_call_id
-        )
+    {:ok, %{verboice_call_id: verboice_call_id}} =
+      channel_setup(channel, respondent, token, not_before, not_after)
 
-        state
-        |> State.set_verboice_call_id(respondent.id, verboice_call_id)
-
-      _ ->
-        # FIXME: what about failures to queue the call to verboice?
-        state
-    end
+    channel_state = %{"verboice_call_id" => verboice_call_id}
+    info("put_channel_state", respondent_id: respondent.id, channel_state: channel_state)
+    State.put_channel_state(state, respondent.id, channel_state)
   end
 
-  defp channel_ask(%Channel{} = channel, respondent, token, reply, channel_id) do
-    channel
-    |> Channel.runtime_channel()
-    |> channel_ask(respondent, token, reply, channel_id)
+  defp channel_ask(state, %Channel{} = channel, respondent, token, reply, channel_id) do
+    runtime_channel = Channel.runtime_channel(channel)
+    channel_ask(state, runtime_channel, respondent, token, reply, channel_id)
   end
 
-  defp channel_ask(runtime_channel, %{id: respondent_id} = respondent, token, reply, channel_id) do
-    %{id: ^respondent_id} =
-      runtime_channel
-      |> Ask.Runtime.Channel.ask(respondent, token, reply, channel_id)
+  defp channel_ask(
+         state,
+         runtime_channel,
+         %{id: respondent_id} = respondent,
+         token,
+         reply,
+         channel_id
+       ) do
+    {:ok, %{nuntium_token: nuntium_token}} =
+      Ask.Runtime.Channel.ask(runtime_channel, respondent, token, reply, channel_id)
+
+    channel_state = %{"nuntium_token" => nuntium_token}
+    info("put_channel_state", respondent_id: respondent_id, channel_state: channel_state)
+    State.put_channel_state(state, respondent.id, channel_state)
   end
 
   # NOTE: save to agent and persist to DB are disabled for now.

--- a/lib/ask/runtime/channel_broker_state.ex
+++ b/lib/ask/runtime/channel_broker_state.ex
@@ -1,0 +1,316 @@
+defmodule Ask.Runtime.ChannelBrokerState do
+  alias Ask.{Config, SystemTime}
+
+  @enforce_keys [
+    :channel_id,
+    :capacity,
+    :config,
+    :op_count
+  ]
+
+  defstruct [
+    # Each ChannelBroker process manages a single channel.
+    :channel_id,
+
+    # The maximum parallel contacts the channel shouldn't exceded.
+    :capacity,
+
+    # See `Config.channel_broker_config/0`
+    :config,
+
+    # Internal counter of how many updates until this state shall be saved to the DB
+    :op_count,
+
+    # A dictionary of active contacts with the following shape:
+    # ```
+    # %{respondent_id => %{
+    #   contacts: Integer,
+    #   last_contact: DateTime,
+    #   verboice_call_id: Integer
+    # }}
+    # ```
+    #
+    # Where:
+    # - contacts: number of contacts being currently managed by the channel (ivr=1, sms=1+)
+    # - last_contact: timestamp of the last sent contact or received callback
+    # - verboice_call_id: to match the contact with its associated call on Verboice
+    active_contacts: %{},
+
+    # A priority queue implemented using pqueue (https://github.com/okeuday/pqueue/).
+    #
+    # When a contact is queued, the received params are stored to be used when the time
+    # to make the contact comes.
+    #
+    # Elements are tuples whose shape depend on the channel provider:
+    # - Verboice: `{respondent, token, not_before, not_after, channel}`
+    # - Nuntium: `{respondent, token, reply, channel}`
+    contacts_queue: :pqueue.new()
+  ]
+
+  def new(channel_id, settings) do
+    config = Config.channel_broker_config()
+
+    %Ask.Runtime.ChannelBrokerState{
+      channel_id: channel_id,
+      capacity: Map.get(settings, "capacity", Config.default_channel_capacity()),
+      config: config,
+      op_count: config.to_db_operations
+    }
+  end
+
+  def put_capacity(state, nil) do
+    Map.put(state, :capacity, Config.default_channel_capacity())
+  end
+
+  def put_capacity(state, capacity) do
+    Map.put(state, :capacity, capacity)
+  end
+
+  # TODO: should be in a ChannelBrokerConfig struct
+  def process_timeout(state) do
+    state.config.shut_down_minutes * 60_000
+  end
+
+  # TODO: should be in a ChannelBrokerConfig struct
+  def gc_interval(state) do
+    state.config.gc_interval_minutes * 60_000
+  end
+
+  # TODO: should be in a ChannelBrokerConfig struct
+  def gc_allowed_idle_time(state) do
+    state.config.gc_active_idle_minutes * 60
+  end
+
+  def is_active(state, respondent_id) do
+    state.active_contacts
+    |> Map.has_key?(respondent_id)
+  end
+
+  def get_channel_state("ivr", state, respondent_id) do
+    if is_active(state, respondent_id) do
+      %{"verboice_call_id" => get_verboice_call_id(state, respondent_id)}
+    else
+      # TODO: shall we raise instead?
+      %{}
+    end
+  end
+
+  def get_channel_state("sms", _state, _respondent_id), do: %{}
+
+  def get_channel_state("ivr", active_contact) do
+    %{"verboice_call_id" => get_verboice_call_id(active_contact)}
+  end
+
+  def get_channel_state("sms", _active_contact), do: %{}
+
+  defp get_verboice_call_id(state, respondent_id) do
+    case Map.get(state.active_contacts, respondent_id) do
+      %{verboice_call_id: verboice_call_id} -> verboice_call_id
+      _ -> nil
+    end
+  end
+
+  defp get_verboice_call_id(active_contact) do
+    Map.get(active_contact, :verboice_call_id)
+  end
+
+  def set_verboice_call_id(state, respondent_id, %{verboice_call_id: verboice_call_id}) do
+    set_verboice_call_id(state, respondent_id, verboice_call_id)
+  end
+
+  def set_verboice_call_id(state, respondent_id, verboice_call_id) do
+    update_active_contact(state, respondent_id, fn active_contact ->
+      Map.put(active_contact, :verboice_call_id, verboice_call_id)
+    end)
+  end
+
+  # Adds a contact to the queue.
+  def queue_contact(state, contact, size) do
+    respondent = elem(contact, 0)
+    priority = if respondent.disposition == :queued, do: 2, else: 1
+    new_contacts_queue = :pqueue.in([size, contact], priority, state.contacts_queue)
+    Map.put(state, :contacts_queue, new_contacts_queue)
+  end
+
+  # Updates the active contact for the respondent. Does nothing if there are
+  # no active contact for this respondent.
+  defp update_active_contact(%{active_contacts: active_contacts} = state, respondent_id, cb) do
+    if active_contact = Map.get(active_contacts, respondent_id) do
+      new_active_contacts = Map.put(active_contacts, respondent_id, cb.(active_contact))
+      Map.put(state, :active_contacts, new_active_contacts)
+    else
+      state
+    end
+  end
+
+  # Touches the :last_contact attribute for a respondent. Does nothing if the
+  # respondent can't be found.
+  def touch_last_contact(state, respondent_id) do
+    update_active_contact(state, respondent_id, fn active_contact ->
+      Map.put(active_contact, :last_contact, SystemTime.time().now)
+    end)
+  end
+
+  # Activates the next contact from the queue. There must be at least one
+  # contact currently waiting in queue!
+  def activate_next_in_queue(%{active_contacts: active_contacts} = state) do
+    {{_unqueue_res, [size, unqueued_item]}, new_contacts_queue} =
+      :pqueue.out(state.contacts_queue)
+
+    respondent_id = queued_respondent_id(unqueued_item)
+
+    active_contact =
+      active_contacts
+      |> Map.get(respondent_id, %{contacts: 0})
+
+    new_active_contact =
+      active_contact
+      |> Map.put(:contacts, active_contact.contacts + size)
+      |> Map.put(:last_contact, SystemTime.time().now)
+
+    new_active_contacts =
+      active_contacts
+      |> Map.put(respondent_id, new_active_contact)
+
+    new_state =
+      state
+      |> Map.put(:contacts_queue, new_contacts_queue)
+      |> Map.put(:active_contacts, new_active_contacts)
+
+    {new_state, unqueued_item}
+  end
+
+  # Increments the number of contacts for the respondent. Activates the contact
+  # if it wasn't already.
+  def increment_respondents_contacts(
+        %{active_contacts: active_contacts} = state,
+        respondent_id,
+        size
+      ) do
+    active_contact =
+      active_contacts
+      |> Map.get(respondent_id, %{contacts: 0})
+
+    new_active_contact =
+      active_contact
+      |> Map.put(:contacts, active_contact.contacts + size)
+      |> Map.put(:last_contact, SystemTime.time().now)
+
+    new_active_contacts =
+      active_contacts
+      |> Map.put(respondent_id, new_active_contact)
+
+    Map.put(state, :active_contacts, new_active_contacts)
+  end
+
+  def deactivate_contact(state, respondent_id) do
+    respondent_contacts = contacts_for(state, respondent_id)
+
+    if respondent_contacts > 1 do
+      update_active_contact(state, respondent_id, fn active_contact ->
+        active_contact
+        |> Map.put(:contacts, respondent_contacts - 1)
+        |> Map.put(:last_contact, SystemTime.time().now)
+      end)
+    else
+      state
+      |> Map.put(:active_contacts, Map.delete(state.active_contacts, respondent_id))
+    end
+  end
+
+  # Returns the current number of active contacts for the respondent.
+  defp contacts_for(state, respondent_id) do
+    case Map.get(state.active_contacts, respondent_id) do
+      %{contacts: contacts} -> contacts
+      _ -> 0
+    end
+  end
+
+  def can_unqueue(state) do
+    if :pqueue.is_empty(state.contacts_queue) do
+      false
+    else
+      count_active_contacts(state) < state.capacity
+    end
+  end
+
+  defp count_active_contacts(state) do
+    state.active_contacts
+    |> Enum.reduce(0, fn {_, %{contacts: contacts}}, acc -> contacts + acc end)
+  end
+
+  def is_queued(state, respondent_id) do
+    state.contacts_queue
+    |> :pqueue.to_list()
+    |> Enum.any?(fn [_, queued_item] -> queued_respondent_id(queued_item) == respondent_id end)
+  end
+
+  def remove_from_queue(state, respondent_id) do
+    contacts_queue = state.contacts_queue
+    n = :pqueue.len(contacts_queue)
+    new_contacts_queue = remove_from_queue(contacts_queue, respondent_id, :pqueue.new(), n)
+    Map.put(state, :contacts_queue, new_contacts_queue)
+  end
+
+  defp remove_from_queue(contacts_queue, respondent_id, new_contacts_queue, n) when n > 0 do
+    {{:value, [size, unqueued_item], priority}, contacts_queue} = :pqueue.pout(contacts_queue)
+
+    new_contacts_queue =
+      if respondent_id == queued_respondent_id(unqueued_item) do
+        new_contacts_queue
+      else
+        :pqueue.in([size, unqueued_item], priority, new_contacts_queue)
+      end
+
+    remove_from_queue(contacts_queue, respondent_id, new_contacts_queue, n - 1)
+  end
+
+  defp remove_from_queue(_contacts_queue, _respondent_id, new_contacts_queue, 0) do
+    new_contacts_queue
+  end
+
+  # Keep only the contacts for active respondents.
+  #
+  # Respondents that failed could have active contacts in Surveda, despite being
+  # failed on the provider.
+  #
+  # FIXME: understand why Surveda would know about a contact having failed but
+  #        the channel broker wouldn't have been notified?!
+  def clean_inactive_respondents(state, active_respondents) do
+    # TODO: Elixir 1.13 has Map.filter/2
+    new_active_contacts =
+      :maps.filter(
+        fn respondent_id, _ -> respondent_id in active_respondents end,
+        state.active_contacts
+      )
+
+    Map.put(state, :active_contacts, new_active_contacts)
+  end
+
+  # For leftover active contacts, we ask the remote channel for the actual IVR
+  # call or SMS message state. Keep only the contacts that are active or queued.
+  def clean_outdated_respondents(state, channel_type, runtime_channel) do
+    idle_time = gc_allowed_idle_time(state)
+    now = SystemTime.time().now
+
+    # TODO: Elixir 1.13 has Map.filter/2
+    new_active_contacts =
+      :maps.filter(
+        fn _, %{last_contact: last_contact} = active_contact ->
+          if DateTime.diff(now, last_contact, :second) < idle_time do
+            true
+          else
+            channel_state = get_channel_state(channel_type, active_contact)
+            !Ask.Runtime.Channel.message_inactive?(runtime_channel, channel_state)
+          end
+        end,
+        state.active_contacts
+      )
+
+    Map.put(state, :active_contacts, new_active_contacts)
+  end
+
+  defp queued_respondent_id(queued_item) do
+    elem(queued_item, 0).id
+  end
+end

--- a/lib/ask/runtime/channel_broker_state.ex
+++ b/lib/ask/runtime/channel_broker_state.ex
@@ -26,14 +26,14 @@ defmodule Ask.Runtime.ChannelBrokerState do
     # %{respondent_id => %{
     #   contacts: Integer,
     #   last_contact: DateTime,
-    #   verboice_call_id: Integer
+    #   channel_state: %{String.t => any()}
     # }}
     # ```
     #
     # Where:
     # - contacts: number of contacts being currently managed by the channel (ivr=1, sms=1+)
     # - last_contact: timestamp of the last sent contact or received callback
-    # - verboice_call_id: to match the contact with its associated call on Verboice
+    # - channel_state: identifier(s) for the contact on the channel
     active_contacts: %{},
 
     # A priority queue implemented using pqueue (https://github.com/okeuday/pqueue/).
@@ -86,42 +86,18 @@ defmodule Ask.Runtime.ChannelBrokerState do
     |> Map.has_key?(respondent_id)
   end
 
-  def get_channel_state("ivr", state, respondent_id) do
-    if is_active(state, respondent_id) do
-      %{"verboice_call_id" => get_verboice_call_id(state, respondent_id)}
-    else
-      # TODO: shall we raise instead?
-      %{}
-    end
-  end
-
-  def get_channel_state("sms", _state, _respondent_id), do: %{}
-
-  def get_channel_state("ivr", active_contact) do
-    %{"verboice_call_id" => get_verboice_call_id(active_contact)}
-  end
-
-  def get_channel_state("sms", _active_contact), do: %{}
-
-  defp get_verboice_call_id(state, respondent_id) do
-    case Map.get(state.active_contacts, respondent_id) do
-      %{verboice_call_id: verboice_call_id} -> verboice_call_id
-      _ -> nil
-    end
-  end
-
-  defp get_verboice_call_id(active_contact) do
-    Map.get(active_contact, :verboice_call_id)
-  end
-
-  def set_verboice_call_id(state, respondent_id, %{verboice_call_id: verboice_call_id}) do
-    set_verboice_call_id(state, respondent_id, verboice_call_id)
-  end
-
-  def set_verboice_call_id(state, respondent_id, verboice_call_id) do
+  def put_channel_state(state, respondent_id, channel_state) do
     update_active_contact(state, respondent_id, fn active_contact ->
-      Map.put(active_contact, :verboice_call_id, verboice_call_id)
+      Map.put(active_contact, :channel_state, channel_state)
     end)
+  end
+
+  def get_channel_state(state, respondent_id) do
+    case Map.get(state.active_contacts, respondent_id) do
+      %{channel_state: channel_state} -> channel_state
+      # TODO: shall we raise instead?
+      _ -> %{}
+    end
   end
 
   # Adds a contact to the queue.
@@ -201,6 +177,40 @@ defmodule Ask.Runtime.ChannelBrokerState do
       |> Map.put(respondent_id, new_active_contact)
 
     Map.put(state, :active_contacts, new_active_contacts)
+  end
+
+  # Decrements the number of contacts for the respondent. Does nothing if the
+  # respondent isn't an active contact. Deactivates the respondent if the number
+  # of contacts falls down to zero.
+  def decrement_respondents_contacts(
+        %{active_contacts: active_contacts} = state,
+        respondent_id,
+        size
+      ) do
+    active_contact =
+      active_contacts
+      |> Map.get(respondent_id)
+
+    if active_contact do
+      new_value = active_contact.contacts - size
+
+      if new_value <= 0 do
+        deactivate_contact(state, respondent_id)
+      else
+        new_active_contact =
+          active_contact
+          |> Map.put(:contacts, new_value)
+          |> Map.put(:last_contact, SystemTime.time().now)
+
+        new_active_contacts =
+          active_contacts
+          |> Map.put(respondent_id, new_active_contact)
+
+        Map.put(state, :active_contacts, new_active_contacts)
+      end
+    else
+      state
+    end
   end
 
   def deactivate_contact(state, respondent_id) do
@@ -289,7 +299,7 @@ defmodule Ask.Runtime.ChannelBrokerState do
 
   # For leftover active contacts, we ask the remote channel for the actual IVR
   # call or SMS message state. Keep only the contacts that are active or queued.
-  def clean_outdated_respondents(state, channel_type, runtime_channel) do
+  def clean_outdated_respondents(state, runtime_channel) do
     idle_time = gc_allowed_idle_time(state)
     now = SystemTime.time().now
 
@@ -300,8 +310,7 @@ defmodule Ask.Runtime.ChannelBrokerState do
           if DateTime.diff(now, last_contact, :second) < idle_time do
             true
           else
-            channel_state = get_channel_state(channel_type, active_contact)
-            !Ask.Runtime.Channel.message_inactive?(runtime_channel, channel_state)
+            !Ask.Runtime.Channel.message_inactive?(runtime_channel, active_contact.channel_state)
           end
         end,
         state.active_contacts

--- a/lib/ask/runtime/nuntium_channel.ex
+++ b/lib/ask/runtime/nuntium_channel.ex
@@ -452,6 +452,16 @@ defmodule Ask.Runtime.NuntiumChannel do
       end
     end
 
+    # def message_inactive?(channel, %{"nuntium_ao_message_id" => ao_message_id}) do
+    #   client = Nuntium.Client.new(runtime_channel.base_url, runtime_channel.oauth_token)
+    #   case Nuntium.Client.ao_message_state(client, ao_message_id) do
+    #     {:ok, %{"state" => "queued"}} -> false
+    #     {:ok, %{"state" => _}} -> true
+    #     {:error, _} -> false # in case of error, we consider it's still active
+    #   end
+    # end
+    def message_inactive?(_, _), do: false
+
     def has_delivery_confirmation?(_), do: true
     def has_queued_message?(_, _), do: false
     def message_expired?(_, _), do: false

--- a/lib/ask/runtime/verboice_channel.ex
+++ b/lib/ask/runtime/verboice_channel.ex
@@ -482,6 +482,7 @@ defmodule Ask.Runtime.VerboiceChannel do
     def has_delivery_confirmation?(_), do: false
     def ask(_, _, _, _, _), do: throw(:not_implemented)
     def prepare(_), do: :ok
+    def messages_count(_, _, _, _, _), do: 1
 
     def setup(channel, respondent, token, not_before, not_after) do
       in_five_seconds = Timex.shift(not_before, seconds: 5)
@@ -532,7 +533,8 @@ defmodule Ask.Runtime.VerboiceChannel do
         {:ok, %{"state" => "active"}} -> false
         {:ok, %{"state" => "queued"}} -> false
         {:ok, %{"state" => _}} -> true
-        {:error, _} -> false # in case of error, we consider it's still active
+        # in case of error, we consider it's still active
+        {:error, _} -> false
       end
     end
     def message_inactive?(_, _), do: false

--- a/lib/nuntium/client.ex
+++ b/lib/nuntium/client.ex
@@ -4,6 +4,8 @@ defmodule Nuntium.Client do
   defstruct [:base_url, :oauth2_client]
 
   # @type t :: %Client{}
+  # @type ok :: {:ok, String.t}
+  # @type error :: {:error, integer | String.t}
 
   # @spec new(String.t, OAuth2.AccessToken.t) :: t
   def new(url, token) do
@@ -11,7 +13,7 @@ defmodule Nuntium.Client do
     %Client{base_url: url, oauth2_client: oauth2_client}
   end
 
-  # @spec send_ao(t, String.t) :: any()
+  # @spec send_ao(t, String.t, list()) :: {:ok, %{nuntium_token: String.t}} | error
   def send_ao(client, account, messages) do
     url = "#{client.base_url}/api/ao_messages.json?#{URI.encode_query(account: account)}"
 
@@ -24,6 +26,25 @@ defmodule Nuntium.Client do
     SurvedaMetrics.increment_counter_with_label(:surveda_nuntium_enqueue, [
       response_body.status_code
     ])
+
+    if response_body.status_code == 200 do
+      {"x-nuntium-token", nuntium_token} =
+        List.keyfind(response_body.headers, "x-nuntium-token", 0)
+
+      {:ok, %{nuntium_token: nuntium_token}}
+    else
+      parse_response(response)
+    end
+  end
+
+  # @spec get_ao(t, String.t, String.t) :: ok | error
+  def get_ao(client, account, token) do
+    url =
+      "#{client.base_url}/api/ao_messages.json?#{URI.encode_query(account: account, token: token)}"
+
+    response =
+      client.oauth2_client
+      |> OAuth2.Client.get(url)
 
     parse_response(response)
   end

--- a/test/ask/runtime/channel_broker_state_test.exs
+++ b/test/ask/runtime/channel_broker_state_test.exs
@@ -1,0 +1,49 @@
+defmodule Ask.Runtime.ChannelBrokerStateTest do
+  use AskWeb.ConnCase
+  use Ask.TestHelpers
+  alias Ask.Runtime.ChannelBrokerState, as: State
+
+  setup do
+    mock_queued_contact = fn respondent_id, params, disposition ->
+      {%{id: respondent_id, disposition: disposition}, params}
+    end
+
+    {:ok, state: State.new(0, %{}), mock_queued_contact: mock_queued_contact}
+  end
+
+  test "queues contact", %{state: state, mock_queued_contact: mqc} do
+    respondent_id = 2
+    params = 3
+    disposition = 4
+    contact = mqc.(respondent_id, params, disposition)
+    size = 5
+
+    %{contacts_queue: q} = State.queue_contact(state, contact, size)
+
+    {{:value, [queud_size, queued_contact]}, _} = :pqueue.out(q)
+    assert queued_contact == {%{id: respondent_id, disposition: disposition}, params}
+    assert queud_size == size
+  end
+
+  test "removes the respondent", %{state: state, mock_queued_contact: mqc} do
+    respondent_id = 2
+    contact = mqc.(respondent_id, 3, 4)
+    size = 5
+    state = State.queue_contact(state, contact, size)
+
+    %{contacts_queue: q} = State.remove_from_queue(state, respondent_id)
+
+    assert :pqueue.is_empty(q)
+  end
+
+  test "doesn't removes other respondent", %{state: state, mock_queued_contact: mqc} do
+    respondent_id = 2
+    contact = mqc.(respondent_id, 3, 4)
+    size = 5
+    state = State.queue_contact(state, contact, size)
+
+    new_state = State.remove_from_queue(state, 6)
+
+    assert new_state == state
+  end
+end

--- a/test/ask/runtime/channel_broker_test.exs
+++ b/test/ask/runtime/channel_broker_test.exs
@@ -106,9 +106,20 @@ defmodule Ask.Runtime.ChannelBrokerTest do
 
     setup do
       set_actual_time()
+      :ok
+    end
 
-      # create IVR survey:
-      [_, respondents, channel] = initialize_survey("ivr", @channel_capacity)
+    defp channel_state("ivr", respondent) do
+      %{"verboice_call_id" => respondent.id}
+    end
+
+    defp channel_state("sms", respondent) do
+      %{"nuntium_token" => respondent.id}
+    end
+
+    defp start_survey(channel_type) do
+      # create survey:
+      [_, respondents, channel] = initialize_survey(channel_type, @channel_capacity)
 
       # activate respondents:
       from(r in Respondent, where: r.id in ^Enum.map(respondents, fn r -> r.id end))
@@ -121,7 +132,7 @@ defmodule Ask.Runtime.ChannelBrokerTest do
           Map.put(a, e.id, %{
             contacts: 1,
             last_contact: Ask.SystemTime.time().now,
-            verboice_call_id: e.id
+            channel_state: channel_state(channel_type, e)
           })
         end)
 
@@ -130,7 +141,10 @@ defmodule Ask.Runtime.ChannelBrokerTest do
         respondents
         |> Enum.slice(5..9)
         |> Enum.reduce(:pqueue.new(), fn e, a ->
-          :pqueue.in([1, {e, "secret", nil, nil, channel}], 2, a)
+          case channel_type do
+            "ivr" -> :pqueue.in([1, {e, "secret", nil, nil, channel}], 2, a)
+            "sms" -> :pqueue.in([1, {e, "secret", [], channel}], 2, a)
+          end
         end)
 
       state = %Ask.Runtime.ChannelBrokerState{
@@ -142,10 +156,12 @@ defmodule Ask.Runtime.ChannelBrokerTest do
         op_count: 2
       }
 
-      {:ok, state: state, respondents: respondents, channel: channel}
+      %{state: state, respondents: respondents, channel: channel}
     end
 
-    test "deactivates failed respondents", %{state: state, respondents: respondents} do
+    test "deactivates failed respondents" do
+      %{state: state, respondents: respondents} = start_survey("ivr")
+
       # fail some respondents:
       Enum.at(respondents, 1) |> Respondent.changeset(%{state: :failed}) |> Repo.update!()
       Enum.at(respondents, 3) |> Respondent.changeset(%{state: :failed}) |> Repo.update!()
@@ -164,10 +180,9 @@ defmodule Ask.Runtime.ChannelBrokerTest do
              ] == Map.keys(new_state.active_contacts)
     end
 
-    test "asks verboice for actual state of long idle contacts", %{
-      state: state,
-      respondents: respondents
-    } do
+    test "asks verboice for actual state of long idle contacts" do
+      %{state: state, respondents: respondents} = start_survey("ivr")
+
       # travel to the future (within allowed contact idle time):
       time_passes(minutes: trunc(state.config.gc_active_idle_minutes / 2))
       {:noreply, new_state} = ChannelBroker.handle_info({:collect_garbage, "ivr"}, state)
@@ -177,7 +192,7 @@ defmodule Ask.Runtime.ChannelBrokerTest do
       time_passes(minutes: state.config.gc_active_idle_minutes * 2)
 
       # mock calls to channel:
-      verboice_call_state_fn = fn _, %{"verboice_call_id" => call_id} ->
+      verboice_message_inactive_fn = fn _, %{"verboice_call_id" => call_id} ->
         call_id in [
           Enum.at(respondents, 0).id,
           Enum.at(respondents, 1).id,
@@ -185,10 +200,12 @@ defmodule Ask.Runtime.ChannelBrokerTest do
         ]
       end
 
-      with_mock Ask.Runtime.Channel,
-        message_inactive?: verboice_call_state_fn,
-        # NOTE: must mock setup/5 called by ChannelBroker.ivr_call/6 (why?)
-        setup: fn _, _, _, _, _ -> {:ok, 0} end do
+      mocks = [
+        message_inactive?: verboice_message_inactive_fn,
+        setup: fn _, r, _, _, _ -> {:ok, %{verboice_call_id: r.id}} end
+      ]
+
+      with_mock Ask.Runtime.Channel, mocks do
         {:noreply, new_state} = ChannelBroker.handle_info({:collect_garbage, "ivr"}, state)
 
         # it asked verboice for call state (all calls are long idle in this test case):
@@ -198,6 +215,48 @@ defmodule Ask.Runtime.ChannelBrokerTest do
         assert [
                  Enum.at(respondents, 2).id,
                  Enum.at(respondents, 4).id,
+                 Enum.at(respondents, 5).id,
+                 Enum.at(respondents, 6).id,
+                 Enum.at(respondents, 7).id
+               ] == Map.keys(new_state.active_contacts)
+      end
+    end
+
+    test "asks nuntium for actual state of long idle contacts" do
+      %{state: state, respondents: respondents} = start_survey("sms")
+
+      # travel to the future (within allowed contact idle time):
+      time_passes(minutes: trunc(state.config.gc_active_idle_minutes / 2))
+      {:noreply, new_state} = ChannelBroker.handle_info({:collect_garbage, "sms"}, state)
+      assert new_state.active_contacts == state.active_contacts
+
+      # travel to the future again (after allowed contact idle time):
+      time_passes(minutes: state.config.gc_active_idle_minutes * 2)
+
+      # mock calls to channel:
+      nuntium_message_inactive_fn = fn _, %{"nuntium_token" => nuntium_token} ->
+        nuntium_token in [
+          Enum.at(respondents, 0).id,
+          Enum.at(respondents, 1).id,
+          Enum.at(respondents, 4).id
+        ]
+      end
+
+      mocks = [
+        message_inactive?: nuntium_message_inactive_fn,
+        ask: fn _, r, _, _, _ -> {:ok, %{nuntium_token: r.id}} end
+      ]
+
+      with_mock Ask.Runtime.Channel, mocks do
+        {:noreply, new_state} = ChannelBroker.handle_info({:collect_garbage, "sms"}, state)
+
+        # it asked nuntium for call state (all messages are long idle in this test case):
+        assert_called_exactly(Ask.Runtime.Channel.message_inactive?(:_, :_), @channel_capacity)
+
+        # it removed inactive respondents (0, 1, 4) and activated queued ones (5, 6, 7):
+        assert [
+                 Enum.at(respondents, 2).id,
+                 Enum.at(respondents, 3).id,
                  Enum.at(respondents, 5).id,
                  Enum.at(respondents, 6).id,
                  Enum.at(respondents, 7).id

--- a/test/ask/runtime/channel_broker_test.exs
+++ b/test/ask/runtime/channel_broker_test.exs
@@ -100,71 +100,6 @@ defmodule Ask.Runtime.ChannelBrokerTest do
     end
   end
 
-  describe "contacts_queue" do
-    setup do
-      mock_queued_contact = fn respondent_id, params, disposition ->
-        {%{id: respondent_id, disposition: disposition}, params}
-      end
-
-      {
-        :ok,
-        state: %{
-          contacts_queue: :pqueue.new(),
-          active_contacts: Map.new(),
-          channel_id: 1,
-          op_count: 2,
-          config: Config.channel_broker_config()
-        },
-        mock_queued_contact: mock_queued_contact
-      }
-    end
-
-    test "queues contact", %{
-      state: s,
-      mock_queued_contact: mqc
-    } do
-      respondent_id = 2
-      params = 3
-      disposition = 4
-      contact = mqc.(respondent_id, params, disposition)
-      size = 5
-
-      %{contacts_queue: q} = ChannelBroker.queue_contact(s, contact, size)
-
-      {{:value, [queud_size, queued_contact]}, _} = :pqueue.out(q)
-      assert queued_contact == {%{id: respondent_id, disposition: disposition}, params}
-      assert queud_size == size
-    end
-
-    test "removes the respondent", %{
-      state: s,
-      mock_queued_contact: mqc
-    } do
-      respondent_id = 2
-      contact = mqc.(respondent_id, 3, 4)
-      size = 5
-      state = ChannelBroker.queue_contact(s, contact, size)
-
-      %{contacts_queue: q} = ChannelBroker.remove_from_queue(state, respondent_id)
-
-      assert :pqueue.is_empty(q)
-    end
-
-    test "doesn't removes other respondent", %{
-      state: s,
-      mock_queued_contact: mqc
-    } do
-      respondent_id = 2
-      contact = mqc.(respondent_id, 3, 4)
-      size = 5
-      state = ChannelBroker.queue_contact(s, contact, size)
-
-      new_state = ChannelBroker.remove_from_queue(state, 6)
-
-      assert new_state == state
-    end
-  end
-
   describe ":collect_garbage" do
     @describetag :time_mock
     @channel_capacity 5
@@ -182,21 +117,23 @@ defmodule Ask.Runtime.ChannelBrokerTest do
       active_contacts =
         respondents
         |> Enum.slice(0..4)
-        |> Enum.reduce(%{}, fn e, a -> Map.put(a, e.id, %{
-          contacts: 1,
-          last_contact: Ask.SystemTime.time().now,
-          verboice_call_id: e.id
-        })
+        |> Enum.reduce(%{}, fn e, a ->
+          Map.put(a, e.id, %{
+            contacts: 1,
+            last_contact: Ask.SystemTime.time().now,
+            verboice_call_id: e.id
+          })
         end)
 
       # queue the other respondents:
       contacts_queue =
         respondents
         |> Enum.slice(5..9)
-        |> Enum.reduce(:pqueue.new(), fn e, a -> :pqueue.in([1, {e, "secret", nil, nil, channel}], 2, a) end)
+        |> Enum.reduce(:pqueue.new(), fn e, a ->
+          :pqueue.in([1, {e, "secret", nil, nil, channel}], 2, a)
+        end)
 
-      # build channel broker state:
-      state = %{
+      state = %Ask.Runtime.ChannelBrokerState{
         channel_id: channel.id,
         capacity: @channel_capacity,
         active_contacts: active_contacts,
@@ -219,15 +156,18 @@ defmodule Ask.Runtime.ChannelBrokerTest do
 
       # it removed failed respondents (1, 3, 4) and activated queued ones (5, 6, 7):
       assert [
-        Enum.at(respondents, 0).id,
-        Enum.at(respondents, 2).id,
-        Enum.at(respondents, 5).id,
-        Enum.at(respondents, 6).id,
-        Enum.at(respondents, 7).id,
-      ] == Map.keys(new_state.active_contacts)
+               Enum.at(respondents, 0).id,
+               Enum.at(respondents, 2).id,
+               Enum.at(respondents, 5).id,
+               Enum.at(respondents, 6).id,
+               Enum.at(respondents, 7).id
+             ] == Map.keys(new_state.active_contacts)
     end
 
-    test "asks verboice for actual state of long idle contacts", %{state: state, respondents: respondents} do
+    test "asks verboice for actual state of long idle contacts", %{
+      state: state,
+      respondents: respondents
+    } do
       # travel to the future (within allowed contact idle time):
       time_passes(minutes: trunc(state.config.gc_active_idle_minutes / 2))
       {:noreply, new_state} = ChannelBroker.handle_info({:collect_garbage, "ivr"}, state)
@@ -244,23 +184,24 @@ defmodule Ask.Runtime.ChannelBrokerTest do
           Enum.at(respondents, 3).id
         ]
       end
-      with_mock Ask.Runtime.Channel, [
+
+      with_mock Ask.Runtime.Channel,
         message_inactive?: verboice_call_state_fn,
-        setup: fn _, _, _, _, _ -> {:ok, 0} end # NOTE: must mock setup/5 called by ChannelBroker.ivr_call/6 (why?)
-      ] do
+        # NOTE: must mock setup/5 called by ChannelBroker.ivr_call/6 (why?)
+        setup: fn _, _, _, _, _ -> {:ok, 0} end do
         {:noreply, new_state} = ChannelBroker.handle_info({:collect_garbage, "ivr"}, state)
 
         # it asked verboice for call state (all calls are long idle in this test case):
-        assert_called_exactly Ask.Runtime.Channel.message_inactive?(:_, :_), @channel_capacity
+        assert_called_exactly(Ask.Runtime.Channel.message_inactive?(:_, :_), @channel_capacity)
 
         # it removed inactive respondents (0, 1, 3) and activated queued ones (5, 6, 7):
         assert [
-          Enum.at(respondents, 2).id,
-          Enum.at(respondents, 4).id,
-          Enum.at(respondents, 5).id,
-          Enum.at(respondents, 6).id,
-          Enum.at(respondents, 7).id,
-        ] == Map.keys(new_state.active_contacts)
+                 Enum.at(respondents, 2).id,
+                 Enum.at(respondents, 4).id,
+                 Enum.at(respondents, 5).id,
+                 Enum.at(respondents, 6).id,
+                 Enum.at(respondents, 7).id
+               ] == Map.keys(new_state.active_contacts)
       end
     end
   end

--- a/test/support/test_channel.ex
+++ b/test/support/test_channel.ex
@@ -108,13 +108,17 @@ defimpl Ask.Runtime.Channel, for: Ask.TestChannel do
     send(channel.pid, [:setup, channel, respondent, token])
     # TODO: Mock this response to test error scenarios.
     # Real answers like this should be tested: `{:error, {:error, 400}}`
-    {:ok, 0}
+    {:ok, %{verboice_call_id: 0}}
   end
 
   def ask(channel, respondent, token, prompts, channel_id) do
     send(channel.pid, [:ask, channel, respondent, token, prompts, channel_id])
-    respondent
+    # TODO: Mock this response to test error scenarios.
+    # Real answers like this should be tested: `{:error, {:error, 400}}`
+    {:ok, %{nuntium_token: UUID.uuid4()}}
   end
+
+  def messages_count(_, _, _, _, _), do: 1
 
   def has_delivery_confirmation?(%{delivery: delivery}), do: delivery
 

--- a/test/support/test_channel.ex
+++ b/test/support/test_channel.ex
@@ -122,6 +122,8 @@ defimpl Ask.Runtime.Channel, for: Ask.TestChannel do
 
   def message_expired?(%{message_expired: message_expired}, _), do: message_expired
 
+  def message_inactive?(_, _), do: false
+
   def cancel_message(channel, channel_state) do
     send(channel.pid, [:cancel_message, channel, channel_state])
     :ok


### PR DESCRIPTION
Revamps the GC to regularly check for the actual state of idle active contacts on the external channel (Verboice or Nuntium).

Also extracts the `Ask.RunTime.ChannelBrokerState` out of the `Ask.Runtime.ChannelBroker` to separate the state operations from the channel broker logic.

Depends on https://github.com/instedd/nuntium/pull/98
Closes #2252 