### PR TITLE
ChannelBroker: small improvements

### DIFF
--- a/lib/ask/channel_broker_queue.ex
+++ b/lib/ask/channel_broker_queue.ex
@@ -12,7 +12,7 @@ defmodule Ask.ChannelBrokerQueue do
 
     # queued (pending):
     field :queued_at, :utc_datetime
-    field :priority, Ecto.Enum, values: [low: 2, normal: 1, high: 0]
+    field :priority, Ecto.Enum, values: [normal: 1, high: 0]
     # number of outgoing messages (ivr=1, sms=1+)
     field :size, :integer
     field :token, :string

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -420,8 +420,8 @@ defmodule Ask.Runtime.ChannelBroker do
       {respondent, token, not_before, not_after} ->
         cond do
           expired_call?(not_after) ->
-            Ask.Runtime.Survey.contact_attempt_expired(respondent)
             State.deactivate_contact(new_state, respondent.id)
+            Ask.Runtime.Survey.contact_attempt_expired(respondent)
 
           future_call?(not_before) ->
             State.reenqueue_contact(new_state, respondent.id, :low)

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -420,9 +420,10 @@ defmodule Ask.Runtime.ChannelBroker do
       {respondent, token, not_before, not_after} ->
         cond do
           expired_call?(not_after) ->
-            State.deactivate_contact(new_state, respondent.id)
+            new_state = State.deactivate_contact(new_state, respondent.id)
             Ask.Runtime.Survey.contact_attempt_expired(respondent)
-
+            new_state
+            
           true ->
             ivr_call(new_state, respondent, token, not_before, not_after)
         end

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -423,9 +423,6 @@ defmodule Ask.Runtime.ChannelBroker do
             State.deactivate_contact(new_state, respondent.id)
             Ask.Runtime.Survey.contact_attempt_expired(respondent)
 
-          future_call?(not_before) ->
-            State.reenqueue_contact(new_state, respondent.id, :low)
-
           true ->
             ivr_call(new_state, respondent, token, not_before, not_after)
         end
@@ -433,13 +430,6 @@ defmodule Ask.Runtime.ChannelBroker do
       {respondent, token, reply} ->
         channel_ask(new_state, respondent, token, reply)
     end
-  end
-
-  defp future_call?(not_before) do
-    # we add some leeway to avoid deprioritizing calls that have just been
-    # pushed (scheduled for 5 seconds in the future) and allow calls that are
-    # about to be made to be scheduled now
-    DateTime.compare(not_before, Ask.SystemTime.time().now |> DateTime.add(60, :second)) == :gt
   end
 
   defp expired_call?(not_after) do

--- a/lib/ask/runtime/channel_broker_state.ex
+++ b/lib/ask/runtime/channel_broker_state.ex
@@ -86,7 +86,7 @@ defmodule Ask.Runtime.ChannelBrokerState do
     end
   end
 
