### PR TITLE
#1744: fix respondent_stats deadlocks

### DIFF
--- a/lib/mix/tasks/deadlock.test.ex
+++ b/lib/mix/tasks/deadlock.test.ex
@@ -1,0 +1,74 @@
+defmodule Mix.Tasks.Ask.Deadlock.Test do
+  import Ecto.Query
+  use Mix.Task
+
+  alias Ask.{Repo, Respondent}
+
+
+  @shortdoc """
+  Edits multiple respondents at the same time to try to generate a deadlock by respondent_stats locks.
+  """
+ 
+  # Prerequisites
+  # have a survey with respondents 
+  # - state:active, disposition:queued
+  # - state:active, disposition:contacted
+  #
+  # Steps to achieve that:
+  # - create new survey and load respondent sample (without launching)
+  # - update n respondents to be active & queued
+  # - update m respondents to be active & contacted
+  @impl Mix.Task
+  def run([survey_id]) do
+    Mix.shell().info("Starting deadlock test..")
+    Mix.shell().info("Max concurrency: #{System.schedulers_online()}")
+
+    Mix.Task.run("app.start")
+
+    # respondents = Repo.all(from r in Respondent, 
+    #         where: r.survey_id == ^survey_id,
+    #         where: r.state == :pending,
+    #         where: r.disposition == :registered,
+    #         limit: 1000
+    #         )
+    
+    # Task.async_stream(respondents, fn r -> 
+    #     :timer.sleep(Enum.random(50..1_000))
+    #     disposition = Enum.random(Ecto.Enum.values(Ask.Respondent, :disposition))
+    #     state = Enum.random(Ecto.Enum.values(Ask.Respondent, :state))
+    #     mode = Enum.random(["['sms']", "['ivr']"])
+    #     Respondent.update(r, %{disposition: disposition, state: state, mode: mode, quota_bucket_id: 1}, true) 
+    #   end, 
+    #   timeout: :infinity)
+    # |> Stream.run()
+
+    contacted_respondents = Repo.all(from r in Respondent, 
+            where: r.survey_id == ^survey_id,
+            where: r.state == :active,
+            where: r.disposition == :contacted
+    )
+
+    queued_respondents = Repo.all(from r in Respondent, 
+            where: r.survey_id == ^survey_id,
+            where: r.state == :active,
+            where: r.disposition == :queued
+    )
+    
+    tasks1 = contacted_respondents |> Enum.map(fn r -> 
+      Task.async(fn -> 
+        :timer.sleep(Enum.random(50..500))
+        r |> Respondent.update(%{disposition: :queued}, true) 
+      end)
+    end)
+    
+    tasks2 = queued_respondents |> Enum.map(fn r -> 
+      Task.async(fn -> 
+        :timer.sleep(Enum.random(50..500))
+        r |> Respondent.update(%{disposition: :contacted}, true) 
+      end)
+    end)
+
+    Task.yield_many(tasks1 ++ tasks2, :infinity)
+
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -116,7 +116,8 @@ defmodule Ask.Mixfile do
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "ecto.migrate": ["ecto.migrate", "ask.ecto_dump"],
       "ecto.rollback": ["ecto.rollback", "ask.ecto_dump"],
-      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      deadlocks: ["ask.deadlock.test"]
     ]
   end
 end

--- a/priv/repo/migrations/20240422175453_fix_respondent_stats_trigger.exs
+++ b/priv/repo/migrations/20240422175453_fix_respondent_stats_trigger.exs
@@ -1,91 +1,89 @@
 defmodule Ask.Repo.Migrations.FixRespondentStatsTrigger do
   use Ecto.Migration
+  alias Ask.Repo
 
   def up do
