### PR TITLE
#2343: Log in interaction files on ChannelBroker

### DIFF
--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -439,7 +439,7 @@ defmodule Ask.Runtime.ChannelBroker do
     DateTime.compare(not_after, Ask.SystemTime.time().now) != :gt
   end
 
-  defp log_contact(status, state, respondent) do #channel, mode, respondent, disposition \\ nil) do
+  defp log_contact(status, respondent) do
     session = respondent.session |> Ask.Runtime.Session.load()
     SurveyLogger.log(
       respondent.survey_id,
@@ -454,7 +454,7 @@ defmodule Ask.Runtime.ChannelBroker do
   end
 
   defp ivr_call(state, respondent, token, not_before, not_after) do
-    log_contact("Enqueueing call", state, respondent)
+    log_contact("Enqueueing call", respondent)
 
     response =
       state.runtime_channel
@@ -473,7 +473,7 @@ defmodule Ask.Runtime.ChannelBroker do
   end
 
   defp channel_ask(state, respondent, token, reply) do
-    log_contact("Enqueueing sms", state, respondent)
+    log_contact("Enqueueing sms", respondent)
 
     # FIXME: only needed for tests to pass
     state.runtime_channel

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -439,11 +439,18 @@ defmodule Ask.Runtime.ChannelBroker do
     DateTime.compare(not_after, Ask.SystemTime.time().now) != :gt
   end
 
+  # This guard is only for test purposes
+  defp log_contact(_status, %{session: nil}) do
+    if Mix.env() != :test do
+      raise "Trying to contact a respondent without a session"
+    end
+  end
+
   defp log_contact(status, respondent) do
     session = respondent.session |> Ask.Runtime.Session.load()
     SurveyLogger.log(
       respondent.survey_id,
-      session.current_mode.channel.type,
+      session.flow.mode,
       respondent.id,
       respondent.hashed_number,
       session.current_mode.channel.id,

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -490,8 +490,6 @@ defmodule Ask.Runtime.Session do
       today_end_time
     )
 
-    log_contact("Enqueueing call", channel, flow.mode, respondent)
-
     {:ok, %{session | respondent: respondent}, %Reply{}, current_timeout(session)}
   end
 

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -466,7 +466,6 @@ defmodule Ask.Runtime.Session do
 
   defp mode_start(
          %Session{
-           flow: flow,
            current_mode: %IVRMode{channel: channel},
            respondent: respondent,
            token: token,

--- a/lib/ask/runtime/survey_logger.ex
+++ b/lib/ask/runtime/survey_logger.ex
@@ -62,6 +62,7 @@ defmodule Ask.Runtime.SurveyLogger do
       action_data: action_data,
       timestamp: DateTime.truncate(timestamp, :second)
     }
+    |> SurveyLogEntry.changeset()
     |> Repo.insert!()
 
     {:noreply, state}

--- a/lib/ask/survey_log_entry.ex
+++ b/lib/ask/survey_log_entry.ex
@@ -48,12 +48,12 @@ defmodule Ask.SurveyLogEntry do
   end
   
   defp normalize_mode_field(changeset) do
-    downcase_mode_field = String.downcase(get_field(changeset, :mode))
-    formatted_mode = case downcase_mode_field do
+    mode_field = get_field(changeset, :mode)
+    formatted_mode = case String.downcase(mode_field) do
       "sms" -> "SMS"
       "ivr" -> "IVR"
       "mobileweb" -> "Mobile Web"
-      other -> other
+      _ -> mode_field
     end
     changeset |> put_change(:mode, formatted_mode)
   end

--- a/lib/ask/survey_log_entry.ex
+++ b/lib/ask/survey_log_entry.ex
@@ -41,8 +41,20 @@ defmodule Ask.SurveyLogEntry do
       :action_type,
       :timestamp
     ])
+    |> normalize_mode_field()
     |> foreign_key_constraint(:survey_id)
     |> foreign_key_constraint(:channel_id)
     |> foreign_key_constraint(:respondent_id)
+  end
+  
+  defp normalize_mode_field(changeset) do
+    downcase_mode_field = String.downcase(get_field(changeset, :mode))
+    formatted_mode = case downcase_mode_field do
+      "sms" -> "SMS"
+      "ivr" -> "IVR"
+      "mobileweb" -> "Mobile Web"
+      other -> other
+    end
+    changeset |> put_change(:mode, formatted_mode)
   end
 end