-  # Adds an IVR contact to the queue with given priority (`:high`, `:normal`, `:low`).
+  # Adds an IVR contact to the queue with given priority (`:high`, `:normal`).
   def queue_contact(state, {respondent, token, not_before, not_after}, size, priority) do
     Queue.upsert!(%{
       channel_id: state.channel_id,
@@ -103,7 +103,7 @@ defmodule Ask.Runtime.ChannelBrokerState do
     state
   end
 
-  # Adds an SMS contact to the queue with given priority (`:high`, `:normal`, `:low`).
+  # Adds an SMS contact to the queue with given priority (`:high`, `:normal`).
   def queue_contact(state, {respondent, token, reply}, size, priority) do
     Queue.upsert!(%{
       channel_id: state.channel_id,
@@ -350,7 +350,6 @@ defmodule Ask.Runtime.ChannelBrokerState do
       channel: state.channel_id,
       active: Queue.count_active_contacts(state.channel_id),
       queued: Enum.reduce(queued, 0, fn {_, count}, a -> a + count end),
-      queued_low: queued[:low] || 0,
       queued_normal: queued[:normal] || 0,
       queued_high: queued[:high] || 0
     ]

--- a/test/ask/runtime/channel_broker_state_test.exs
+++ b/test/ask/runtime/channel_broker_state_test.exs
@@ -256,7 +256,7 @@ defmodule Ask.Runtime.ChannelBrokerStateTest do
                Queue.active_contacts(0) |> Enum.map(fn c -> c.respondent_id end) |> Enum.sort()
 
       # 4. normal priority queued 2nd
-      {state, _} = State.activate_next_in_queue(state)
+      {_, _} = State.activate_next_in_queue(state)
 
       assert [1, 2, 3, 4] =
                Queue.active_contacts(0) |> Enum.map(fn c -> c.respondent_id end) |> Enum.sort()

--- a/test/ask/runtime/channel_broker_state_test.exs
+++ b/test/ask/runtime/channel_broker_state_test.exs
@@ -232,13 +232,10 @@ defmodule Ask.Runtime.ChannelBrokerStateTest do
       state = State.queue_contact(state, new_contact(2), 1, :high)
 
       mock_time(DateTime.add(now, 2, :second))
-      state = State.queue_contact(state, new_contact(3), 1, :low)
+      state = State.queue_contact(state, new_contact(3), 1, :normal)
 
       mock_time(DateTime.add(now, 3, :second))
-      state = State.queue_contact(state, new_contact(4), 1, :normal)
-
-      mock_time(DateTime.add(now, 5, :second))
-      state = State.queue_contact(state, new_contact(5), 1, :low)
+      state = State.queue_contact(state, new_contact(4), 1, :high)
 
       # 1. high priority
       {state, _} = State.activate_next_in_queue(state)
@@ -246,25 +243,23 @@ defmodule Ask.Runtime.ChannelBrokerStateTest do
       assert [2] =
                Queue.active_contacts(0) |> Enum.map(fn c -> c.respondent_id end) |> Enum.sort()
 
-      # 2. normal priority queued 1st
+      # 2. high priority queued 2nd
       {state, _} = State.activate_next_in_queue(state)
 
-      assert [1, 2] =
+      assert [2, 4] =
                Queue.active_contacts(0) |> Enum.map(fn c -> c.respondent_id end) |> Enum.sort()
 
-      # 3. normal priority queued 2nd
+      # 3. normal priority queued 1st
       {state, _} = State.activate_next_in_queue(state)
 
       assert [1, 2, 4] =
                Queue.active_contacts(0) |> Enum.map(fn c -> c.respondent_id end) |> Enum.sort()
 
-      # 4. low priority queued 1st
-      {_, _} = State.activate_next_in_queue(state)
+      # 4. normal priority queued 2nd
+      {state, _} = State.activate_next_in_queue(state)
 
       assert [1, 2, 3, 4] =
                Queue.active_contacts(0) |> Enum.map(fn c -> c.respondent_id end) |> Enum.sort()
-
-      assert [%{respondent_id: 5}] = Queue.queued_contacts(0)
     end
 
     @tag :time_mock


### PR DESCRIPTION
 - Remove `:low` priority since it doesn't make sense anymore. The piece of code where it was being considered is now unreachable after #2300 
   ```
      future_call?(not_before) ->
            State.reenqueue_contact(new_state, respondent.id, :low)

        defp future_call?(not_before) do
    
            DateTime.compare(not_before, Ask.SystemTime.time().now |> DateTime.add(60, :second)) == :gt
        end
    ```
    
    ☝️ The thing is that now (with the queue stored in the db) we only activate respondents which contact 
    ```
    not_before <= not_before = SystemTime.time().now |> DateTime.add(60, :second)
    ```
    See [`ChannelBrokerState.activate_next_in_queue`](https://github.com/instedd/surveda/blob/683a050b2aeec1a6bfafaa65f481f1f5e1c8ab72/lib/ask/runtime/channel_broker_state.ex#L166)
    
    this closes #2289 
    
 - Invert calls to `Survey` and `ChannelBrokerState` when the `ChannelBroker` tries to activate the next queued contact and it's expired
    - See [this slack thread](https://manas.slack.com/archives/C1L7CJMNU/p1710878095079079) for more context 

## Observations 👀
I had to do a workaround for inverting the calls. I had to keep the `state` in a variable and return that after the call to `Survey.contact_attempt_expired`. 
I'm not fan of this solution, but I _think_ I prefer this to the previous version, but I read your opinions!
    