### PR TITLE
Fix: check each channel status in a distinct process

### DIFF
--- a/lib/ask/runtime/channel_status_server.ex
+++ b/lib/ask/runtime/channel_status_server.ex
@@ -45,45 +45,47 @@ defmodule Ask.Runtime.ChannelStatusServer do
       |> Enum.each(fn c ->
         previous_status = get_status_from_state(c.id, state)
 
-        status = ChannelBroker.check_status(c.id)
-        timestamp = Timex.now()
+        spawn(fn ->
+          status = ChannelBroker.check_status(c.id)
+          timestamp = Timex.now()
 
-        case status do
-          {:down, messages} ->
-            case previous_status do
-              %{status: :down} ->
-                nil
+          case status do
+            {:down, messages} ->
+              case previous_status do
+                %{status: :down} ->
+                  nil
 
-              _ ->
-                AskWeb.Email.channel_down(c.user.email, c, messages) |> Ask.Mailer.deliver()
+                _ ->
+                  AskWeb.Email.channel_down(c.user.email, c, messages) |> Ask.Mailer.deliver()
 
-                update_channel_status(c.id, %{
-                  status: :down,
-                  messages: messages,
-                  name: c.name,
-                  timestamp: timestamp
-                })
-            end
+                  update_channel_status(c.id, %{
+                    status: :down,
+                    messages: messages,
+                    name: c.name,
+                    timestamp: timestamp
+                  })
+              end
 
-          {:error, code} ->
-            case previous_status do
-              %{status: :error} ->
-                nil
+            {:error, code} ->
+              case previous_status do
+                %{status: :error} ->
+                  nil
 
-              _ ->
-                AskWeb.Email.channel_error(c.user.email, c, code) |> Ask.Mailer.deliver()
+                _ ->
+                  AskWeb.Email.channel_error(c.user.email, c, code) |> Ask.Mailer.deliver()
 
-                update_channel_status(c.id, %{
-                  status: :error,
-                  code: code,
-                  name: c.name,
-                  timestamp: timestamp
-                })
-            end
+                  update_channel_status(c.id, %{
+                    status: :error,
+                    code: code,
+                    name: c.name,
+                    timestamp: timestamp
+                  })
+              end
 
-          status ->
-            update_channel_status(c.id, status)
-        end
+            status ->
+              update_channel_status(c.id, status)
+          end
+        end)
       end)
 
       {:noreply, state}


### PR DESCRIPTION
Restores the `spawn` call to check each channel status in its own process, allowing parallel checks and avoiding a crash while checking a channel to block checking the status of the following channels (AFAIK).

The change was only introduced to fix a test, but I can't replicate the issue anymore. See:
https://github.com/instedd/surveda/pull/2127/commits/a58fbde4ba6630b2794f217a0f8443c9bc4c3baf