--- a/test/ask/runtime/session_test.exs
+++ b/test/ask/runtime/session_test.exs
@@ -2000,17 +2000,17 @@ defmodule Ask.Runtime.SessionTest do
       survey_logger |> GenServer.stop()
       entries = SurveyLogEntry |> Repo.all()
 
+      first_entry = entries |> Enum.at(0)
+      assert first_entry.action_type == "contact"
+      assert first_entry.action_data == "Answer"
       second_entry = entries |> Enum.at(1)
-      assert second_entry.action_type == "contact"
-      assert second_entry.action_data == "Answer"
+      assert second_entry.action_type == "disposition changed"
+      assert second_entry.disposition == "queued"
+      assert second_entry.action_data == "Contacted"
       third_entry = entries |> Enum.at(2)
-      assert third_entry.action_type == "disposition changed"
-      assert third_entry.disposition == "queued"
-      assert third_entry.action_data == "Contacted"
-      fourth_entry = entries |> Enum.at(3)
-      assert fourth_entry.action_type == "prompt"
-      assert fourth_entry.disposition == "contacted"
-      assert fourth_entry.action_data == "Do you exercise?"
+      assert third_entry.action_type == "prompt"
+      assert third_entry.disposition == "contacted"
+      assert third_entry.action_data == "Do you exercise?"
     end
   end
 

--- a/test/ask/runtime/session_test.exs
+++ b/test/ask/runtime/session_test.exs
@@ -2000,17 +2000,9 @@ defmodule Ask.Runtime.SessionTest do
       survey_logger |> GenServer.stop()
       entries = SurveyLogEntry |> Repo.all()
 
-      first_entry = entries |> Enum.at(0)
-      assert first_entry.action_type == "contact"
-      assert first_entry.action_data == "Answer"
-      second_entry = entries |> Enum.at(1)
-      assert second_entry.action_type == "disposition changed"
-      assert second_entry.disposition == "queued"
-      assert second_entry.action_data == "Contacted"
-      third_entry = entries |> Enum.at(2)
-      assert third_entry.action_type == "prompt"
-      assert third_entry.disposition == "contacted"
-      assert third_entry.action_data == "Do you exercise?"
+      assert entries |> Enum.find(fn e -> e.action_type == "contact" && e.action_data == "Answer" end)
+      assert entries |> Enum.find(fn e -> e.action_type == "disposition changed" && e.action_data == "Contacted" && e.disposition == "queued" end)
+      assert entries |> Enum.find(fn e -> e.action_type == "prompt" && e.action_data == "Do you exercise?" && e.disposition == "contacted" end)
     end
   end
 

--- a/test/ask/runtime/survey_broker_test.exs
+++ b/test/ask/runtime/survey_broker_test.exs
@@ -532,7 +532,7 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       # Second poll, retry the question
       SurveyBroker.handle_info(:poll, nil)
 
