### PR TITLE
ChannelBroker: cleanup logs

### DIFF
--- a/lib/ask/pqueue.ex
+++ b/lib/ask/pqueue.ex
@@ -85,4 +85,9 @@ defmodule Ask.PQueue do
   def len(queue) do
     length(queue.high) + length(queue.normal) + length(queue.low)
   end
+
+  @spec len(t, :high | :normal | :low) :: non_neg_integer
+  def len(queue, :high), do: length(queue.high)
+  def len(queue, :normal), do: length(queue.normal)
+  def len(queue, :low), do: length(queue.low)
 end

--- a/test/ask/pqueue_test.exs
+++ b/test/ask/pqueue_test.exs
@@ -83,9 +83,25 @@ defmodule Ask.PQueueTest do
   test "len" do
     queue = PQueue.new()
     assert 0 == PQueue.len(queue)
+
     assert 1 == PQueue.len(queue = PQueue.push(queue, 1, :high))
+    assert 1 == PQueue.len(queue, :high)
+    assert 0 == PQueue.len(queue, :normal)
+    assert 0 == PQueue.len(queue, :low)
+
     assert 2 == PQueue.len(queue = PQueue.push(queue, 1, :high))
+    assert 2 == PQueue.len(queue, :high)
+    assert 0 == PQueue.len(queue, :normal)
+    assert 0 == PQueue.len(queue, :low)
+
     assert 3 == PQueue.len(queue = PQueue.push(queue, 1, :normal))
-    assert 4 == PQueue.len(PQueue.push(queue, 1, :low))
+    assert 2 == PQueue.len(queue, :high)
+    assert 1 == PQueue.len(queue, :normal)
+    assert 0 == PQueue.len(queue, :low)
+
+    assert 4 == PQueue.len(queue = PQueue.push(queue, 1, :low))
+    assert 2 == PQueue.len(queue, :high)
+    assert 1 == PQueue.len(queue, :normal)
+    assert 1 == PQueue.len(queue, :low)
   end
 end


### PR DESCRIPTION
Logs more information about the state (how many contacts are in high/normal and low queues), and changes most logs from info to debug level.