### PR TITLE
#2306: prioritize contacted respondents

### DIFF
--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -501,10 +501,13 @@ defmodule Ask.Runtime.ChannelBroker do
     priority = cond do
       # Respondent is participating in the survey
       prioritized_disposition?(respondent.disposition) -> :high
+
       # We have already 'bothered' this respondent
-      # attempts > 1 since when queuing the respondent the first time
-      # it already has `attempts: 1`
+      # we check that attempts > 1 since
+      # when queuing the respondent the first time
+      # already has `attempts: 1` (see Session.run_flow)
       Stats.attempts(respondent.stats, :full) > 1 -> :high
+
       true -> :normal
     end
 

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -161,7 +161,7 @@ defmodule Ask.Runtime.ChannelBroker do
 
     new_state =
       refreshed_state
-      |> State.queue_contact(contact, size)
+      |> queue_contact(contact, size)
       |> try_activate_next_queued_contact()
       |> Agent.save_state()
 
@@ -184,7 +184,7 @@ defmodule Ask.Runtime.ChannelBroker do
 
     new_state =
       state
-      |> State.queue_contact(contact, 1)
+      |> queue_contact(contact, 1)
       |> try_activate_next_queued_contact()
       |> Agent.save_state()
 
@@ -492,6 +492,19 @@ defmodule Ask.Runtime.ChannelBroker do
     else
       state
     end
+  end
+
+  # Adds a contact to the queue.
+  # The priority is set from the respondent's state
+  defp queue_contact(state, contact, size) do  
+    respondent = elem(contact, 0)
+    priority = cond do
+      respondent.disposition != :queued -> :high
+      respondent.stats.attempts != nil -> :high 
+      true -> :normal
+    end
+    
+    State.queue_contact(state, contact, size, priority)
   end
 
   # Log helpers

--- a/lib/ask/runtime/channel_broker_state.ex
+++ b/lib/ask/runtime/channel_broker_state.ex
@@ -74,6 +74,8 @@ defmodule Ask.Runtime.ChannelBrokerState do
     )
   end
 
+  def queue_contact(state, contact, size, priority \\ :normal)
+
   # Adds an IVR contact to the queue with given priority (`:high`, `:normal`).
   def queue_contact(state, {respondent, token, not_before, not_after}, size, priority) do
     Queue.upsert!(%{

--- a/lib/ask/runtime/channel_broker_state.ex
+++ b/lib/ask/runtime/channel_broker_state.ex
@@ -74,18 +74,6 @@ defmodule Ask.Runtime.ChannelBrokerState do
     )
   end
 
-  # Adds a contact to the queue. The priority is set from the respondent's
-  # disposition.
-  def queue_contact(state, contact, size) do
-    respondent = elem(contact, 0)
-
-    if respondent.disposition == :queued do
-      queue_contact(state, contact, size, :normal)
-    else
-      queue_contact(state, contact, size, :high)
-    end
-  end
-
   # Adds an IVR contact to the queue with given priority (`:high`, `:normal`).
   def queue_contact(state, {respondent, token, not_before, not_after}, size, priority) do
     Queue.upsert!(%{

--- a/test/ask/runtime/channel_broker_state_test.exs
+++ b/test/ask/runtime/channel_broker_state_test.exs
@@ -75,10 +75,10 @@ defmodule Ask.Runtime.ChannelBrokerStateTest do
       assert [] = Queue.active_contacts(0)
     end
 
-    test "sets priority from respondent's disposition", %{state: state} do
+    test "respects given priority", %{state: state} do
       state
-      |> State.queue_contact(new_contact(1, :queued), 1)
-      |> State.queue_contact(new_contact(2, :started), 1)
+      |> State.queue_contact(new_contact(1, :queued), 1, :normal)
+      |> State.queue_contact(new_contact(2, :started), 1, :high)
 
       assert [
                %{respondent_id: 1, priority: :normal},


### PR DESCRIPTION
## Changes

* move responsibility of defining a contact priority from `ChannelBrokerState` to `ChannelBroker`
   * `ChannelBrokerState` should not be deciding how to queue respondents. It's something that's outside it responsibility. The one that _knows_ about respondents is `ChannelBroker`
* Enqueue contacts with `priority: :high` if surveda has already _bothered_ that respondent
   * We are checking `Stats.attempts :full` because 
      * we want to count any mode attempt 
      * we want to consider ivr pending calls as well
   * When `runtime/Session` starts a respondent, already adds the mode attempt. This happens before the respondent gets queued to the `ChannelBrokerQueue` - see [`runtime/Session.run_flow`](https://github.com/instedd/surveda/blob/c2b39f6eb1c2c12c79fac2f843b7acdce97b4e84/lib/ask/runtime/session.ex#L595). This means that for distinguishing respondents that are being queued for the first time or not, we have to check for `attempts > 1`

closes #2306 