### PR TITLE
#2308: Fix SuccessRateLine chart

### DIFF
--- a/assets/js/components/charts/SuccessRateLine.jsx
+++ b/assets/js/components/charts/SuccessRateLine.jsx
@@ -99,7 +99,7 @@ export default class SuccessRateLine extends Component<Props> {
           .attr("r", "3px")
           .style("fill", data.color)
           .style("stroke", data.color)
-          .style("opacity", 0.2)
+          .style("opacity", 0.1)
           .on("mouseover", (d) => {
             tooltip
               .text(percentFormat(d.value / 100))

--- a/assets/js/components/charts/SuccessRateLine.jsx
+++ b/assets/js/components/charts/SuccessRateLine.jsx
@@ -53,33 +53,28 @@ export default class SuccessRateLine extends Component<Props> {
   renderD3(initial = false) {
     const { width, height, data } = this.state
 
-    let srData = data.filter((d) => d.label === "Success rate")
-    if (!srData[0].values.length) {
+    if (!data){
       return
     }
-    srData[0].values.unshift({ time: srData[0].values[0].time, value: 0 })
-    srData[0].values.push({ time: srData[0].values[srData[0].values.length - 1].time, value: 0 })
-
-    const flatten = Array.prototype.concat(...srData.map((d) => [...d.values, ...d.forecast]))
 
     let initialTime, lastTime
 
-    if (!flatten || flatten.length < 1) {
+    if (!data.values || data.values.length < 1) {
       initialTime = new Date()
       lastTime = d3.timeMonth.offset(initialTime, 1)
     } else {
       initialTime = d3.timeHour.offset(
-        d3.min(flatten, (d) => d.time),
+        d3.min(data.values, (d) => d.time),
         -1
       )
-      lastTime = d3.timeMonth.offset(initialTime, 1)
-      lastTime = d3.max([d3.max(flatten, (d) => d.time), lastTime])
+      const oneMonthFromStart = d3.timeMonth.offset(initialTime, 1)
+      lastTime = d3.max([d3.max(data.values, (d) => d.time), oneMonthFromStart])
     }
 
     const x = d3.scaleTime().domain([initialTime, lastTime]).range([0, width])
     const y = d3
       .scaleLinear()
-      .domain([0, d3.max(srData[0].values, (d) => d.value * 1.2)])
+      .domain([0, d3.max(data.values, (d) => d.value * 1.2)])
       .range([height, 0])
     const line = d3
       .line()
@@ -92,35 +87,33 @@ export default class SuccessRateLine extends Component<Props> {
       .classed("forecast-tooltip", true)
       .style("visibility", "hidden")
 
-    for (var i = 0; i < srData.length; i++) {
-      for (var j = 1; j < srData[i].values.length - 1; j++) {
-        if (y(srData[i].values[j].value) != 0 && x(srData[i].values[j].time) != 0) {
-          d3.select(this.refs.circles)
-            .selectAll("path")
-            .data([srData[i].values[j]])
-            .enter()
-            .append("circle")
-            .attr("cx", (d) => x(d.time))
-            .attr("cy", (d) => y(d.value))
-            .attr("r", "3px")
-            .style("fill", srData[i].color)
-            .style("stroke", srData[i].color)
-            .style("opacity", 0.1)
-            .on("mouseover", (d) => {
-              tooltip
-                .text(percentFormat(d.value / 100))
-                .style("top", d3.event.pageY - 10 + "px")
-                .style("left", d3.event.pageX + 10 + "px")
-                .style("visibility", "visible")
-            })
-            .on("mouseout", () => tooltip.style("visibility", "hidden"))
-        }
+    for (var j = 1; j < data.values.length - 1; j++) {
+      if (y(data.values[j].value) != 0 && x(data.values[j].time) != 0) {
+        d3.select(this.refs.circles)
+          .selectAll("path")
+          .data([data.values[j]])
+          .enter()
+          .append("circle")
+          .attr("cx", (d) => x(d.time))
+          .attr("cy", (d) => y(d.value))
+          .attr("r", "3px")
+          .style("fill", data.color)
+          .style("stroke", data.color)
+          .style("opacity", 0.2)
+          .on("mouseover", (d) => {
+            tooltip
+              .text(percentFormat(d.value / 100))
+              .style("top", d3.event.pageY - 10 + "px")
+              .style("left", d3.event.pageX + 10 + "px")
+              .style("visibility", "visible")
+          })
+          .on("mouseout", () => tooltip.style("visibility", "hidden"))
       }
     }
 
     d3.select(this.refs.values)
       .selectAll("path")
-      .data(srData)
+      .data([data])
       .enter()
       .append("path")
       .merge(d3.select(this.refs.values).selectAll("path"))

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -289,23 +289,26 @@ class SurveyShow extends Component<any, State> {
       ]
     }
 
-    if (percentages) {
-      forecastsReferences.push({
-        label: "Success rate",
-        color: "#000000",
-        id: "successRate",
-      })
-    }
-
     // TODO: we should be doing this when receiving properties, not at render
     let forecasts = forecastsReferences.map((d) => {
-      const values = (cumulativePercentages[d.id] || percentages[d.id] || []).map((v) => ({
+      const values = (cumulativePercentages[d.id] || []).map((v) => ({
         time: new Date(v.date),
         value: Number(v.percent),
       }))
 
       return { ...d, values }
     })
+
+    const successRates = percentages && percentages.successRate && {
+      label: "Success rate",
+      color: "#000000",
+      id: "successRate",
+      values: percentages.successRate.map((v) => ({
+        time: new Date(v.date),
+        value: Number(v.percent),
+      })),
+    }
+    
 
     forecasts = forecasts.map((d) => {
       if (this.shouldForecast(d, 100, survey.state == "running")) {
@@ -317,9 +320,6 @@ class SurveyShow extends Component<any, State> {
         return { ...d, forecast: [] }
       }
     })
-
-    let forecastLines = forecasts.filter((d) => d.label !== "Success rate")
-    let successRateLines = forecasts.filter((d) => d.label === "Success rate")
 
     return (
       <div className="cockpit">
@@ -399,16 +399,16 @@ class SurveyShow extends Component<any, State> {
                 )}
               </div>
               <Stats data={stats} />
-              <Forecasts data={forecastLines} ceil={100} />
-              {successRateLines.length ? (
+              <Forecasts data={forecasts} ceil={100} />
+              {successRates && successRates.values.length ? (
                 <div>
                   <div className="header" style={{ marginTop: "40px", marginBottom: "0" }}>
-                    <div className="title">{t("Success Rate")}</div>
+                    <div className="title">{t("Historical Success Rate")}</div>
                     <div className="description">
-                      {t("Estimated by combining initial and current values")}
+                      {t("Actual success rate value throughout the survey's life")}
                     </div>
                   </div>
-                  <SuccessRateLine data={forecasts} />
+                  <SuccessRateLine data={successRates} />
                 </div>
               ) : null}
               {this.showHistograms() ? (

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -403,7 +403,7 @@ class SurveyShow extends Component<any, State> {
               {successRates && successRates.values.length ? (
                 <div>
                   <div className="header" style={{ marginTop: "40px", marginBottom: "0" }}>
-                    <div className="title">{t("Historical Success Rate")}</div>
+                    <div className="title">{t("Success Rate over time")}</div>
                     <div className="description">
                       {t("Actual success rate value throughout the survey's life")}
                     </div>


### PR DESCRIPTION
## Changes
* Remove the forecast for success rate values. We were trying to forecast when will the success rate percentage hit the `100%` ceil. This didn't (and doesn't) make any sense. It was this "forecasted" date the one that was messing around the x-axis, since we were selecting this date as the end-date of the chart.
* Simplify `SuccessRateLine` component by reciving a single data object instead of a list of them. This seems to be a leftover from copying Forecasts component
* Simplify `SurveyShow` component by avoid putting together quota bucket forecasts and success rate values
* Change chart title and subtitle since it was the same as the cockpit chart


### Evidence
**Before**
<img width="1313" alt="image" src="https://github.com/instedd/surveda/assets/13237343/a1ab67af-29bc-462a-bf12-c0f365550e5b">

**After**

<img width="1313" alt="image" src="https://github.com/instedd/surveda/assets/13237343/d88c8c21-9f78-423d-8468-1c730777872b">


closes #2308 