### PR TITLE
Refactor: SurveyCanceller per survey

### DIFF
--- a/lib/ask/activity_log.ex
+++ b/lib/ask/activity_log.ex
@@ -103,7 +103,11 @@ defmodule Ask.ActivityLog do
   defp typeof(%Questionnaire{}), do: "questionnaire"
   defp typeof(%Folder{}), do: "folder"
 
-  defp create(action, project, conn, entity, metadata) do
+  defp create(action, %Project{id: project_id}, conn, entity, metadata) do
+    create(action, project_id, conn, entity, metadata)
+  end
+
+  defp create(action, project_id, conn, entity, metadata) do
     {user_id, remote_ip} =
       case conn do
         nil ->
@@ -119,7 +123,7 @@ defmodule Ask.ActivityLog do
       end
 
     ActivityLog.changeset(%ActivityLog{}, %{
-      project_id: project.id,
+      project_id: project_id,
       user_id: user_id,
       entity_type: typeof(entity),
       entity_id: entity.id,
@@ -299,8 +303,8 @@ defmodule Ask.ActivityLog do
     create("request_cancel", project, conn, survey, %{survey_name: survey.name})
   end
 
-  def completed_cancel(project, conn, survey) do
-    create("completed_cancel", project, conn, survey, %{survey_name: survey.name})
+  def completed_cancel(survey) do
+    create("completed_cancel", survey.project_id, nil, survey, %{survey_name: survey.name})
   end
 
   def create_questionnaire(project, conn, questionnaire) do

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -100,7 +100,7 @@ defmodule Ask.Runtime.SurveyAction do
           {:ok, %{survey: survey}} ->
             survey.project |> Project.touch!()
 
-            SurveyCanceller.cancel(survey.id)
+            SurveyCancellerSupervisor.start_cancelling(survey.id)
 
             {:ok, %{survey: survey}}
 

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -13,7 +13,7 @@ defmodule Ask.Runtime.SurveyAction do
 
   alias Ask.Runtime.{
     ChannelBroker,
-    SurveyCanceller
+    SurveyCancellerSupervisor
   }
 
   alias Ecto.Multi

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -5,14 +5,16 @@ defmodule Ask.Runtime.SurveyAction do
     Repo,
     Questionnaire,
     ActivityLog,
-    SurveyCanceller,
     Project,
     SystemTime,
     Schedule,
     PanelSurvey
   }
 
-  alias Ask.Runtime.ChannelBroker
+  alias Ask.Runtime.{
+    ChannelBroker,
+    SurveyCanceller
+  }
 
   alias Ecto.Multi
 

--- a/lib/ask/runtime/survey_action.ex
+++ b/lib/ask/runtime/survey_action.ex
@@ -98,10 +98,9 @@ defmodule Ask.Runtime.SurveyAction do
           {:ok, %{survey: survey}} ->
             survey.project |> Project.touch!()
 
-            %{consumers_pids: consumers_pids, processes: processes} =
-              SurveyCanceller.start_cancelling(survey.id)
+            SurveyCanceller.cancel(survey.id)
 
-            {:ok, %{survey: survey, cancellers_pids: consumers_pids, processes: processes}}
+            {:ok, %{survey: survey}}
 
           {:error, _, changeset, _} ->
             Logger.warn("Error when stopping survey #{inspect(survey)}")

--- a/lib/ask/runtime/survey_canceller.ex
+++ b/lib/ask/runtime/survey_canceller.ex
@@ -11,10 +11,7 @@ defmodule Ask.Runtime.SurveyCanceller do
     Survey
   }
 
-  alias Ask.Runtime.{
-    Session,
-    SurveyCancellerSupervisor
-  }
+  alias Ask.Runtime.Session
 
   alias Ecto.Multi
 

--- a/lib/ask/runtime/survey_canceller.ex
+++ b/lib/ask/runtime/survey_canceller.ex
@@ -1,4 +1,4 @@
-defmodule Ask.SurveyCanceller do
+defmodule Ask.Runtime.SurveyCanceller do
   use Ecto.Schema
   use GenServer
   import Ecto.Query

--- a/lib/ask/runtime/survey_canceller.ex
+++ b/lib/ask/runtime/survey_canceller.ex
@@ -37,7 +37,7 @@ defmodule Ask.Runtime.SurveyCanceller do
     )
   end
 