-    Repo.transaction(fn ->
-      Repo.query!(
-        """
-        DROP TRIGGER respondents_upd;
-        """
-      )
+    Repo.query!(
+      """
+      DROP TRIGGER respondents_upd;
+      """
+    )
 
-      Repo.query!(
-        Repo.query!(
-          """
-          CREATE TRIGGER respondents_upd
-          AFTER UPDATE ON respondents
-          FOR EACH ROW
-          BEGIN
-    
-            # This is a hack for using the `select for update`
-            # so we can lock all the records that will get updated 
-            # by this trigger before actually modifying them
-            # so we prevent this trigger to generate deadlocks
-            # see #1744
-            DECLARE temp_stats INT;
-    
-            SELECT count(*) 
-            INTO temp_stats
-            FROM respondent_stats
-            WHERE (survey_id = OLD.survey_id
-                      AND questionnaire_id = IFNULL(OLD.questionnaire_id, 0)
-                      AND state = OLD.state
-                      AND disposition = OLD.disposition
-                      AND quota_bucket_id = IFNULL(OLD.quota_bucket_id, 0)
-                      AND mode = IFNULL(OLD.mode, ''))
-            OR (survey_id = NEW.survey_id
-                      AND questionnaire_id = IFNULL(NEW.questionnaire_id, 0)
-                      AND state = NEW.state
-                      AND disposition = NEW.disposition
-                      AND quota_bucket_id = IFNULL(NEW.quota_bucket_id, 0)
-                      AND mode = IFNULL(NEW.mode, ''))
-            FOR UPDATE;
-    
-            UPDATE respondent_stats
-               SET `count` = `count` - 1
-             WHERE survey_id = OLD.survey_id
-               AND questionnaire_id = IFNULL(OLD.questionnaire_id, 0)
-               AND state = OLD.state
-               AND disposition = OLD.disposition
-               AND quota_bucket_id = IFNULL(OLD.quota_bucket_id, 0)
-               AND mode = IFNULL(OLD.mode, '')
-            ;
+    Repo.query!(
+      """
+      CREATE TRIGGER respondents_upd
+      AFTER UPDATE ON respondents
+      FOR EACH ROW
+      BEGIN
 
-            INSERT INTO respondent_stats(survey_id, questionnaire_id, state, disposition, quota_bucket_id, mode, `count`)
-            VALUES (NEW.survey_id, IFNULL(NEW.questionnaire_id, 0), NEW.state, NEW.disposition, IFNULL(NEW.quota_bucket_id, 0), IFNULL(NEW.mode, ''), 1)
-            ON DUPLICATE KEY UPDATE `count` = `count` + 1
-            ;
+        # This is a hack for using the `select for update`
+        # so we can lock all the records that will get updated 
+        # by this trigger before actually modifying them
+        # so we prevent this trigger to generate deadlocks
+        # see #1744
+        DECLARE temp_stats INT;
+
+        SELECT count(*) 
+        INTO temp_stats
+        FROM respondent_stats
+        WHERE (survey_id = OLD.survey_id
+                  AND questionnaire_id = IFNULL(OLD.questionnaire_id, 0)
+                  AND state = OLD.state
+                  AND disposition = OLD.disposition
+                  AND quota_bucket_id = IFNULL(OLD.quota_bucket_id, 0)
+                  AND mode = IFNULL(OLD.mode, ''))
+        OR (survey_id = NEW.survey_id
+                  AND questionnaire_id = IFNULL(NEW.questionnaire_id, 0)
+                  AND state = NEW.state
+                  AND disposition = NEW.disposition
+                  AND quota_bucket_id = IFNULL(NEW.quota_bucket_id, 0)
+                  AND mode = IFNULL(NEW.mode, ''))
+        FOR UPDATE;
+
+        UPDATE respondent_stats
+            SET `count` = `count` - 1
+          WHERE survey_id = OLD.survey_id
+            AND questionnaire_id = IFNULL(OLD.questionnaire_id, 0)
+            AND state = OLD.state
+            AND disposition = OLD.disposition
+            AND quota_bucket_id = IFNULL(OLD.quota_bucket_id, 0)
+            AND mode = IFNULL(OLD.mode, '')
+        ;
+
+        INSERT INTO respondent_stats(survey_id, questionnaire_id, state, disposition, quota_bucket_id, mode, `count`)
+        VALUES (NEW.survey_id, IFNULL(NEW.questionnaire_id, 0), NEW.state, NEW.disposition, IFNULL(NEW.quota_bucket_id, 0), IFNULL(NEW.mode, ''), 1)
+        ON DUPLICATE KEY UPDATE `count` = `count` + 1
+        ;
+
+      END;
+      """
+      ) 
     
-          END;
-          """
-        )
-      )
-    end)
   end
 
   def down do
     # Re-create the trigger as it was before
