### PR TITLE
#2318: make numeric ranges quotas exhaustive

### DIFF
--- a/assets/js/components/surveys/SurveyWizardCutoffStep.jsx
+++ b/assets/js/components/surveys/SurveyWizardCutoffStep.jsx
@@ -77,9 +77,9 @@ class SurveyWizardCutoffStep extends Component {
       bucket.condition.map(({ store, value }) => {
         if(Array.isArray(value) && value.length == 2){
           if(value[0] == null){
-            value = `<= ${value[1]}`
+            value = `< ${value[1] + 1}`
           } else if(value[1] == null){
-            value = `>= ${value[0]}`
+            value = `${value[0]}+`
           } else {
             value = join(value, " - ")
           }

--- a/assets/js/components/surveys/SurveyWizardCutoffStep.jsx
+++ b/assets/js/components/surveys/SurveyWizardCutoffStep.jsx
@@ -75,8 +75,14 @@ class SurveyWizardCutoffStep extends Component {
   bucketLabel(bucket) {
     return join(
       bucket.condition.map(({ store, value }) => {
-        if (typeof value == "object") {
-          value = join(value, " - ")
+        if(Array.isArray(value) && value.length == 2){
+          if(value[0] == null){
+            value = `<= ${value[1]}`
+          } else if(value[1] == null){
+            value = `>= ${value[0]}`
+          } else {
+            value = join(value, " - ")
+          }
         }
         return `${store}: ${value}`
       }),

--- a/assets/js/reducers/survey.js
+++ b/assets/js/reducers/survey.js
@@ -5,6 +5,7 @@ import fetchReducer from "./fetch"
 import drop from "lodash/drop"
 import flatten from "lodash/flatten"
 import map from "lodash/map"
+import zip from "lodash/zip"
 import split from "lodash/split"
 import find from "lodash/find"
 import findIndex from "lodash/findIndex"
@@ -293,15 +294,11 @@ const intervalsFrom = (valueString) => {
   const values = map(split(valueString, ","), (value) => parseInt(value.trim())).sort(
     (a, b) => a - b
   )
-  if (values.length <= 1) {
-    return []
-  }
-
-  if (values.length == 2) {
-    return [[values[0], values[1]]]
-  }
-
-  return [[values[0], values[1] - 1], ...intervalsFrom(drop(values))]
+  const prevValues = map(values, (value) => value - 1)
+  
+  const lowerBounds = [null, ...values]
+  const upperBounds = [...prevValues, null]
+  return zip(lowerBounds, upperBounds)
 }
 
 const comparisonRatioChange = (state, action) => {
@@ -368,11 +365,7 @@ export const rebuildInputFromQuotaBuckets = (store: string, survey: Survey) => {
     buckets.map((bucket) => find(bucket.condition, (condition) => condition.store == store).value),
     isEqual
   )
-  let lastCondition = conditions.pop() // last condition's upper bound doesn't have to be incremented
-  conditions = conditions.map((x) => [x[0], x[1] + 1])
-  conditions.push(lastCondition)
-  conditions = flatten(conditions)
-  conditions = uniqWith(conditions, isEqual)
+  conditions = conditions.map((x) => x[0]).filter((x) => x !== null)
   return conditions.join()
 }
 

--- a/lib/ask/quota_bucket.ex
+++ b/lib/ask/quota_bucket.ex
@@ -50,6 +50,28 @@ defmodule Ask.QuotaBucket do
     end
   end
 
+  def matches_condition?(value, [from, nil]) do
+    from = if is_integer(from), do: from, else: String.to_integer(from)
+    case Integer.parse(value) do
+      {value, ""} ->
+        from <= value
+
+      _ ->
+        false
+    end
+  end
+
+  def matches_condition?(value, [nil, to]) do
+    to = if is_integer(to), do: to, else: String.to_integer(to)
+    case Integer.parse(value) do
+      {value, ""} ->
+        value <= to
+
+      _ ->
+        false
+    end
+  end
+
   def matches_condition?(value, [from, to]) do
     matches_condition?(value, [String.to_integer(from), String.to_integer(to)])
   end

--- a/lib/ask/quota_bucket.ex
+++ b/lib/ask/quota_bucket.ex
@@ -50,8 +50,7 @@ defmodule Ask.QuotaBucket do
     end
   end
 
-  def matches_condition?(value, [from, nil]) do
-    from = if is_integer(from), do: from, else: String.to_integer(from)
+  def matches_condition?(value, [from, nil]) when is_integer(from) do
     case Integer.parse(value) do
       {value, ""} ->
         from <= value
@@ -61,8 +60,7 @@ defmodule Ask.QuotaBucket do
     end
   end
 
-  def matches_condition?(value, [nil, to]) do
-    to = if is_integer(to), do: to, else: String.to_integer(to)
+  def matches_condition?(value, [nil, to]) when is_integer(to) do
     case Integer.parse(value) do
       {value, ""} ->
         value <= to
@@ -70,6 +68,14 @@ defmodule Ask.QuotaBucket do
       _ ->
         false
     end
+  end
+
+  def matches_condition?(value, [from, nil]) do
+    matches_condition?(value, [String.to_integer(from), nil])
+  end
+  
+  def matches_condition?(value, [nil, to]) do
+    matches_condition?(value, [nil, String.to_integer(to)])
   end
 
   def matches_condition?(value, [from, to]) do

--- a/test/ask/quota_bucket_test.exs
+++ b/test/ask/quota_bucket_test.exs
@@ -1,0 +1,95 @@
+defmodule Ask.QuotaBucketTest do
+  use Ask.DataCase
+
+  alias Ask.{QuotaBucket}
+
+  describe "matches_condition?" do
+    test "lower bound bucket matches any value less than the lower bound" do
+      matches_lower_bound = QuotaBucket.matches_condition?("5", [nil, 18])
+      assert matches_lower_bound
+
+      matches_lower_bound = QuotaBucket.matches_condition?("5", [nil, "18"])
+      assert matches_lower_bound
+    end
+
+    test "lower bound bucket matches on the same value than the lower bound" do
+      matches_lower_bound = QuotaBucket.matches_condition?("18", [nil, 18])
+      assert matches_lower_bound
+
+      matches_lower_bound = QuotaBucket.matches_condition?("18", [nil, "18"])
+      assert matches_lower_bound
+    end
+
+    test "lower bound bucket does not match any value greater than the lower bound" do
+      matches_lower_bound = QuotaBucket.matches_condition?("19", [nil, 18])
+      assert !matches_lower_bound
+
+      matches_lower_bound = QuotaBucket.matches_condition?("19", [nil, "18"])
+      assert !matches_lower_bound
+    end
+
+    test "upper bound bucket matches any value greater than the upper bound" do
+      matches_upper_bound = QuotaBucket.matches_condition?("110", [100, nil])
+      assert matches_upper_bound
+
+      matches_upper_bound = QuotaBucket.matches_condition?("110", ["100", nil])
+      assert matches_upper_bound
+    end
+
+    test "upper bound bucket matches on the same value than the upper bound" do
+      matches_upper_bound = QuotaBucket.matches_condition?("100", [100, nil])
+      assert matches_upper_bound
+
+      matches_upper_bound = QuotaBucket.matches_condition?("100", ["100", nil])
+      assert matches_upper_bound
+    end
+
+    test "upper bound bucket does not match any value less than the upper bound" do
+      matches_upper_bound = QuotaBucket.matches_condition?("95", [100, nil])
+      assert !matches_upper_bound
+
+      matches_upper_bound = QuotaBucket.matches_condition?("95", ["100", nil])
+      assert !matches_upper_bound
+    end
+
+    test "common bucket matches if value is contained in range" do
+      matches_bucket = QuotaBucket.matches_condition?("95", [18, 100])
+      assert matches_bucket
+
+      matches_bucket = QuotaBucket.matches_condition?("95", ["18", "100"])
+      assert matches_bucket
+    end
+
+    test "common bucket matches if value equals the lower bound" do
+      matches_bucket = QuotaBucket.matches_condition?("18", [18, 100])
+      assert matches_bucket
+
+      matches_bucket = QuotaBucket.matches_condition?("18", ["18", "100"])
+      assert matches_bucket
+    end
+
+    test "common bucket matches if value equals the upper bound" do
+      matches_bucket = QuotaBucket.matches_condition?("100", [18, 100])
+      assert matches_bucket
+
+      matches_bucket = QuotaBucket.matches_condition?("100", ["18", "100"])
+      assert matches_bucket
+    end
+
+    test "common bucket does not match if value its bigger than the defined range" do
+      matches_bucket = QuotaBucket.matches_condition?("101", [18, 100])
+      assert !matches_bucket
+
+      matches_bucket = QuotaBucket.matches_condition?("101", ["18", "100"])
+      assert !matches_bucket
+    end
+
+    test "common bucket does not match if value its smalled than the defined range" do
+      matches_bucket = QuotaBucket.matches_condition?("17", [18, 100])
+      assert !matches_bucket
+
+      matches_bucket = QuotaBucket.matches_condition?("17", ["18", "100"])
+      assert !matches_bucket
+    end
+  end
+end

--- a/test/js/reducers/survey.spec.js
+++ b/test/js/reducers/survey.spec.js
@@ -522,14 +522,49 @@ describe('survey reducer', () => {
         quotas: {
           vars: ['Smokes', 'Age'],
           buckets: [
+            {'condition': [{store: 'Age', value: [null, 19]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [20, 29]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [30, 39]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [40, 49]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
-            {'condition': [{store: 'Age', value: [50, 120]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
+            {'condition': [{store: 'Age', value: [50, 119]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
+            {'condition': [{store: 'Age', value: [120, null]}, {store: 'Smokes', value: 'Yes'}], 'quota': 0},
+            {'condition': [{store: 'Age', value: [null, 19]}, {store: 'Smokes', value: 'No'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [20, 29]}, {store: 'Smokes', value: 'No'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [30, 39]}, {store: 'Smokes', value: 'No'}], 'quota': 0},
             {'condition': [{store: 'Age', value: [40, 49]}, {store: 'Smokes', value: 'No'}], 'quota': 0},
-            {'condition': [{store: 'Age', value: [50, 120]}, {store: 'Smokes', value: 'No'}], 'quota': 0}
+            {'condition': [{store: 'Age', value: [50, 119]}, {store: 'Smokes', value: 'No'}], 'quota': 0},
+            {'condition': [{store: 'Age', value: [120, null]}, {store: 'Smokes', value: 'No'}], 'quota': 0}
+          ]
+        }
+      }
+    })
+  })
+
+  it('should set quota vars from single numeric step', () => {
+    const questionnaire = deepFreeze({
+      steps: [
+        {
+          type: 'numeric',
+          store: 'Age'
+        }
+      ],
+      id: 1
+    })
+    const state = playActions([
+      actions.fetch(1, 1),
+      actions.receive(survey),
+      actions.setQuotaVars([{var: 'Age', steps: '35'}], questionnaire)
+    ])
+
+    expect(state).toEqual({
+      ...state,
+      data: {
+        ...state.data,
+        quotas: {
+          vars: ['Age'],
+          buckets: [
+            {'condition': [{store: 'Age', value: [null, 34]}], 'quota': 0},
+            {'condition': [{store: 'Age', value: [35, null]}], 'quota': 0},
           ]
         }
       }
@@ -581,18 +616,23 @@ describe('survey reducer', () => {
         buckets: [
           {
             'condition': [
-              { store: 'age', value: [1, 9] }
+              { store: 'age', value: [null, 9] }
             ]
           },
           {
             'condition': [
-              { store: 'age', value: [10, 50] }
+              { store: 'age', value: [10, 49] }
+            ]
+          },
+          {
+            'condition': [
+              { store: 'age', value: [50, null] }
             ]
           }
         ]
       }
     })
-    expect(rebuildInputFromQuotaBuckets('age', survey)).toEqual('1,10,50')
+    expect(rebuildInputFromQuotaBuckets('age', survey)).toEqual('10,50')
   })
 
   it('changes modeComparison', () => {


### PR DESCRIPTION
## Changes
Create upperbound and lowerbound ranges to make numeric quotas exhaustive.

### Examples
![image](https://github.com/instedd/surveda/assets/13237343/2ad55791-39d3-4b0c-805e-7ec979037c52)

### Evidence

https://github.com/instedd/surveda/assets/13237343/72c403e1-10d6-4aa4-a1b2-7e0b4b446de4

![image](https://github.com/instedd/surveda/assets/13237343/4dbc1eaf-27df-4f3a-b300-9008a9be0639)


closes #2318 