### PR TITLE
Use proxy-forwarded IP address in ActivityLog

### DIFF
--- a/lib/ask/activity_log.ex
+++ b/lib/ask/activity_log.ex
@@ -118,13 +118,9 @@ defmodule Ask.ActivityLog do
 
   defp create(action, project_id, conn, entity, metadata) do
     user_id =
-      if conn do
-        case current_user(conn) do
-          nil -> nil
-          user -> user.id
-        end
-      else
-        nil
+      case current_user(conn) do
+        nil -> nil
+        user -> user.id
       end
 
     remote_ip = remote_ip(conn)

--- a/lib/ask_web/helpers/user_helper.ex
+++ b/lib/ask_web/helpers/user_helper.ex
@@ -4,6 +4,8 @@ defmodule User.Helper do
   alias Ask.{Repo, Project, ProjectMembership}
   alias AskWeb.UnauthorizedError
 
+  def current_user(nil), do: nil
+
   def current_user(conn) do
     case conn.assigns do
       %{current_user: user} -> user


### PR DESCRIPTION
There's no fail-safe way of detecting it[0], but we were logging Rancher internal IPs so far - so it won't be worse than that.

See #2329

[0]: https://adam-p.ca/blog/2022/03/x-forwarded-for/