-  defp cancel_survey(survey_id) do
+  defp terminate_survey(survey_id) do
     survey = Repo.get(Survey, survey_id)
 
     changeset =
@@ -80,7 +80,7 @@ defmodule Ask.Runtime.SurveyCanceller do
 
     case respondents_to_cancel(survey_id) do
       [] ->
-        cancel_survey(survey_id)
+        terminate_survey(survey_id)
         Logger.info("Finished cancelling survey #{survey_id}")
         {:stop, :normal, nil}
 

--- a/lib/ask/runtime/survey_canceller.ex
+++ b/lib/ask/runtime/survey_canceller.ex
@@ -22,10 +22,6 @@ defmodule Ask.Runtime.SurveyCanceller do
     GenServer.start_link(__MODULE__, survey_id)
   end
 
-  def cancel(survey_id) do
-    SurveyCancellerSupervisor.start_cancelling(survey_id)
-  end
-
   @impl true
   def init(survey_id) do
     :timer.send_after(1000, :cancel)

--- a/lib/ask/runtime/survey_canceller_supervisor.ex
+++ b/lib/ask/runtime/survey_canceller_supervisor.ex
@@ -17,19 +17,25 @@ defmodule Ask.Runtime.SurveyCancellerSupervisor do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
 
+  def start_cancelling(survey_id) do
+    Supervisor.start_child(__MODULE__, canceller_process_spec(survey_id))
+  end
+
+  defp canceller_process_spec(survey_id) do
+    process_name = String.to_atom("SurveyCanceller_#{survey_id}")
+
+    %{
+      id: process_name,
+      start: {SurveyCanceller, :start_link, [survey_id]},
+      restart: :transient
+    }
+  end
+
   @impl true
   def init(_init_arg) do
     processes_to_start =
       SurveyCanceller.surveys_cancelling()
-      |> Enum.map(fn survey_id ->
-        process_name = String.to_atom("SurveyCanceller_#{survey_id}")
-
-        %{
-          id: process_name,
-          start: {SurveyCanceller, :start_link, [survey_id]},
-          restart: :transient
-        }
-      end)
+      |> Enum.map(fn survey_id -> canceller_process_spec(survey_id) end)
 
     Supervisor.init(processes_to_start, strategy: :one_for_one)
   end

--- a/lib/ask/runtime/survey_canceller_supervisor.ex
+++ b/lib/ask/runtime/survey_canceller_supervisor.ex
@@ -1,7 +1,15 @@
 defmodule Ask.Runtime.SurveyCancellerSupervisor do
   alias Ask.Runtime.SurveyCancellerSupervisor
-  alias Ask.SurveyCanceller
+
+  alias Ask.{
+    SurveyCanceller,
+    RespondentsCancellerProducer,
+    RespondentsCancellerConsumer
+  }
+
   use Supervisor
+
+  @default_number_consumers 3
 
   def start_link() do
     SurveyCancellerSupervisor.start_link([])
@@ -11,16 +19,38 @@ defmodule Ask.Runtime.SurveyCancellerSupervisor do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
 
+  defp consumer_name(survey_id, index_number) do
+    String.to_atom("RespondentsCancellerConsumer_#{survey_id}_#{index_number}")
+  end
+
+  defp processes_to_cancel_surveys(survey_ids) do
+    survey_ids
+    |> Enum.flat_map(fn survey_id ->
+      producer_name = String.to_atom("RespondentsCancellerProducer_#{survey_id}")
+
+      [
+        %{id: producer_name, start: {RespondentsCancellerProducer, :start_link, [survey_id]}},
+        # FIXME: parametrizable amount
+        %{
+          id: consumer_name(survey_id, 1),
+          start: {RespondentsCancellerConsumer, :start_link, [producer_name]}
+        },
+        %{
+          id: consumer_name(survey_id, 2),
+          start: {RespondentsCancellerConsumer, :start_link, [producer_name]}
+        },
+        %{
+          id: consumer_name(survey_id, 3),
+          start: {RespondentsCancellerConsumer, :start_link, [producer_name]}
+        }
+      ]
+    end)
+  end
+
   @impl true
   def init(_init_arg) do