-      assert_received [
+      assert_receive [
         :setup,
         ^test_channel,
         %Respondent{sanitized_phone_number: ^phone_number},

--- a/test/ask/runtime/survey_test.exs
+++ b/test/ask/runtime/survey_test.exs
@@ -163,79 +163,72 @@ defmodule Ask.Runtime.SurveyTest do
 
       :ok = logger |> GenServer.stop()
 
-      assert [
-               do_you_smoke,
-               disposition_changed_to_contacted,
-               do_smoke,
-               disposition_changed_to_started,
-               do_you_exercise,
-               do_exercise,
-               second_perfect_number,
-               ninety_nine,
-               question_number,
-               eleven,
-               thank_you,
-               disposition_changed_to_completed
-             ] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      entries = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      [
+        do_you_smoke,
+        do_you_exercise,
+        second_perfect_number,
+        question_number,
+        thank_you
+      ] = entries |> Enum.filter(fn e -> e.action_type == "prompt" end)
+      [
+        do_smoke,
+        do_exercise,
+        ninety_nine,
+        eleven
+      ] = entries |> Enum.filter(fn e -> e.action_type == "response" end)
+      [
+        disposition_changed_to_contacted,
+        disposition_changed_to_started,
+        disposition_changed_to_completed,
+      ] = entries |> Enum.filter(fn e -> e.action_type == "disposition changed" end)
 
       assert do_you_smoke.survey_id == survey.id
       assert do_you_smoke.action_data == "Do you smoke?"
-      assert do_you_smoke.action_type == "prompt"
       assert do_you_smoke.disposition == "queued"
 
       assert disposition_changed_to_contacted.survey_id == survey.id
       assert disposition_changed_to_contacted.action_data == "Contacted"
-      assert disposition_changed_to_contacted.action_type == "disposition changed"
       assert disposition_changed_to_contacted.disposition == "queued"
 
       assert do_smoke.survey_id == survey.id
       assert do_smoke.action_data == "Yes"
-      assert do_smoke.action_type == "response"
       assert do_smoke.disposition == "contacted"
 
       assert disposition_changed_to_started.survey_id == survey.id
       assert disposition_changed_to_started.action_data == "Started"
-      assert disposition_changed_to_started.action_type == "disposition changed"
       assert disposition_changed_to_started.disposition == "contacted"
 
       assert do_you_exercise.survey_id == survey.id
       assert do_you_exercise.action_data == "Do you exercise"
-      assert do_you_exercise.action_type == "prompt"
       assert do_you_exercise.disposition == "started"
 
       assert do_exercise.survey_id == survey.id
       assert do_exercise.action_data == "Yes"
-      assert do_exercise.action_type == "response"
       assert do_exercise.disposition == "started"
 
       assert second_perfect_number.survey_id == survey.id
       assert second_perfect_number.action_data == "Which is the second perfect number?"
-      assert second_perfect_number.action_type == "prompt"
       assert second_perfect_number.disposition == "started"
 
       assert ninety_nine.survey_id == survey.id
       assert ninety_nine.action_data == "99"
-      assert ninety_nine.action_type == "response"
       assert ninety_nine.disposition == "started"
 
       assert question_number.survey_id == survey.id
       assert question_number.action_data == "What's the number of this question?"
-      assert question_number.action_type == "prompt"
       assert question_number.disposition == "started"
 
       assert eleven.survey_id == survey.id
       assert eleven.action_data == "11"
-      assert eleven.action_type == "response"
       assert eleven.disposition == "started"
 
       assert thank_you.survey_id == survey.id
       assert thank_you.action_data == "Thank you"
-      assert thank_you.action_type == "prompt"
       assert thank_you.disposition == "started"
 
       assert disposition_changed_to_completed.survey_id == survey.id
       assert disposition_changed_to_completed.action_data == "Completed"
-      assert disposition_changed_to_completed.action_type == "disposition changed"
       assert disposition_changed_to_completed.disposition == "started"
 
       :ok = broker |> GenServer.stop()
@@ -604,73 +597,67 @@ defmodule Ask.Runtime.SurveyTest do
 
       :ok = logger |> GenServer.stop()
 
-      assert [
-               do_you_smoke,
-               disposition_changed_to_contacted,
-               do_smoke,
-               disposition_changed_to_started,
-               do_you_exercise,
-               do_exercise,
-               second_perfect_number,
-               ninety_nine,
-               question_number,
-               eleven,
-               disposition_changed_to_completed
-             ] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      entries = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      [
+        do_you_smoke,
+        do_you_exercise,
+        second_perfect_number,
+        question_number
+      ] = entries |> Enum.filter(fn e -> e.action_type == "prompt" end)
+      [
+        do_smoke,
+        do_exercise,
+        ninety_nine,
+        eleven
+      ] = entries |> Enum.filter(fn e -> e.action_type == "response" end)
+      [
+        disposition_changed_to_contacted,
+        disposition_changed_to_started,
+        disposition_changed_to_completed,
+      ] = entries |> Enum.filter(fn e -> e.action_type == "disposition changed" end)
 
       assert do_you_smoke.survey_id == survey.id
       assert do_you_smoke.action_data == "Do you smoke?"
-      assert do_you_smoke.action_type == "prompt"
       assert do_you_smoke.disposition == "queued"
 
       assert disposition_changed_to_contacted.survey_id == survey.id
       assert disposition_changed_to_contacted.action_data == "Contacted"
-      assert disposition_changed_to_contacted.action_type == "disposition changed"
       assert disposition_changed_to_contacted.disposition == "queued"
 
       assert do_smoke.survey_id == survey.id
       assert do_smoke.action_data == "Yes"
-      assert do_smoke.action_type == "response"
       assert do_smoke.disposition == "contacted"
 
       assert disposition_changed_to_started.survey_id == survey.id
       assert disposition_changed_to_started.action_data == "Started"
-      assert disposition_changed_to_started.action_type == "disposition changed"
       assert disposition_changed_to_started.disposition == "contacted"
 
       assert do_you_exercise.survey_id == survey.id
       assert do_you_exercise.action_data == "Do you exercise"
-      assert do_you_exercise.action_type == "prompt"
       assert do_you_exercise.disposition == "started"
 
       assert do_exercise.survey_id == survey.id
       assert do_exercise.action_data == "Yes"
-      assert do_exercise.action_type == "response"
       assert do_exercise.disposition == "started"
 
       assert second_perfect_number.survey_id == survey.id
       assert second_perfect_number.action_data == "Which is the second perfect number?"
-      assert second_perfect_number.action_type == "prompt"
       assert second_perfect_number.disposition == "started"
 
       assert ninety_nine.survey_id == survey.id
       assert ninety_nine.action_data == "99"
-      assert ninety_nine.action_type == "response"
       assert ninety_nine.disposition == "started"
 
       assert question_number.survey_id == survey.id
       assert question_number.action_data == "What's the number of this question?"
-      assert question_number.action_type == "prompt"
       assert question_number.disposition == "started"
 
       assert eleven.survey_id == survey.id
       assert eleven.action_data == "11"
-      assert eleven.action_type == "response"
       assert eleven.disposition == "started"
 
       assert disposition_changed_to_completed.survey_id == survey.id
       assert disposition_changed_to_completed.action_data == "Completed"
-      assert disposition_changed_to_completed.action_type == "disposition changed"
       assert disposition_changed_to_completed.disposition == "started"
 
       :ok = broker |> GenServer.stop()
@@ -787,79 +774,73 @@ defmodule Ask.Runtime.SurveyTest do
 
       :ok = logger |> GenServer.stop()
 
-      assert [
-               do_you_smoke,
-               disposition_changed_to_contacted,
-               do_smoke,
-               disposition_changed_to_started,
-               do_you_exercise,
-               do_exercise,
-               second_perfect_number,
-               ninety_nine,
-               question_number,
-               eleven,
-               bye,
-               disposition_changed_to_completed
-             ] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      entries = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+
+      [
+        do_you_smoke,
+        do_you_exercise,
+        second_perfect_number,
+        question_number,
+        bye
+      ] = entries |> Enum.filter(fn e -> e.action_type == "prompt" end)
+      [
+        do_smoke,
+        do_exercise,
+        ninety_nine,
+        eleven
+      ] = entries |> Enum.filter(fn e -> e.action_type == "response" end)
+      [
+        disposition_changed_to_contacted,
+        disposition_changed_to_started,
+        disposition_changed_to_completed,
+      ] = entries |> Enum.filter(fn e -> e.action_type == "disposition changed" end)
 
       assert do_you_smoke.survey_id == survey.id
       assert do_you_smoke.action_data == "Do you smoke?"
-      assert do_you_smoke.action_type == "prompt"
       assert do_you_smoke.disposition == "queued"
 
       assert disposition_changed_to_contacted.survey_id == survey.id
       assert disposition_changed_to_contacted.action_data == "Contacted"
-      assert disposition_changed_to_contacted.action_type == "disposition changed"
       assert disposition_changed_to_contacted.disposition == "queued"
 
       assert do_smoke.survey_id == survey.id
       assert do_smoke.action_data == "Yes"
-      assert do_smoke.action_type == "response"
       assert do_smoke.disposition == "contacted"
 
       assert disposition_changed_to_started.survey_id == survey.id
       assert disposition_changed_to_started.action_data == "Started"
-      assert disposition_changed_to_started.action_type == "disposition changed"
       assert disposition_changed_to_started.disposition == "contacted"
 
       assert do_you_exercise.survey_id == survey.id
       assert do_you_exercise.action_data == "Do you exercise"
-      assert do_you_exercise.action_type == "prompt"
       assert do_you_exercise.disposition == "started"
 
       assert do_exercise.survey_id == survey.id
       assert do_exercise.action_data == "Yes"
-      assert do_exercise.action_type == "response"
       assert do_exercise.disposition == "started"
 
       assert second_perfect_number.survey_id == survey.id
       assert second_perfect_number.action_data == "Which is the second perfect number?"
-      assert second_perfect_number.action_type == "prompt"
       assert second_perfect_number.disposition == "started"
 
       assert ninety_nine.survey_id == survey.id
       assert ninety_nine.action_data == "99"
-      assert ninety_nine.action_type == "response"
       assert ninety_nine.disposition == "started"
 
       assert question_number.survey_id == survey.id
       assert question_number.action_data == "What's the number of this question?"
-      assert question_number.action_type == "prompt"
       assert question_number.disposition == "started"
 
       assert eleven.survey_id == survey.id
       assert eleven.action_data == "11"
-      assert eleven.action_type == "response"
       assert eleven.disposition == "started"
 
       assert bye.survey_id == survey.id
       assert bye.action_data == "Bye"
-      assert bye.action_type == "prompt"
       assert bye.disposition == "started"
 
       assert disposition_changed_to_completed.survey_id == survey.id
       assert disposition_changed_to_completed.action_data == "Completed"
-      assert disposition_changed_to_completed.action_type == "disposition changed"
       assert disposition_changed_to_completed.disposition == "started"
 
       :ok = broker |> GenServer.stop()
@@ -1207,73 +1188,68 @@ defmodule Ask.Runtime.SurveyTest do
 
       :ok = logger |> GenServer.stop()
 
-      assert [
-               do_you_smoke,
-               disposition_changed_to_contacted,
-               foo,
-               disposition_changed_to_started,
-               wrong_answer,
-               do_you_smoke_again,
-               dont_smoke,
-               disposition_changed_to_rejected,
-               satisfaction,
-               dissatisfied,
-               completed
-             ] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      entries = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+
+      [
+        do_you_smoke,
+        wrong_answer,
+        do_you_smoke_again,
+        satisfaction,
+        completed,
+      ] = entries |> Enum.filter(fn e -> e.action_type == "prompt" end)
+      [
+        foo,
+        dont_smoke,
+        dissatisfied,
+      ]= entries |> Enum.filter(fn e -> e.action_type == "response" end)
+      [
+        disposition_changed_to_contacted,
+        disposition_changed_to_started,
+        disposition_changed_to_rejected,
+      ]= entries |> Enum.filter(fn e -> e.action_type == "disposition changed" end)
 
       assert do_you_smoke.survey_id == survey.id
       assert do_you_smoke.action_data == "Do you smoke?"
-      assert do_you_smoke.action_type == "prompt"
       assert do_you_smoke.disposition == "queued"
 
       assert disposition_changed_to_contacted.survey_id == survey.id
       assert disposition_changed_to_contacted.action_data == "Contacted"
-      assert disposition_changed_to_contacted.action_type == "disposition changed"
       assert disposition_changed_to_contacted.disposition == "queued"
 
       assert foo.survey_id == survey.id
       assert foo.action_data == "Foo"
-      assert foo.action_type == "response"
       assert foo.disposition == "contacted"
 
       assert disposition_changed_to_started.survey_id == survey.id
       assert disposition_changed_to_started.action_data == "Started"
-      assert disposition_changed_to_started.action_type == "disposition changed"
       assert disposition_changed_to_started.disposition == "contacted"
 
       assert wrong_answer.survey_id == survey.id
       assert wrong_answer.action_data == "Error"
-      assert wrong_answer.action_type == "prompt"
       assert wrong_answer.disposition == "started"
 
       assert do_you_smoke_again.survey_id == survey.id
       assert do_you_smoke_again.action_data == "Do you smoke?"
-      assert do_you_smoke_again.action_type == "prompt"
       assert do_you_smoke_again.disposition == "started"
 
       assert dont_smoke.survey_id == survey.id
       assert dont_smoke.action_data == "No"
-      assert dont_smoke.action_type == "response"
       assert dont_smoke.disposition == "started"
 
       assert disposition_changed_to_rejected.survey_id == survey.id
       assert disposition_changed_to_rejected.action_data == "Rejected"
-      assert disposition_changed_to_rejected.action_type == "disposition changed"
       assert disposition_changed_to_rejected.disposition == "started"
 
       assert satisfaction.survey_id == survey.id
       assert satisfaction.action_data == "Satisfaction"
-      assert satisfaction.action_type == "prompt"
       assert satisfaction.disposition == "rejected"
 
       assert dissatisfied.survey_id == survey.id
       assert dissatisfied.action_data == "No"
-      assert dissatisfied.action_type == "response"
       assert dissatisfied.disposition == "rejected"
 
       assert completed.survey_id == survey.id
       assert completed.action_data == "Completed"
-      assert completed.action_type == "prompt"
       assert completed.disposition == "rejected"
 
       :ok = broker |> GenServer.stop()
@@ -2092,23 +2068,30 @@ defmodule Ask.Runtime.SurveyTest do
 
     :ok = logger |> GenServer.stop()
 
-    assert [
-             do_you_exercise,
-             disposition_changed_to_contacted,
-             do_exercise,
-             disposition_changed_to_started,
-             disposition_changed_to_completed,
-             thank_you
-           ] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+    entries = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+
+    enqueueing_contact = entries |> Enum.find(fn e -> e.action_type == "contact" end)
+    do_exercise = entries |> Enum.find(fn e -> e.action_type == "response" end)
+    [
+      do_you_exercise,
+      thank_you
+    ] = entries|> Enum.filter(fn e -> e.action_type == "prompt" end)
+    [ 
+      disposition_changed_to_contacted,
+      disposition_changed_to_started,
+      disposition_changed_to_completed,
+    ]  = entries|> Enum.filter(fn e -> e.action_type == "disposition changed" end)
 
     assert do_you_exercise.survey_id == survey.id
     assert do_you_exercise.action_data == "Do you exercise?"
-    assert do_you_exercise.action_type == "prompt"
     assert do_you_exercise.disposition == "queued"
+
+    assert enqueueing_contact.survey_id == survey.id
+    assert enqueueing_contact.action_data == "Enqueueing sms"
+    assert enqueueing_contact.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
     assert disposition_changed_to_contacted.action_data == "Contacted"
-    assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
 
     assert do_exercise.survey_id == survey.id
@@ -2118,17 +2101,14 @@ defmodule Ask.Runtime.SurveyTest do
 
     assert disposition_changed_to_started.survey_id == survey.id
     assert disposition_changed_to_started.action_data == "Started"
-    assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 
     assert disposition_changed_to_completed.survey_id == survey.id
     assert disposition_changed_to_completed.action_data == "Completed"
-    assert disposition_changed_to_completed.action_type == "disposition changed"
     assert disposition_changed_to_completed.disposition == "started"
 
     assert thank_you.survey_id == survey.id
     assert thank_you.action_data == "Thank you"
-    assert thank_you.action_type == "prompt"
     assert thank_you.disposition == "completed"
 
     :ok = broker |> GenServer.stop()
@@ -2356,17 +2336,17 @@ defmodule Ask.Runtime.SurveyTest do
 
     :ok = logger |> GenServer.stop()
 
-    [disposition_changed_to_interim_partial, do_you_exercise] =
+    entries = 
       (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+    disposition_changed_to_interim_partial = entries |> Enum.find(fn e -> e.action_type == "disposition changed" end)
+    do_you_exercise = entries |> Enum.find(fn e -> e.action_type == "prompt" end)
 
     assert disposition_changed_to_interim_partial.survey_id == survey.id
     assert disposition_changed_to_interim_partial.action_data == "Interim partial"
-    assert disposition_changed_to_interim_partial.action_type == "disposition changed"
     assert disposition_changed_to_interim_partial.disposition == "queued"
 
     assert do_you_exercise.survey_id == survey.id
     assert do_you_exercise.action_data == "Do you exercise?"
-    assert do_you_exercise.action_type == "prompt"
     assert do_you_exercise.disposition == "interim partial"
 
     :ok = broker |> GenServer.stop()
@@ -2455,32 +2435,37 @@ defmodule Ask.Runtime.SurveyTest do
 
     :ok = logger |> GenServer.stop()
 
-    [do_exercise, disposition_changed_to_started, disposition_changed_to_refused, bye, thank_you] =
+    entries = 
       (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+    
+    do_exercise = entries |> Enum.find(fn e -> e.action_type == "response" end)
+    [
+      disposition_changed_to_started, 
+      disposition_changed_to_refused
+    ] = entries |> Enum.filter(fn e -> e.action_type == "disposition changed" end)
+    [
+      bye,
+      thank_you
+    ] = entries |> Enum.filter(fn e -> e.action_type == "prompt" end)
 
     assert do_exercise.survey_id == survey.id
     assert do_exercise.action_data == "Yes"
-    assert do_exercise.action_type == "response"
     assert do_exercise.disposition == "queued"
 
     assert disposition_changed_to_started.survey_id == survey.id
     assert disposition_changed_to_started.action_data == "Started"
-    assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "queued"
 
     assert disposition_changed_to_refused.survey_id == survey.id
     assert disposition_changed_to_refused.action_data == "Refused"
-    assert disposition_changed_to_refused.action_type == "disposition changed"
     assert disposition_changed_to_refused.disposition == "started"
 
     assert bye.survey_id == survey.id
     assert bye.action_data == "Bye"
-    assert bye.action_type == "prompt"
     assert bye.disposition == "refused"
 
     assert thank_you.survey_id == survey.id
     assert thank_you.action_data == "Thank you"
-    assert thank_you.action_type == "prompt"
     assert thank_you.disposition == "refused"
 
     :ok = broker |> GenServer.stop()
@@ -3422,22 +3407,21 @@ defmodule Ask.Runtime.SurveyTest do
 
     :ok = logger |> GenServer.stop()
 
-    [enqueueing, channel_failed, disposition_changed_to_failed] =
+    entries =
       (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
+    enqueueing = entries |> Enum.find(fn e -> e.action_data == "Enqueueing call" && e.action_type == "contact" end)
+    channel_failed = entries |> Enum.find(fn e -> e.action_data == "The channel failed" && e.action_type == "contact" end)
+    disposition_changed_to_failed = entries |> Enum.find(fn e -> e.action_type == "disposition changed" end)
+
     assert enqueueing.survey_id == survey.id
-    assert enqueueing.action_data == "Enqueueing call"
-    assert enqueueing.action_type == "contact"
     assert enqueueing.disposition == "queued"
 
     assert channel_failed.survey_id == survey.id
-    assert channel_failed.action_data == "The channel failed"
-    assert channel_failed.action_type == "contact"
     assert channel_failed.disposition == "queued"
 
     assert disposition_changed_to_failed.survey_id == survey.id
     assert disposition_changed_to_failed.action_data == "Failed"
-    assert disposition_changed_to_failed.action_type == "disposition changed"
     assert disposition_changed_to_failed.disposition == "queued"
 
     :ok = broker |> GenServer.stop()
@@ -3497,51 +3481,48 @@ defmodule Ask.Runtime.SurveyTest do
 
     :ok = logger |> GenServer.stop()
 
-    assert [
-             do_you_smoke,
-             disposition_changed_to_contacted,
-             response1,
-             disposition_changed_to_started,
-             response2,
-             response3,
-             disposition_changed_to_breakoff
-           ] =
+    entries = 
              (Repo.get(Respondent, respondent.id)
               |> Repo.preload(:survey_log_entries)).survey_log_entries
 
+    do_you_smoke = entries |> Enum.find(fn e -> e.action_type == "prompt" end)
+    [
+      disposition_changed_to_contacted,
+      disposition_changed_to_started,
+      disposition_changed_to_breakoff
+    ] = entries |> Enum.filter(fn e -> e.action_type == "disposition changed" end)
+    [
+      response1,
+      response2,
+      response3
+    ]  = entries |> Enum.filter(fn e -> e.action_type == "response" end)
+
     assert do_you_smoke.survey_id == survey.id
     assert do_you_smoke.action_data == "Do you smoke?"
-    assert do_you_smoke.action_type == "prompt"
     assert do_you_smoke.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
     assert disposition_changed_to_contacted.action_data == "Contacted"
-    assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
 
     assert response1.survey_id == survey.id
     assert response1.action_data == "1-734-5##-####"
-    assert response1.action_type == "response"
     assert response1.disposition == "contacted"
 
     assert disposition_changed_to_started.survey_id == survey.id
     assert disposition_changed_to_started.action_data == "Started"
-    assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 
     assert response2.survey_id == survey.id
     assert response2.action_data == "fooo (1-734) 5## #### bar"
-    assert response2.action_type == "response"
     assert response2.disposition == "started"
 
     assert response3.survey_id == survey.id
     assert response3.action_data == "fooo (1734) 5##.#### bar"
-    assert response3.action_type == "response"
     assert response3.disposition == "started"
 
     assert disposition_changed_to_breakoff.survey_id == survey.id
     assert disposition_changed_to_breakoff.action_data == "Breakoff"
-    assert disposition_changed_to_breakoff.action_type == "disposition changed"
     assert disposition_changed_to_breakoff.disposition == "started"
 
     :ok = broker |> GenServer.stop()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -190,13 +190,14 @@ defmodule Ask.Factory do
 
     respondent_group = insert(:respondent_group)
     canonical_phone_number = Ask.Respondent.canonicalize_phone_number(phone_number)
-
+    hashed_number = Ask.Respondent.hash_phone_number(phone_number, respondent_group.survey.project.salt)
     %Ask.Respondent{
       respondent_group: respondent_group,
       survey: (respondent_group |> Ask.Repo.preload(:survey)).survey,
       phone_number: phone_number,
       sanitized_phone_number: canonical_phone_number,
-      canonical_phone_number: canonical_phone_number
+      canonical_phone_number: canonical_phone_number,
+      hashed_number: hashed_number,
     }
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -155,12 +155,14 @@ defmodule Ask.TestHelpers do
       end
 
       def assert_disposition_changed(respondent_id, old_disposition, new_disposition) do
-        last_entry =
-          Repo.one(from log in SurveyLogEntry, where: log.respondent_id == ^respondent_id, where: log.action_type == "disposition changed", order_by: [desc: :id], limit: 1)
-
-        assert last_entry.disposition == to_string(old_disposition)
-        assert last_entry.action_data == upcaseFirst(new_disposition)
+        case Repo.one(from log in SurveyLogEntry, where: log.respondent_id == ^respondent_id, where: log.action_type == "disposition changed", order_by: [desc: :id], limit: 1) do
+          nil -> raise "No 'disposition changed' SurveyLogEntry for respondent (id: #{respondent_id})"
+          last_entry -> 
+            assert last_entry.disposition == to_string(old_disposition)
+            assert last_entry.action_data == upcaseFirst(new_disposition)
+        end
       end
+      
       defp upcaseFirst(value) when is_atom(value), do: to_string(value) |> upcaseFirst
       defp upcaseFirst(<<first::utf8, rest::binary>>), do: String.upcase(<<first::utf8>>) <> rest
 


### PR DESCRIPTION
## Changes
Move the responsibility of logging into the interaction fril from the `runtime/session` to `runtime/channel_broker` since is the "last" component of the chain, is who's responsible of actually enqueuing the contacts in the runtime channels

## Collateral changes
 - with these new changes, we are logging into `SurveyLog` the "enqueuing" message both for IVR, SMS and WebMobile. Before it was only recorded for IVR
 - Included the usage of `SurveyLogEntry.changeset()` to validate and normalize the entries
 - As logging it is now the `ChannelBroker` responsibility, which is a different process than the `SurveyBroker`, the entries generated by the SurveyBroker "compete" with the ones generate by the `ChannelBroker`. So, it could happen that two entries get "swapped". 
   - I had to change how we were testing these things to avoid having erratic tests about it
   - 
## Considerations 👀 
~Mobile web surveys contacts will be registered as `sms` mode since the channel being used is an sms one
@manumoreira is this ok? or do we want to have `mobile web` mode listed there?~
Was able to get the real mode by looking into the `session.flow` instead on the channel


closes #2343 