-    Repo.transaction(fn ->
-      Repo.query!(
-        """
-        DROP TRIGGER respondents_upd;
-        """
-      )
+    Repo.query!(
+      """
+      DROP TRIGGER respondents_upd;
+      """
+    )
 
-      Repo.query!("""
+    Repo.query!(
+      """
       CREATE TRIGGER respondents_upd
       AFTER UPDATE ON respondents
       FOR EACH ROW
       BEGIN
 
         UPDATE respondent_stats
-           SET `count` = `count` - 1
-         WHERE survey_id = OLD.survey_id
-           AND questionnaire_id = IFNULL(OLD.questionnaire_id, 0)
-           AND state = OLD.state
-           AND disposition = OLD.disposition
-           AND quota_bucket_id = IFNULL(OLD.quota_bucket_id, 0)
-           AND mode = IFNULL(OLD.mode, '')
+          SET `count` = `count` - 1
+        WHERE survey_id = OLD.survey_id
+          AND questionnaire_id = IFNULL(OLD.questionnaire_id, 0)
+          AND state = OLD.state
+          AND disposition = OLD.disposition
+          AND quota_bucket_id = IFNULL(OLD.quota_bucket_id, 0)
+          AND mode = IFNULL(OLD.mode, '')
         ;
 
         INSERT INTO respondent_stats(survey_id, questionnaire_id, state, disposition, quota_bucket_id, mode, `count`)
@@ -95,6 +93,5 @@ defmodule Ask.Repo.Migrations.FixRespondentStatsTrigger do
 
       END;
       """)
-    end)
   end
 end

--- a/priv/repo/migrations/20240422175453_fix_respondent_stats_trigger.exs
+++ b/priv/repo/migrations/20240422175453_fix_respondent_stats_trigger.exs
@@ -1,0 +1,100 @@
+defmodule Ask.Repo.Migrations.FixRespondentStatsTrigger do
+  use Ecto.Migration
+
+  def up do
+    Repo.transaction(fn ->
+      Repo.query!(
+        """
+        DROP TRIGGER respondents_upd;
+        """
+      )
+
+      Repo.query!(
+        Repo.query!(
+          """
+          CREATE TRIGGER respondents_upd
+          AFTER UPDATE ON respondents
+          FOR EACH ROW
+          BEGIN
+    
+            # This is a hack for using the `select for update`
+            # so we can lock all the records that will get updated 
+            # by this trigger before actually modifying them
+            # so we prevent this trigger to generate deadlocks
+            # see #1744
+            DECLARE temp_stats INT;
+    
+            SELECT count(*) 
+            INTO temp_stats
+            FROM respondent_stats
+            WHERE (survey_id = OLD.survey_id
+                      AND questionnaire_id = IFNULL(OLD.questionnaire_id, 0)
+                      AND state = OLD.state
+                      AND disposition = OLD.disposition
+                      AND quota_bucket_id = IFNULL(OLD.quota_bucket_id, 0)
+                      AND mode = IFNULL(OLD.mode, ''))
+            OR (survey_id = NEW.survey_id
+                      AND questionnaire_id = IFNULL(NEW.questionnaire_id, 0)
+                      AND state = NEW.state
+                      AND disposition = NEW.disposition
+                      AND quota_bucket_id = IFNULL(NEW.quota_bucket_id, 0)
+                      AND mode = IFNULL(NEW.mode, ''))
+            FOR UPDATE;
+    
+            UPDATE respondent_stats
+               SET `count` = `count` - 1
+             WHERE survey_id = OLD.survey_id
+               AND questionnaire_id = IFNULL(OLD.questionnaire_id, 0)
+               AND state = OLD.state
+               AND disposition = OLD.disposition
+               AND quota_bucket_id = IFNULL(OLD.quota_bucket_id, 0)
+               AND mode = IFNULL(OLD.mode, '')
+            ;
+
+            INSERT INTO respondent_stats(survey_id, questionnaire_id, state, disposition, quota_bucket_id, mode, `count`)
+            VALUES (NEW.survey_id, IFNULL(NEW.questionnaire_id, 0), NEW.state, NEW.disposition, IFNULL(NEW.quota_bucket_id, 0), IFNULL(NEW.mode, ''), 1)
+            ON DUPLICATE KEY UPDATE `count` = `count` + 1
+            ;
+    
+          END;
+          """
+        )
+      )
+    end)
+  end
+
+  def down do
+    # Re-create the trigger as it was before
+    Repo.transaction(fn ->
+      Repo.query!(
+        """
+        DROP TRIGGER respondents_upd;
+        """
+      )
+
+      Repo.query!("""
+      CREATE TRIGGER respondents_upd
+      AFTER UPDATE ON respondents
+      FOR EACH ROW
+      BEGIN
+
+        UPDATE respondent_stats
+           SET `count` = `count` - 1
+         WHERE survey_id = OLD.survey_id
+           AND questionnaire_id = IFNULL(OLD.questionnaire_id, 0)
+           AND state = OLD.state
+           AND disposition = OLD.disposition
+           AND quota_bucket_id = IFNULL(OLD.quota_bucket_id, 0)
+           AND mode = IFNULL(OLD.mode, '')
+        ;
+
+        INSERT INTO respondent_stats(survey_id, questionnaire_id, state, disposition, quota_bucket_id, mode, `count`)
+        VALUES (NEW.survey_id, IFNULL(NEW.questionnaire_id, 0), NEW.state, NEW.disposition, IFNULL(NEW.quota_bucket_id, 0), IFNULL(NEW.mode, ''), 1)
+        ON DUPLICATE KEY UPDATE `count` = `count` + 1
+        ;
+
+      END;
+      """)
+    end)
+  end
+end


### PR DESCRIPTION
## Changes
 - Add `select for update` statement at the beginning of the trigger to lock both respondent_stats records, so to prevent deadlock from happening
   - Note: I had to hack my way to it, since you cannot use a `select for update` directly in a trigger since it fails with `ERROR 1415 (0A000): Not allowed to return a result set from a trigger`
   - Note 2: ☝️ I went with the workaround since `LOCK TABLE` statements are not allowed in triggers either
     >LOCK TABLES and UNLOCK TABLES cannot be used within stored programs. 

     See https://dev.mysql.com/doc/refman/5.7/en/lock-tables.html


## Tests
 - Created a mix task script that given a survey id and two dispositions will update respondents from one disposition to the other one in multiple concurrent tasks
   - The execution of this scrip before these changes would fail since it would trigger the deadlocks
   - After the re-definition of the trigger the script no longer fails 🙌 


https://github.com/instedd/surveda/assets/13237343/344794a8-3ad9-4baf-8feb-a82a12487758

---

closes #1744 