-    survey_canceller = SurveyCanceller.start_cancelling(nil)
-
-    case survey_canceller do
-      :ignore ->
-        :ignore
-
-      %SurveyCanceller{processes: processes, consumers_pids: _} ->
-        Supervisor.start_link(processes, strategy: :rest_for_one)
-    end
+    surveys_to_cancel = SurveyCanceller.surveys_cancelling()
+    processes_to_start = processes_to_cancel_surveys(surveys_to_cancel)
+    Supervisor.init(processes_to_start, strategy: :rest_for_one)
   end
 end

--- a/lib/ask/runtime/survey_canceller_supervisor.ex
+++ b/lib/ask/runtime/survey_canceller_supervisor.ex
@@ -21,7 +21,7 @@ defmodule Ask.Runtime.SurveyCancellerSupervisor do
     target_name = canceller_process_name(survey_id)
 
     case Supervisor.which_children(__MODULE__)
-         |> Enum.find(fn {process_name, _, _, _} -> ^target_name = process_name end) do
+         |> Enum.find(fn {children_name, _, _, _} -> children_name == target_name end) do
       {_, pid, _, _} -> pid
       _ -> nil
     end

--- a/lib/ask/runtime/survey_canceller_supervisor.ex
+++ b/lib/ask/runtime/survey_canceller_supervisor.ex
@@ -33,6 +33,11 @@ defmodule Ask.Runtime.SurveyCancellerSupervisor do
     }
   end
 
+  # The SurveyCancellerSupervisor makes sure every cancelling Survey
+  # effectively gets cancelled. Upon startup, it checks and starts a
+  # SurveyCanceller process for each survey pending of cancellation, and
+  # then it also starts new cancellers on demand when a new survey gets
+  # cancelled.
   @impl true
   def init(_init_arg) do
     processes_to_start =

--- a/lib/ask/runtime/survey_canceller_supervisor.ex
+++ b/lib/ask/runtime/survey_canceller_supervisor.ex
@@ -1,7 +1,8 @@
 defmodule Ask.Runtime.SurveyCancellerSupervisor do
-  alias Ask.Runtime.SurveyCancellerSupervisor
-
-  alias Ask.SurveyCanceller
+  alias Ask.Runtime.{
+    SurveyCanceller,
+    SurveyCancellerSupervisor
+  }
 
   use Supervisor
 

--- a/lib/ask/runtime/survey_canceller_supervisor.ex
+++ b/lib/ask/runtime/survey_canceller_supervisor.ex
@@ -1,17 +1,10 @@
 defmodule Ask.Runtime.SurveyCancellerSupervisor do
-  alias Ask.Runtime.{
-    SurveyCanceller,
-    SurveyCancellerSupervisor
-  }
+  alias Ask.Runtime.SurveyCanceller
 
   use Supervisor
 
   def start_link() do
-    SurveyCancellerSupervisor.start_link([])
-  end
-
-  def start_link(init_arg) do
-    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+    Supervisor.start_link(__MODULE__, nil, name: __MODULE__)
   end
 
   defp canceller_process_name(survey_id) do

--- a/lib/ask/survey_respondents_canceller.ex
+++ b/lib/ask/survey_respondents_canceller.ex
@@ -122,7 +122,17 @@ defmodule Ask.RespondentsCancellerConsumer do
 end
 
 defmodule Ask.SurveyCanceller do
-  alias Ask.{RespondentsCancellerConsumer, RespondentsCancellerProducer, Logger}
+  use Ecto.Schema
+  import Ecto.Query
+
+  alias Ask.{
+    Logger,
+    Repo,
+    RespondentsCancellerConsumer,
+    RespondentsCancellerProducer,
+    Survey
+  }
+
   @default_number_consumers 3
 
   defstruct [:processes, :consumers_pids]
@@ -142,6 +152,15 @@ defmodule Ask.SurveyCanceller do
     |> Enum.map(fn name ->
       GenStage.start_link(RespondentsCancellerConsumer, producer_pid, name: name)
     end)
+  end
+
+  def surveys_cancelling() do
+    from(
+      s in Survey,
+      where: s.state == :cancelling,
+      select: s.id
+    )
+    |> Repo.all()
   end
 
   def start_cancelling(survey_id, number_consumers \\ @default_number_consumers) do

