### PR TITLE
Upgrade ngrok image in docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,9 @@ erl_crash.dump
 # variables.
 /config/prod.secret.exs
 
+# Local configuration
 /config/local.exs
+/docker-compose.override.yml
 
 .vagrant
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,10 +49,11 @@ services:
       - yarn-cache:/usr/local/share/.cache/yarn
 
   ngrok:
-    image: wernight/ngrok
+    image: ngrok/ngrok:3.8.0-alpine
     ports:
       - 4040
+    command: http app:80
     environment:
-      NGROK_PORT: 'app:80'
       # Get your Authtoken here: https://dashboard.ngrok.com/get-started/your-authtoken
-      NGROK_AUTH: 'TheActualAuthToken'
+      # and override this value on docker-compose.override.yml
+      NGROK_AUTHTOKEN: 'TheActualAuthToken'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - yarn-cache:/usr/local/share/.cache/yarn
 
   ngrok:
-    image: ngrok/ngrok:3.8.0-alpine
+    image: ngrok/ngrok:alpine
     ports:
       - 4040
     command: http app:80


### PR DESCRIPTION
### Context
Current ngrok accounts are not allowing old versions of ngrok. When trying to run the old ngrok with a new token the app wouldn't start and fail with
> Your ngrok-agent version "2.3.40" is too old. The minimum supported agent version for your account is "3.2.0". Please update to a newer version

### Solution
Replace old `wernight/ngrok` image with `ngrok/ngrok:3.8.0-alpine` image