### PR TITLE
Increase CSV downloads' timeout by default

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,10 +18,6 @@ config :phoenix, :json_library, Poison
 config :ask,
   ecto_repos: [Ask.Repo]
 
-if System.get_env("DISABLE_TIMEOUTS") == "true" do
-  config :ask, AskWeb.Endpoint, http: [protocol_options: [idle_timeout: :infinity]]
-end
-
 # Configures the endpoint
 config :ask, AskWeb.Endpoint,
   url: [host: "localhost"],

--- a/lib/ask_web/helpers/csv_helper.ex
+++ b/lib/ask_web/helpers/csv_helper.ex
@@ -1,10 +1,23 @@
 defmodule CSV.Helper do
   import Plug.Conn
   @chunk_lines 100
+  @long_connection_timeout 3_600_000 # in ms
 
-  def csv_stream(conn, rows, filename) do
+  defp connection_timeout(%Plug.Conn{adapter: adapter} = conn, timeout) do
+    case adapter do
+      {Plug.Cowboy.Conn, request} -> :cowboy_req.cast({:set_options, %{ idle_timeout: timeout }}, request)
+      _ -> :ok
+    end
+    conn
+  end
+
+  # TODO: we now want to have long timeouts by default for the CSV files we generate
+  # but we eventually may want to change this to use the default timeout except for
+  # some specific CSV files we know take long
+  def csv_stream(conn, rows, filename, timeout \\ @long_connection_timeout) do
     conn =
       conn
+      |> connection_timeout(timeout)
       |> put_resp_content_type("text/csv")
       |> put_resp_header("content-disposition", "attachment; filename=\"#{filename}\"")
       |> send_chunked(200)


### PR DESCRIPTION
Instead of using an environment variable to remove timeouts for every app's endpoint, we now only increase the download timeout for CSV files to 1 hour - just for those endpoints.

See #2146