### PR TITLE
Fix 'Stop MO' tests

### DIFF
--- a/test/ask/runtime/survey_test.exs
+++ b/test/ask/runtime/survey_test.exs
@@ -3673,13 +3673,13 @@ defmodule Ask.Runtime.SurveyTest do
   end
 
   defp assert_respondent(respondent_id, %{
-    current_state: current_state,
-    previous_disposition: previous_disposition,
-    current_disposition: current_disposition,
-    user_stopped: user_stopped
-    }) do
+         current_state: current_state,
+         previous_disposition: previous_disposition,
+         current_disposition: current_disposition,
+         user_stopped: user_stopped
+       }) do
     respondent = Repo.get!(Respondent, respondent_id)
-      
+
     assert respondent.state == current_state
     assert respondent.disposition == current_disposition
     assert respondent.user_stopped == user_stopped
@@ -3692,7 +3692,9 @@ defmodule Ask.Runtime.SurveyTest do
   end
 
   defp assert_disposition_changed(respondent_id, old_disposition, new_disposition) do
-    last_entry = Repo.all(from log in SurveyLogEntry, where: log.respondent_id == ^respondent_id) |> take_last
+    last_entry =
+      Repo.all(from log in SurveyLogEntry, where: log.respondent_id == ^respondent_id)
+      |> take_last
 
     assert last_entry.action_type == "disposition changed"
     assert last_entry.disposition == to_string(old_disposition)
@@ -3700,7 +3702,12 @@ defmodule Ask.Runtime.SurveyTest do
   end
 
   defp assert_last_history_disposition_is(respondent_id, disposition) do
-    last_history = Repo.all(from history in RespondentDispositionHistory, where: history.respondent_id == ^respondent_id) |> take_last
+    last_history =
+      Repo.all(
+        from history in RespondentDispositionHistory,
+          where: history.respondent_id == ^respondent_id
+      )
+      |> take_last
 
     assert last_history.disposition == to_string(disposition)
   end


### PR DESCRIPTION
## Context
Stop MO tests have been failing erratically.
They have been failing even before changing the `ChannelBroker` to use the `Respondent.with_lock` mutex. [This](https://github.com/instedd/surveda/actions/runs/8757591555/job/24036559070) is an evidence of that

## Discovery
The tests were not filtering by `respondent_id`, so they could be using another records than the intended ones for the assertions.
The tests were using plain `Repo.one!` for fetching `Respondent`, `SurveyLogEntry` and `RespondentDispositionHistory` models. The thing is that Mix runs tests of different modules in parallel and other tests insert records in those tables, so there is no guarantee from the `stop mo` tests that they will be testing the same respondent activity throughout the test

## Observations
I could not replicate the failures locally, so I actually have no guarantee that these changes fix them. However I find this a plausible cause of the failures
Leaving here some other examples of the failures in GHA
 - https://github.com/instedd/surveda/actions/runs/8972247623/job/24641885219
 - https://github.com/instedd/surveda/actions/runs/8819089373/job/24209452986


 