--- a/lib/ask/survey_respondents_canceller.ex
+++ b/lib/ask/survey_respondents_canceller.ex
@@ -123,15 +123,103 @@ end
 
 defmodule Ask.SurveyCanceller do
   use Ecto.Schema
+  use GenServer
   import Ecto.Query
 
   alias Ask.{
+    ActivityLog,
     Logger,
+    Project,
     Repo,
+    Respondent,
     RespondentsCancellerConsumer,
     RespondentsCancellerProducer,
     Survey
   }
+
+  alias Ask.Runtime.Session
+  alias Ecto.Multi
+
+  def start_link(survey_id) do
+    GenServer.start_link(__MODULE__, survey_id)
+  end
+
+  @impl true
+  def init(survey_id) do
+    :timer.send_after(1000, :cancel)
+    Logger.info("Starting canceller for survey #{survey_id}")
+    {:ok, survey_id}
+  end
+
+  defp respondents_to_cancel(survey_id) do
+    Repo.all(
+      from(
+        r in Respondent,
+        select: r.id,
+        where: r.state == :active and r.survey_id == ^survey_id,
+        limit: 100
+      )
+    )
+  end
+
+  defp cancel_survey(survey_id) do
+    survey = Repo.get(Survey, survey_id)
+    project = Repo.get!(Project, survey.project_id)
+
+    changeset =
+      Survey.changeset(survey, %{
+        state: "terminated",
+        exit_code: 1,
+        exit_message: "Cancelled by user"
+      })
+
+    Multi.new()
+    |> Multi.update(:survey, changeset)
+    |> Multi.insert(:log, ActivityLog.completed_cancel(project, nil, survey))
+    |> Repo.transaction()
+  end
+
+  defp cancel_respondent(respondent) do
+    if respondent.session != nil do
+      respondent.session
+      |> Session.load()
+      |> Session.cancel()
+    end
+
+    respondent
+    |> Respondent.changeset(%{state: "cancelled", session: nil, timeout_at: nil})
+    |> Repo.update!()
+  end
+
+  defp cancel_respondents(respondent_ids, survey_id) do
+    Logger.debug("Cancelling #{Enum.count(respondent_ids)} respondents for survey #{survey_id}")
+
+    respondent_ids
+    |> Enum.each(fn respondent_id -> Respondent.with_lock(respondent_id, &cancel_respondent/1) end)
+  end
+
+  @impl true
+  def handle_info(:cancel, survey_id) do
+    Logger.info("Canceller handling :cancel (id: #{survey_id})")
+
+    case respondents_to_cancel(survey_id) do
+      [] ->
+        cancel_survey(survey_id)
+        Logger.info("Finished cancelling survey #{survey_id}")
+        {:stop, :normal, nil}
+
+      respondent_ids ->
+        cancel_respondents(respondent_ids, survey_id)
+        :timer.send_after(1000, :cancel)
+        {:noreply, survey_id}
+    end
+  end
+
+  @impl true
+  def handle_info(message, survey_id) do
+    Logger.info("Canceller handling #{message} (id: #{survey_id})")
+    {:noreply, survey_id}
+  end
 
   @default_number_consumers 3
 

--- a/lib/ask/survey_respondents_canceller.ex
+++ b/lib/ask/survey_respondents_canceller.ex
@@ -137,11 +137,19 @@ defmodule Ask.SurveyCanceller do
     Survey
   }
 
-  alias Ask.Runtime.Session
+  alias Ask.Runtime.{
+    Session,
+    SurveyCancellerSupervisor
+  }
+
   alias Ecto.Multi
 
   def start_link(survey_id) do
     GenServer.start_link(__MODULE__, survey_id)
+  end
+
+  def cancel(survey_id) do
+    SurveyCancellerSupervisor.start_cancelling(survey_id)
   end
 
   @impl true

