### PR TITLE
Fix SuccessRateLine chart

### DIFF
--- a/assets/js/components/charts/SuccessRateLine.jsx
+++ b/assets/js/components/charts/SuccessRateLine.jsx
@@ -83,10 +83,12 @@ export default class SuccessRateLine extends Component<Props> {
       .scaleLinear()
       .domain([0, d3.max(data.values, (d) => d.value * 1.2)])
       .range([height, 0])
-    const line = d3
-      .line()
+
+    const area = d3
+      .area()
       .x((d) => x(d.time))
-      .y((d) => y(d.value))
+      .y0(height)
+      .y1((d) => y(d.value))
 
     var tooltip = d3
       .select("body")
@@ -94,7 +96,8 @@ export default class SuccessRateLine extends Component<Props> {
       .classed("forecast-tooltip", true)
       .style("visibility", "hidden")
 
-    for (var j = 1; j < data.values.length - 1; j++) {
+    // add circles
+    for (var j = 0; j < data.values.length ; j++) {
       if (y(data.values[j].value) != 0 && x(data.values[j].time) != 0) {
         d3.select(this.refs.circles)
           .selectAll("path")
@@ -106,7 +109,7 @@ export default class SuccessRateLine extends Component<Props> {
           .attr("r", "3px")
           .style("fill", data.color)
           .style("stroke", data.color)
-          .style("opacity", 0.1)
+          .style("opacity", 0.3)
           .on("mouseover", (d) => {
             tooltip
               .text(percentFormat(d.value / 100))
@@ -117,18 +120,20 @@ export default class SuccessRateLine extends Component<Props> {
           .on("mouseout", () => tooltip.style("visibility", "hidden"))
       }
     }
+      
 
+    // add area
     d3.select(this.refs.values)
       .selectAll("path")
       .data([data])
       .enter()
       .append("path")
       .merge(d3.select(this.refs.values).selectAll("path"))
-      .attr("class", "area")
-      .attr("stroke", (d) => d.color)
-      .attr("fill", (d) => d.color)
+      .attr("stroke", "none")
+      .attr("fill", (d => d.color))
+      .attr("fill-opacity", .2)
       .datum((d) => d.values)
-      .attr("d", line)
+      .attr("d", area)
 
     d3.select(this.refs.x)
       .attr("class", "axis")


### PR DESCRIPTION
## Problem
The colored area of the chart was weird
 
<img width="1309" alt="Screenshot 2024-06-07 at 11 40 02" src="https://github.com/instedd/surveda/assets/13237343/e2fec724-ecbf-4d8a-ac9f-f36a9c2186d0">

## Changes
- use all values (as a leftover of old component we were discarting the first and last element)
- build the area comound by the circle points "by-hand" (instead of just using the "fill" between the line and the points)

### Evidence 
<img width="1309" alt="Screenshot 2024-06-07 at 12 47 49" src="https://github.com/instedd/surveda/assets/13237343/76398e63-01c4-4867-b8ef-5dff7a950ad9">

related to #2308 