### PR TITLE
[workaround] Skip canceller tests

### DIFF
--- a/lib/ask.ex
+++ b/lib/ask.ex
@@ -20,7 +20,6 @@ defmodule Ask do
       supervisor(Registry, [:unique, :channel_broker_registry]),
       worker(Ask.Runtime.ChannelBrokerAgent, []),
       supervisor(Ask.Runtime.ChannelBrokerSupervisor, []),
-      supervisor(Ask.Runtime.SurveyCancellerSupervisor, []),
       {Mutex, name: Ask.Mutex}
       # Start your own worker by calling: Ask.Worker.start_link(arg1, arg2, arg3)
       # worker(Ask.Worker, [arg1, arg2, arg3]),
@@ -45,7 +44,10 @@ defmodule Ask do
             worker(Ask.Config, []),
             worker(Ask.Runtime.QuestionnaireSimulatorStore, [])
             | children
-          ]
+          ] ++ [
+              # SurveyCancellerSupervisor depends on Ask.Repo, so must be started (and declared!) after it
+              supervisor(Ask.Runtime.SurveyCancellerSupervisor, [])
+            ]
 
         true ->
           children

--- a/test/ask/runtime/survey_broker_test.exs
+++ b/test/ask/runtime/survey_broker_test.exs
@@ -936,6 +936,7 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
     @tag :time_mock
     test "stops the survey if it's expired" do
+      start_survey_canceller_supervisor()
       {:ok, now, _} = DateTime.from_iso8601("2021-02-19T00:00:00Z")
       mock_time(now)
       schedule = Schedule.always()

--- a/test/ask/survey_canceller_test.exs
+++ b/test/ask/survey_canceller_test.exs
@@ -35,6 +35,7 @@ defmodule Ask.SurveyCancellerTest do
              ) == 0
     end
 
+    @tag :skip
     test "stops a survey in cancelling status without its id", %{user: user} do
       project = create_project_for_user(user)
       questionnaire = insert(:questionnaire, name: "test", project: project)
@@ -144,6 +145,7 @@ defmodule Ask.SurveyCancellerTest do
       assert_receive [:cancel_message, ^test_channel, %{}]
     end
 