--- a/lib/ask/survey_respondents_canceller.ex
+++ b/lib/ask/survey_respondents_canceller.ex
@@ -6,7 +6,6 @@ defmodule Ask.SurveyCanceller do
   alias Ask.{
     ActivityLog,
     Logger,
-    Project,
     Repo,
     Respondent,
     Survey
@@ -47,7 +46,6 @@ defmodule Ask.SurveyCanceller do
 
   defp cancel_survey(survey_id) do
     survey = Repo.get(Survey, survey_id)
-    project = Repo.get!(Project, survey.project_id)
 
     changeset =
       Survey.changeset(survey, %{
@@ -58,7 +56,7 @@ defmodule Ask.SurveyCanceller do
 
     Multi.new()
     |> Multi.update(:survey, changeset)
-    |> Multi.insert(:log, ActivityLog.completed_cancel(project, nil, survey))
+    |> Multi.insert(:log, ActivityLog.completed_cancel(survey))
     |> Repo.transaction()
   end
 

--- a/lib/ask/survey_respondents_canceller.ex
+++ b/lib/ask/survey_respondents_canceller.ex
@@ -1,126 +1,3 @@
-defmodule Ask.RespondentsCancellerProducer do
-  use Ecto.Schema
-  import Ecto.Query
-  alias Ask.{Respondent, Survey, Repo, ActivityLog, Project}
-  alias Ecto.Multi
-  use GenStage
-
-  def start_link(initial) do
-    GenStage.start_link(__MODULE__, initial, name: __MODULE__)
-  end
-
-  def init(survey_id) when not is_nil(survey_id) do
-    state = %{survey_ids: [survey_id], last_updated_respondent_id: 0}
-    {:producer, state}
-  end
-
-  def init(survey_id) when is_nil(survey_id) do
-    query =
-      from(
-        s in Survey,
-        where: s.state == :cancelling,
-        select: s.id
-      )
-
-    survey_ids =
-      query
-      |> Repo.all()
-
-    case survey_ids do
-      [] ->
-        :ignore
-
-      _ ->
-        state = %{survey_ids: survey_ids, last_updated_respondent_id: 0}
-        {:producer, state}
-    end
-  end
-
-  def handle_demand(_demand, state) do
-    respondent_ids = get_respondents_for_update(state)
-    handle_respondents(respondent_ids, state)
-  end
-
-  def handle_respondents(respondent_ids, state) when length(respondent_ids) > 0 do
-    last_id = List.last(respondent_ids)
-    new_state = %{survey_ids: state.survey_ids, last_updated_respondent_id: last_id}
-    {:noreply, respondent_ids, new_state}
-  end
-
-  def handle_respondents(respondent_ids, state) when length(respondent_ids) == 0 do
-    state.survey_ids
-    |> Enum.each(fn survey_id ->
-      survey = Repo.get(Survey, survey_id)
-      project = Repo.get!(Project, survey.project_id)
-
-      changeset =
-        Survey.changeset(survey, %{
-          state: "terminated",
-          exit_code: 1,
-          exit_message: "Cancelled by user"
-        })
-
-      Multi.new()
-      |> Multi.update(:survey, changeset)
-      |> Multi.insert(:log, ActivityLog.completed_cancel(project, nil, survey))
-      |> Repo.transaction()
-    end)
-
-    {:stop, :normal, state}
-  end
-
-  def get_respondents_for_update(state) do
-    query =
-      from(
-        r in Respondent,
-        select: r.id,
-        where:
-          r.state == :active and r.survey_id in ^state.survey_ids and
-            r.id > ^state.last_updated_respondent_id,
-        limit: 100,
-        order_by: [
-          asc: r.id
-        ]
-      )
-
-    Repo.all(query)
-  end
-end
-
-defmodule Ask.RespondentsCancellerConsumer do
-  use Ecto.Schema
-  alias Ask.{RespondentsCancellerProducer, Respondent, Repo}
-  alias Ask.Runtime.Session
-  use GenStage, restart: :transient
-
-  def start_link(_initial) do
-    GenStage.start_link(__MODULE__, :state, name: __MODULE__)
-  end
-
-  def init(producer_pid) do
-    {:consumer, :state, subscribe_to: [{producer_pid, max_demand: 50, min_demand: 1}]}
-  end
-
-  def handle_events(respondent_ids, _from, state) do
-    respondent_ids
-    |> Enum.each(fn respondent_id -> Respondent.with_lock(respondent_id, &cancel_respondent/1) end)
-
-    {:noreply, [], state}
-  end
-
-  defp cancel_respondent(respondent) do
-    if respondent.session != nil do
-      respondent.session
-      |> Session.load()
-      |> Session.cancel()
-    end
-
-    respondent
-    |> Respondent.changeset(%{state: "cancelled", session: nil, timeout_at: nil})
-    |> Repo.update!()
-  end
-end
-
 defmodule Ask.SurveyCanceller do
   use Ecto.Schema
   use GenServer
@@ -132,8 +9,6 @@ defmodule Ask.SurveyCanceller do
     Project,
     Repo,
     Respondent,
-    RespondentsCancellerConsumer,
-    RespondentsCancellerProducer,
     Survey
   }
 
@@ -229,27 +104,6 @@ defmodule Ask.SurveyCanceller do
     {:noreply, survey_id}
   end
 
-  @default_number_consumers 3
-
-  defstruct [:processes, :consumers_pids]
-
-  defp start_producer(survey_id) do
-    producer_name = String.to_atom("RespondentsCancellerProducer_#{Ecto.UUID.generate()}")
-    GenStage.start_link(RespondentsCancellerProducer, survey_id, name: producer_name)
-  end
-
-  defp start_consumers(number_consumers, producer_pid) do
-    names =
-      Enum.map(1..number_consumers, fn _ ->
-        String.to_atom("RespondentsCancellerConsumer_#{Ecto.UUID.generate()}")
-      end)
-
-    names
-    |> Enum.map(fn name ->
-      GenStage.start_link(RespondentsCancellerConsumer, producer_pid, name: name)
-    end)
-  end
-
   def surveys_cancelling() do
     from(
       s in Survey,
@@ -257,23 +111,5 @@ defmodule Ask.SurveyCanceller do
       select: s.id
     )
     |> Repo.all()
-  end
-
-  def start_cancelling(survey_id, number_consumers \\ @default_number_consumers) do
-    # returns a SurveyCanceller where
-    # * processes is the list of processes started (two-element tuples)
-    # * consumers_pids are only the pids of the consumers
-    Logger.info("Start cancelling survey (id: #{survey_id})")
-    producer = start_producer(survey_id)
-
-    case producer do
-      {:ok, producer_pid} ->
-        consumers = start_consumers(number_consumers, producer_pid)
-        consumers_pids = consumers |> Enum.map(fn {_, pid} -> pid end)
-        %Ask.SurveyCanceller{processes: [producer | consumers], consumers_pids: consumers_pids}
-
-      :ignore ->
-        :ignore
-    end
   end
 end

--- a/lib/ask/survey_respondents_canceller.ex
+++ b/lib/ask/survey_respondents_canceller.ex
@@ -48,11 +48,7 @@ defmodule Ask.SurveyCanceller do
     survey = Repo.get(Survey, survey_id)
 
     changeset =
-      Survey.changeset(survey, %{
-        state: "terminated",
-        exit_code: 1,
-        exit_message: "Cancelled by user"
-      })
+      Survey.changeset(survey, %{ state: "terminated" })
 
     Multi.new()
     |> Multi.update(:survey, changeset)

--- a/lib/ask_web/controllers/survey_controller.ex
+++ b/lib/ask_web/controllers/survey_controller.ex
@@ -388,11 +388,6 @@ defmodule AskWeb.SurveyController do
       |> load_survey(survey_id)
 
     case SurveyAction.stop(survey, conn) do
-      {:ok, %{survey: survey, cancellers_pids: cancellers_pids}} ->
-        conn
-        |> assign(:processors_pids, cancellers_pids)
-        |> render_with_links(survey)
-
       {:ok, %{survey: survey}} ->
         conn
         |> render_with_links(survey)

--- a/test/ask/runtime/survey_broker_test.exs
+++ b/test/ask/runtime/survey_broker_test.exs
@@ -17,7 +17,6 @@ defmodule Ask.Runtime.SurveyBrokerTest do
     Repo,
     Respondent,
     Survey,
-    SurveyLogEntry,
     Schedule,
     RespondentGroupChannel,
     TestChannel,
@@ -1877,14 +1876,4 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       {:DOWN, ^ref, _, _, _} -> :task_is_down
     end
   end
-
-  defp assert_disposition_changed(respondent_id, old_disposition, new_disposition) do
-    last_entry =
-      Repo.one(from log in SurveyLogEntry, where: log.respondent_id == ^respondent_id, where: log.action_type == "disposition changed", order_by: [desc: :id], limit: 1)
-
-    assert last_entry.disposition == to_string(old_disposition)
-    assert last_entry.action_data == upcaseFirst(new_disposition)
-  end
-  defp upcaseFirst(value) when is_atom(value), do: to_string(value) |> upcaseFirst
-  defp upcaseFirst(<<first::utf8, rest::binary>>), do: String.upcase(<<first::utf8>>) <> rest
 end

--- a/test/ask/runtime/survey_canceller_supervisor_test.exs
+++ b/test/ask/runtime/survey_canceller_supervisor_test.exs
@@ -1,0 +1,22 @@
+defmodule Ask.Runtime.SurveyCancellerSupervisorTest do
+  use Ask.DataCase
+  use Timex
+  use Ask.MockTime
+  use Ask.TestHelpers
+
+  alias Ask.Repo
+  alias Ask.Runtime.SurveyCancellerSupervisor
+
+  describe "init" do
+    test "supervisor doesn't init when no surveys are being cancelled" do
+      {:ok, {_, processes}} = SurveyCancellerSupervisor.init([])
+      assert [] = processes
+    end
+
+    test "supervisor starts when surveys to cancel" do
+      build(:survey, state: :cancelling) |> Repo.insert!()
+      {:ok, {_, processes}} = SurveyCancellerSupervisor.init([])
+      assert Enum.count(processes) > 0
+    end
+  end
+end

--- a/test/ask/runtime/survey_test.exs
+++ b/test/ask/runtime/survey_test.exs
@@ -3693,10 +3693,9 @@ defmodule Ask.Runtime.SurveyTest do
 
   defp assert_disposition_changed(respondent_id, old_disposition, new_disposition) do
     last_entry =
-      Repo.all(from log in SurveyLogEntry, where: log.respondent_id == ^respondent_id)
+      Repo.all(from log in SurveyLogEntry, where: log.respondent_id == ^respondent_id, where: log.action_type == "disposition changed")
       |> take_last
 
-    assert last_entry.action_type == "disposition changed"
     assert last_entry.disposition == to_string(old_disposition)
     assert last_entry.action_data == upcaseFirst(new_disposition)
   end

--- a/test/ask/runtime/survey_test.exs
+++ b/test/ask/runtime/survey_test.exs
@@ -3691,15 +3691,6 @@ defmodule Ask.Runtime.SurveyTest do
     respondent_answers(respondent_id, "StoP")
   end
 
-  defp assert_disposition_changed(respondent_id, old_disposition, new_disposition) do
-    last_entry =
-      Repo.all(from log in SurveyLogEntry, where: log.respondent_id == ^respondent_id, where: log.action_type == "disposition changed")
-      |> take_last
-
-    assert last_entry.disposition == to_string(old_disposition)
-    assert last_entry.action_data == upcaseFirst(new_disposition)
-  end
-
   defp assert_last_history_disposition_is(respondent_id, disposition) do
     last_history =
       Repo.all(
@@ -3712,7 +3703,4 @@ defmodule Ask.Runtime.SurveyTest do
   end
 
   defp take_last(records), do: records |> Enum.take(-1) |> hd
-
-  defp upcaseFirst(value) when is_atom(value), do: to_string(value) |> upcaseFirst
-  defp upcaseFirst(<<first::utf8, rest::binary>>), do: String.upcase(<<first::utf8>>) <> rest
 end

--- a/test/ask/survey_canceller_test.exs
+++ b/test/ask/survey_canceller_test.exs
@@ -252,7 +252,7 @@ defmodule Ask.SurveyCancellerTest do
     {:ok, {_, cancellers_to_run}} = SurveyCancellerSupervisor.init(nil)
 
     cancellers_to_run
-    |> Enum.each(fn %{start: {Ask.SurveyCanceller, :start_link, [survey_id]}} ->
+    |> Enum.each(fn %{start: {Ask.Runtime.SurveyCanceller, :start_link, [survey_id]}} ->
       SurveyCancellerSupervisor.start_cancelling(survey_id)
     end)
 

--- a/test/ask/survey_canceller_test.exs
+++ b/test/ask/survey_canceller_test.exs
@@ -270,6 +270,9 @@ defmodule Ask.SurveyCancellerTest do
 
       simulate_survey_canceller_start()
 
+      # first :cancel will cancel all but the failing respondent
+      # second :cancel would have cancelled the survey if not for the failing respondent
+      # we wait for the third :cancel to arrive to be sure that the second :cancel was effectively processed
       wait_for_cancels(survey, 3)
 
       survey = Repo.get(Survey, survey.id)

--- a/test/ask/survey_canceller_test.exs
+++ b/test/ask/survey_canceller_test.exs
@@ -38,7 +38,7 @@ defmodule Ask.SurveyCancellerTest do
     test "stops a survey in cancelling status without its id", %{user: user} do
       project = create_project_for_user(user)
       questionnaire = insert(:questionnaire, name: "test", project: project)
-      survey_1 = insert(:survey, project: project, state: "cancelling")
+      survey_1 = cancelling_survey(project)
       test_channel = TestChannel.new(false)
 
       channel =
@@ -90,8 +90,8 @@ defmodule Ask.SurveyCancellerTest do
     test "stops multiple survey in cancelling status", %{user: user} do
       project = create_project_for_user(user)
       questionnaire = insert(:questionnaire, name: "test", project: project)
-      survey_1 = insert(:survey, project: project, state: "cancelling")
-      survey_2 = insert(:survey, project: project, state: "cancelling")
+      survey_1 = cancelling_survey(project)
+      survey_2 = cancelling_survey(project)
       test_channel = TestChannel.new(false)
 
       channel =
@@ -150,8 +150,8 @@ defmodule Ask.SurveyCancellerTest do
     } do
       project = create_project_for_user(user)
       questionnaire = insert(:questionnaire, name: "test", project: project)
-      survey_1 = insert(:survey, project: project, state: :cancelling)
-      survey_2 = insert(:survey, project: project, state: :cancelling)
+      survey_1 = cancelling_survey(project)
+      survey_2 = cancelling_survey(project)
       survey_3 = insert(:survey, project: project, state: :running)
       test_channel = TestChannel.new(false)
 
@@ -257,5 +257,9 @@ defmodule Ask.SurveyCancellerTest do
     end)
 
     cancellers_to_run
+  end
+
+  defp cancelling_survey(project) do
+    insert(:survey, project: project, state: "cancelling", exit_code: 1)
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -11,7 +11,7 @@ defmodule Ask.TestHelpers do
         ChannelBrokerAgent
       }
 
-      alias Ask.{PanelSurvey, Repo, Respondent, Survey, TestChannel}
+      alias Ask.{PanelSurvey, Repo, Respondent, Survey, SurveyLogEntry, TestChannel}
 
       @foo_string "foo"
       @bar_string "bar"
@@ -150,6 +150,16 @@ defmodule Ask.TestHelpers do
         assert a == active
         assert p == pending
       end
+
+      def assert_disposition_changed(respondent_id, old_disposition, new_disposition) do
+        last_entry =
+          Repo.one(from log in SurveyLogEntry, where: log.respondent_id == ^respondent_id, where: log.action_type == "disposition changed", order_by: [desc: :id], limit: 1)
+
+        assert last_entry.disposition == to_string(old_disposition)
+        assert last_entry.action_data == upcaseFirst(new_disposition)
+      end
+      defp upcaseFirst(value) when is_atom(value), do: to_string(value) |> upcaseFirst
+      defp upcaseFirst(<<first::utf8, rest::binary>>), do: String.upcase(<<first::utf8>>) <> rest
 
       defp broker_poll(), do: SurveyBroker.handle_info(:poll, nil)
 


### PR DESCRIPTION
The old model of a Supervisor + a Canceller that only started Producers and Consumers was not only overly complex, but also buggy (it failed upon app startup - see #2147).

This refactor makes the Supervisor start a single Canceller process per survey that has to be cancelled.

This model should pave the way to turn the Canceller into a SurveyBroker that manages the survey's complete lifecycle in #2331.

Fixes #2147 