### PR TITLE
#2308: Add extra few days in SuccessRateLine if survey is still running

### DIFF
--- a/assets/js/components/charts/SuccessRateLine.jsx
+++ b/assets/js/components/charts/SuccessRateLine.jsx
@@ -68,7 +68,14 @@ export default class SuccessRateLine extends Component<Props> {
         -1
       )
       const oneMonthFromStart = d3.timeMonth.offset(initialTime, 1)
-      lastTime = d3.max([d3.max(data.values, (d) => d.time), oneMonthFromStart])
+      const surveyLastDay = d3.max(data.values, (d) => d.time)
+      // Select lastTime to show as max x-axis value in the chart
+      //
+      // We want the chart to show at least 1 month. 
+      // If the survey is still running and for more than one month already,
+      // we add some extra days to give the sense of incompleteness
+      const lastDay = data.isRunning ? d3.timeDay.offset(surveyLastDay, 5) : surveyLastDay
+      lastTime = d3.max([lastDay, oneMonthFromStart])
     }
 
     const x = d3.scaleTime().domain([initialTime, lastTime]).range([0, width])

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -87,9 +87,13 @@ class SurveyShow extends Component<any, State> {
     }
   }
 
+  surveyIsRunning(survey){
+    return survey && survey.state == "running"
+  }
+
   showHistograms() {
     const { survey } = this.props
-    return survey && survey.state == "running"
+    return this.surveyIsRunning(survey)
   }
 
   stopSurvey() {
@@ -201,7 +205,7 @@ class SurveyShow extends Component<any, State> {
 
     let stopComponent = null
     let switchComponent = null
-    if (!readOnly && survey.state == "running") {
+    if (!readOnly && this.surveyIsRunning(survey)) {
       if (project.level == "owner" || project.level == "admin") {
         let lockOpenClass, lockClass
         if (survey.locked) {
@@ -303,6 +307,7 @@ class SurveyShow extends Component<any, State> {
       label: "Success rate",
       color: "#000000",
       id: "successRate",
+      isRunning: this.surveyIsRunning(survey),
       values: percentages.successRate.map((v) => ({
         time: new Date(v.date),
         value: Number(v.percent),
@@ -311,7 +316,7 @@ class SurveyShow extends Component<any, State> {
     
 
     forecasts = forecasts.map((d) => {
-      if (this.shouldForecast(d, 100, survey.state == "running")) {
+      if (this.shouldForecast(d, 100, this.surveyIsRunning(survey))) {
         return {
           ...d,
           forecast: this.getForecast(d.values[0], d.values[d.values.length - 1], 100),


### PR DESCRIPTION
This is a follow up of #2336 suggestion [comment](https://github.com/instedd/surveda/pull/2336#discussion_r1589656951)

Also, @matiasgarciaisaia [slack comment](https://manas.slack.com/archives/C1L7CJMNU/p1715014678965709?thread_ts=1715012782.365639&cid=C1L7CJMNU) about the x-axis max value 👇 
> We're showing at least one month, but if the survey has been running for, say, 42 days - we show 42 days, then.
My suggestion was to add some extra days (say, 45, 47?) to give the idea of incompleteness.

### Evidence
`survey.state = running` & started less than a month ago
<img width="1289" alt="image" src="https://github.com/instedd/surveda/assets/13237343/f50c091a-e779-45b9-9f3b-fc9a9e17088f"> 

`survey.state = running` & started more than one month ago
<img width="1289" alt="image" src="https://github.com/instedd/surveda/assets/13237343/8f117a78-c820-4ba1-8458-cd0b2e14b11a">

`survey.state = terminated` & started more than one month ago
<img width="1289" alt="image" src="https://github.com/instedd/surveda/assets/13237343/456bf3f2-eb13-4e40-9cff-cf2570c67ece">

for #2308 