### PR TITLE
Duplicate survey

### DIFF
--- a/assets/js/actions/panelSurvey.js
+++ b/assets/js/actions/panelSurvey.js
@@ -7,7 +7,7 @@ export const RECEIVE = "RECEIVE_PANEL_SURVEY"
 
 export const createPanelSurvey =
   (projectId: number, folderId?: number) => (dispatch: Function, getState: () => Store) =>
-    api.createSurvey(projectId, folderId, true).then((response) => {
+    api.createSurvey(projectId, folderId, { generatesPanelSurvey: true } ).then((response) => {
       const firstWave = response.result
       dispatch(fetch(projectId, firstWave.id))
       dispatch(receive(firstWave))

--- a/assets/js/actions/survey.js
+++ b/assets/js/actions/survey.js
@@ -68,7 +68,7 @@ export const fetchSurvey =
       })
   }
 
-export const duplicateSurvey = (survey) => (dispatch) => {
+export const duplicateSurvey = (survey: Survey) => (dispatch: Function) => {
   return api.duplicateSurvey(survey.projectId, survey.id).then((response) => {
     const newSurvey = response.entities.surveys[response.result]
     dispatch(fetch(newSurvey.projectId, newSurvey.id))

--- a/assets/js/actions/survey.js
+++ b/assets/js/actions/survey.js
@@ -68,6 +68,15 @@ export const fetchSurvey =
       })
   }
 
+export const duplicateSurvey = (survey) => (dispatch) => {
+  return api.duplicateSurvey(survey.projectId, survey.id).then((response) => {
+    const newSurvey = response.entities.surveys[response.result]
+    dispatch(fetch(newSurvey.projectId, newSurvey.id))
+    dispatch(receive(newSurvey))
+    return newSurvey
+  })
+}
+
 export const fetchSurveyStats = (projectId: number, id: number) => (dispatch: Function) => {
   api.fetchSurveyStats(projectId, id).then((stats) => dispatch(receiveSurveyStats(id, stats)))
 }

--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -212,6 +212,10 @@ export const createSurvey = (projectId, folderId, survey) => {
   return apiPostJSON(`projects/${projectId}${folderPath}/surveys`, surveySchema, { survey })
 }
 
+export const duplicateSurvey = (projectId, surveyId) => {
+  return apiPostJSON(`projects/${projectId}/surveys/${surveyId}/duplicate`, surveySchema)
+}
+
 export const deleteSurvey = (projectId, survey) => {
   return apiDelete(`projects/${projectId}/surveys/${survey.id}`)
 }

--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -207,11 +207,9 @@ export const renameFolder = (projectId, folderId, name) => {
   return apiPostJSON(`projects/${projectId}/folders/${folderId}/set_name`, folderSchema, { name })
 }
 
-export const createSurvey = (projectId, folderId, generatesPanelSurvey = false) => {
+export const createSurvey = (projectId, folderId, survey) => {
   let folderPath = folderId ? `/folders/${folderId}` : ""
-  return apiPostJSON(`projects/${projectId}${folderPath}/surveys`, surveySchema, {
-    survey: { generatesPanelSurvey },
-  })
+  return apiPostJSON(`projects/${projectId}${folderPath}/surveys`, surveySchema, { survey })
 }
 
 export const deleteSurvey = (projectId, survey) => {

--- a/assets/js/components/surveys/RespondentsContainer.jsx
+++ b/assets/js/components/surveys/RespondentsContainer.jsx
@@ -43,5 +43,5 @@ export const RespondentsContainer = translate()(({ children, t, incentivesEnable
 RespondentsContainer.propTypes = {
   t: PropTypes.func,
   children: PropTypes.node,
-  incentiveDisabled: PropTypes.boolean,
+  incentivesEnabled: PropTypes.bool,
 }

--- a/assets/js/components/surveys/SurveyCard.jsx
+++ b/assets/js/components/surveys/SurveyCard.jsx
@@ -23,7 +23,7 @@ class _SurveyCard extends Component<any> {
     readOnly: boolean,
   }
 
-  duplicatingSurvey: boolean // FIXME: this should be declared at the Index level (shared between cards)
+  duplicatingSurvey: boolean
 
   constructor(props) {
     super(props)
@@ -52,7 +52,6 @@ class _SurveyCard extends Component<any> {
     const { dispatch, survey } = this.props
     dispatch(surveyActions.duplicateSurvey(survey)).then((newSurvey) => {
       this.duplicatingSurvey = false
-      // FIXME: navigate using the router? it's not available here
       window.location = routes.survey(newSurvey.projectId, newSurvey.id)
     })
   }

--- a/assets/js/components/surveys/SurveyCard.jsx
+++ b/assets/js/components/surveys/SurveyCard.jsx
@@ -23,6 +23,8 @@ class _SurveyCard extends Component<any> {
     readOnly: boolean,
   }
 
+  duplicatingSurvey: boolean // FIXME: this should be declared at the Index level (shared between cards)
+
   constructor(props) {
     super(props)
 
@@ -36,9 +38,24 @@ class _SurveyCard extends Component<any> {
     if (survey.state != "not_ready") {
       fetchRespondentsStats(survey.projectId, survey.id)(dispatch)
     }
+
+    this.duplicatingSurvey = false
   }
 
   changeFolder = (folderId) => this.setState({ folderId })
+
+  duplicateSurvey = () => {
+    // Prevent duplicating multiple surveys at once
+    if (this.duplicatingSurvey) return
+    this.duplicatingSurvey = true
+
+    const { dispatch, survey } = this.props
+    dispatch(surveyActions.duplicateSurvey(survey)).then((newSurvey) => {
+      this.duplicatingSurvey = false
+      // FIXME: navigate using the router? it's not available here
+      window.location = routes.survey(newSurvey.projectId, newSurvey.id)
+    })
+  }
 
   askMoveSurvey = () => {
     const moveSurveyConfirmationModal: ConfirmationModal = this.refs.moveSurveyConfirmationModal
@@ -106,7 +123,9 @@ class _SurveyCard extends Component<any> {
   render() {
     const { survey, t, dispatch } = this.props
 
-    let actions = []
+    let actions = [
+      { name: t("Duplicate"), icon: "content_copy", func: this.duplicateSurvey }
+    ]
     if (this.movable())
       actions.push({ name: t("Move to"), icon: "folder", func: this.askMoveSurvey })
     if (this.deletable())

--- a/lib/ask/runtime/survey_canceller.ex
+++ b/lib/ask/runtime/survey_canceller.ex
@@ -21,7 +21,8 @@ defmodule Ask.Runtime.SurveyCanceller do
 
   @impl true
   def init(survey_id) do
-    :timer.send_after(1000, :cancel)
+    # FIXME: We only care about the :cancel being async, so we use the smallest timeout possible - but this smells bad
+    :timer.send_after(1, :cancel)
     Logger.info("Starting canceller for survey #{survey_id}")
     {:ok, survey_id}
   end

--- a/lib/ask_web/controllers/survey_controller.ex
+++ b/lib/ask_web/controllers/survey_controller.ex
@@ -185,6 +185,9 @@ defmodule AskWeb.SurveyController do
       fn %{id: questionnaire_id, snapshot_of: original_questionnaire_id} -> original_questionnaire_id || questionnaire_id end
     )
 
+  # Duplicate the buckets without their counts and quotas
+  # This is because duplicate surveys will have different respondent groups,
+  # implying different quotas - and no current counts
   defp quota_buckets_definitions(quota_buckets), do:
     Enum.map(quota_buckets, fn %{condition: condition} ->
       %QuotaBucket{condition: condition}

--- a/lib/ask_web/router.ex
+++ b/lib/ask_web/router.ex
@@ -102,6 +102,7 @@ defmodule AskWeb.Router do
           post "/launch", SurveyController, :launch
           post "/stop", SurveyController, :stop
           post "/config", SurveyController, :config
+          post "/duplicate", SurveyController, :duplicate
 
           put "/update_locked_status", SurveyController, :update_locked_status,
             as: :update_locked_status

--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -148,6 +148,7 @@
   "Drop your CSV file here, or click to browse": "",
   "Drop your MP3, WAV, M4A, ACC or MP4 file here, or click to browse": "",
   "Drop your file to start uploading": "",
+  "Duplicate": "",
   "Duplicate questionnaire": "",
   "EDIT QUOTAS": "",
   "Edited <i>{{surveyName}}</i> survey": "",

--- a/test/ask/runtime/survey_canceller_supervisor_test.exs
+++ b/test/ask/runtime/survey_canceller_supervisor_test.exs
@@ -13,10 +13,24 @@ defmodule Ask.Runtime.SurveyCancellerSupervisorTest do
       assert [] = processes
     end
 
-    test "supervisor starts when surveys to cancel" do
-      build(:survey, state: :cancelling) |> Repo.insert!()
+    test "supervisor starts canceller process for single survey to cancel" do
+      %{id: survey_id} = build(:survey, state: :cancelling) |> Repo.insert!()
       {:ok, {_, processes}} = SurveyCancellerSupervisor.init([])
-      assert Enum.count(processes) > 0
+      assert Enum.count(processes) == 1
+      %{ id: canceller_id } = processes |> hd
+      assert survey_canceller_name(survey_id) == canceller_id
+    end
+
+    test "supervisor starts canceller process for multilpe surveys to cancel" do
+      %{id: survey_id_1} = build(:survey, state: :cancelling) |> Repo.insert!()
+      %{id: survey_id_2} = build(:survey, state: :cancelling) |> Repo.insert!()
+      {:ok, {_, processes}} = SurveyCancellerSupervisor.init([])
+      assert Enum.count(processes) == 2
+      canceller_ids = Enum.map(processes, fn %{ id: canceller_id } -> canceller_id end) |> MapSet.new
+      expected_ids = [ survey_canceller_name(survey_id_1), survey_canceller_name(survey_id_2) ] |> MapSet.new
+      assert canceller_ids == expected_ids
     end
   end
+
+  defp survey_canceller_name(survey_id), do: :"SurveyCanceller_#{survey_id}"
 end

--- a/test/ask_web/controllers/survey_controller_test.exs
+++ b/test/ask_web/controllers/survey_controller_test.exs
@@ -1384,6 +1384,20 @@ defmodule AskWeb.SurveyControllerTest do
         post conn, project_survey_survey_path(conn, :duplicate, project, survey)
       end
     end
+
+    test "running survey copies use editable questionnaire", %{ conn: conn, user: user } do
+      project = create_project_for_user(user)
+      questionnaire = insert(:questionnaire)
+      snapshot = insert(:questionnaire, snapshot_of_questionnaire: questionnaire)
+      survey = insert(:survey, project: project, questionnaires: [snapshot])
+
+      conn = post conn, project_survey_survey_path(conn, :duplicate, project, survey)
+
+      new_survey = Repo.get(Survey, json_response(conn, 201)["data"]["id"])
+        |> Repo.preload([:questionnaires])
+
+      assert (new_survey.questionnaires |> hd).id == questionnaire.id
+    end
   end
 
   describe "update" do

--- a/test/ask_web/controllers/survey_controller_test.exs
+++ b/test/ask_web/controllers/survey_controller_test.exs
@@ -1398,6 +1398,26 @@ defmodule AskWeb.SurveyControllerTest do
 
       assert (new_survey.questionnaires |> hd).id == questionnaire.id
     end
+
+    test "finished survey copies don't copy their exit status", %{ conn: conn, user: user } do
+      project = create_project_for_user(user)
+
+      survey =
+        insert(:survey,
+          project: project,
+          state: "terminated",
+          exit_code: 0,
+          exit_message: "Successfully completed"
+        )
+
+      conn = post conn, project_survey_survey_path(conn, :duplicate, project, survey)
+
+      new_survey = Repo.get(Survey, json_response(conn, 201)["data"]["id"])
+
+      assert new_survey.state == :not_ready
+      assert new_survey.exit_code == nil
+      assert new_survey.exit_message == nil
+    end
   end
 
   describe "update" do

--- a/test/ask_web/controllers/survey_controller_test.exs
+++ b/test/ask_web/controllers/survey_controller_test.exs
@@ -1389,7 +1389,7 @@ defmodule AskWeb.SurveyControllerTest do
       project = create_project_for_user(user)
       questionnaire = insert(:questionnaire)
       snapshot = insert(:questionnaire, snapshot_of_questionnaire: questionnaire)
-      survey = insert(:survey, project: project, questionnaires: [snapshot])
+      survey = insert(:survey, project: project, questionnaires: [snapshot], state: :running)
 
       conn = post conn, project_survey_survey_path(conn, :duplicate, project, survey)
 


### PR DESCRIPTION
Allows users to duplicate non-panel surveys.

![Survey card showing the button to duplicate it](https://github.com/user-attachments/assets/fba060c0-fb6a-41a1-a0fd-1424ea5c137c)

Duplicated surveys don't copy the source's sample nor bucket's quotas. Surveys can be copied before, during, and after they run.

Fixes #2351