### PR TITLE
Log batch limit when activating respondents

### DIFF
--- a/lib/ask/runtime/survey_broker.ex
+++ b/lib/ask/runtime/survey_broker.ex
@@ -173,7 +173,6 @@ defmodule Ask.Runtime.SurveyBroker do
 
         active < batch_size && pending > 0 && !survey_completed ->
           count = batch_size - active
-          Logger.info("Survey #{survey.id}. Starting up to #{count} respondents.")
           start_some(survey, count)
 
         true ->
@@ -371,8 +370,10 @@ defmodule Ask.Runtime.SurveyBroker do
     )
   end
 
-  defp start_some(survey, count) do
-    count = Enum.min([batch_limit_per_minute(survey.project), count])
+  defp start_some(survey, requested_count) do
+    count_limit = batch_limit_per_minute(survey.project)
+    count = min(requested_count, count_limit)
+    Logger.info("Survey #{survey.id}. Starting up to #{count} respondents (wanted to start #{requested_count}, batch limit at #{count_limit}).")
 
     from(r in assoc(survey, :respondents),
       select: r.id,


### PR DESCRIPTION
If the SurveyBroker wants to activate more respodents than allowed by the batch limit per minute, log the fact that it was capped.

Before this commit, the limit was applied without logging it, making it harder to understand what was going on.