+    @tag :skip
     test "stops multiple surveys from canceller and from controller simultaneously", %{
       conn: conn,
       user: user

--- a/test/ask/survey_canceller_test.exs
+++ b/test/ask/survey_canceller_test.exs
@@ -23,7 +23,7 @@ defmodule Ask.SurveyCancellerTest do
 
   describe "stops surveys as if the application were starting" do
     test "survey canceller does not have pending surveys to cancel" do
-      assert [] = simulate_survey_canceller_start()
+      start_survey_canceller_supervisor()
 
       assert length(
                Repo.all(
@@ -35,7 +35,6 @@ defmodule Ask.SurveyCancellerTest do
              ) == 0
     end
 
-    @tag :skip
     test "stops a survey in cancelling status without its id", %{user: user} do
       project = create_project_for_user(user)
       questionnaire = insert(:questionnaire, name: "test", project: project)
@@ -69,7 +68,7 @@ defmodule Ask.SurveyCancellerTest do
       |> Ask.Respondent.changeset(%{session: session})
       |> Repo.update!()
 
-      simulate_survey_canceller_start()
+      start_survey_canceller_supervisor()
 
       wait_all_cancellations(survey_1)
 
@@ -123,7 +122,7 @@ defmodule Ask.SurveyCancellerTest do
       |> Ask.Respondent.changeset(%{session: session})
       |> Repo.update!()
 
-      simulate_survey_canceller_start()
+      start_survey_canceller_supervisor()
 
       wait_all_cancellations(survey_1)
       wait_all_cancellations(survey_2)
@@ -145,7 +144,6 @@ defmodule Ask.SurveyCancellerTest do
       assert_receive [:cancel_message, ^test_channel, %{}]
     end
 
-    @tag :skip
     test "stops multiple surveys from canceller and from controller simultaneously", %{
       conn: conn,
       user: user
@@ -186,7 +184,7 @@ defmodule Ask.SurveyCancellerTest do
       |> Ask.Respondent.changeset(%{session: session})
       |> Repo.update!()
 
-      simulate_survey_canceller_start()
+      start_survey_canceller_supervisor()
       post(conn, project_survey_survey_path(conn, :stop, survey_3.project, survey_3))
 
       wait_all_cancellations(survey_1)
@@ -270,7 +268,7 @@ defmodule Ask.SurveyCancellerTest do
 
       insert_list(5, :respondent, survey: survey, state: "active", respondent_group: respondent_group)
 
-      simulate_survey_canceller_start()
+      start_survey_canceller_supervisor()
 
       # first :cancel will cancel all but the failing respondent
       # second :cancel would have cancelled the survey if not for the failing respondent
@@ -312,21 +310,6 @@ defmodule Ask.SurveyCancellerTest do
     receive do
       {:DOWN, ^ref, _, _, _reason} -> :task_is_down
     end
-  end
-
-  defp simulate_survey_canceller_start() do
-    # The SurveyCancellerSupervisor is started by mix before running the tests, so calling
-    # `start_link` would error with :already_started
-    # Instead, here we call `init` to check which cancellers should start, and then we start
-    # said cancellers
-    {:ok, {_, cancellers_to_run}} = SurveyCancellerSupervisor.init(nil)
-
-    cancellers_to_run
-    |> Enum.each(fn %{start: {Ask.Runtime.SurveyCanceller, :start_link, [survey_id]}} ->
-      SurveyCancellerSupervisor.start_cancelling(survey_id)
-    end)
-
-    cancellers_to_run
   end
 
   defp cancelling_survey(project) do

--- a/test/ask_web/controllers/survey_controller_test.exs
+++ b/test/ask_web/controllers/survey_controller_test.exs
@@ -2585,6 +2585,7 @@ defmodule AskWeb.SurveyControllerTest do
 
   describe "stopping survey" do
     test "stops survey", %{conn: conn, user: user} do
+      start_survey_canceller_supervisor()
       project = create_project_for_user(user)
       questionnaire = insert(:questionnaire, name: "test", project: project)
       survey = insert(:survey, project: project, state: :running)
@@ -2624,6 +2625,7 @@ defmodule AskWeb.SurveyControllerTest do
     end
 
     test "stops respondents only for the stopped survey", %{conn: conn, user: user} do
+      start_survey_canceller_supervisor() 
       project = create_project_for_user(user)
       questionnaire = insert(:questionnaire, name: "test", project: project)
       survey = insert(:survey, project: project, state: :running)
@@ -2892,6 +2894,7 @@ defmodule AskWeb.SurveyControllerTest do
     end
 
     test "generates logs after stopping a survey", %{conn: conn, user: user} do
+      start_survey_canceller_supervisor()
       project = create_project_for_user(user)
       survey = insert(:survey, project: project, state: :running)
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -5,6 +5,7 @@ defmodule Ask.TestHelpers do
 
       alias Ask.Runtime.{
         SurveyBroker,
+        SurveyCancellerSupervisor,
         Flow,
         RespondentGroupAction,
         ChannelBrokerSupervisor,
@@ -44,6 +45,8 @@ defmodule Ask.TestHelpers do
 
         respondent_groups
       end
+
+      defp start_survey_canceller_supervisor(), do: SurveyCancellerSupervisor.start_link()
 
       defp create_running_survey_with_channel_and_respondents_with_options(options \\ []) do
         steps = Keyword.get(options, :steps, @dummy_steps)


### PR DESCRIPTION
However, there seems to be something odd with the canceller since the tests print these non-test-breaking errors

It seems that we are missing a `handle_cast` implementation on it.
Were these errors always there and we never noticed them? 🤔 

```
2024-06-10T18:10:43.356Z [error] GenServer #PID<0.554.0> terminating
** (FunctionClauseError) no function clause matching in Ecto.Changeset.cast/4
    (ecto 3.9.4) lib/ecto/changeset.ex:497: Ecto.Changeset.cast(nil, %{state: "terminated"}, [:name, :description, :project_id, :folder_id, :mode, :state, :locked, :exit_code, :exit_message, :cutoff, :schedule, :sms_retry_configuration, :ivr_retry_configuration, :mobileweb_retry_configuration, :fallback_delay, :started_at, :quotas, :quota_vars, :comparisons, :count_partial_results, :simulation, :ended_at, :incentives_enabled, :first_window_started_at, :last_window_ends_at, :panel_survey_id, :generates_panel_survey], [])
    (ask 0.31.0) lib/ask/survey.ex:139: Ask.Survey.changeset/2
    (ask 0.31.0) lib/ask/runtime/survey_canceller.ex:44: Ask.Runtime.SurveyCanceller.terminate_survey/1
    (ask 0.31.0) lib/ask/runtime/survey_canceller.ex:83: Ask.Runtime.SurveyCanceller.handle_info/2
    (stdlib 3.12.1.2) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib 3.12.1.2) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib 3.12.1.2) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: :cancel
```