### PR TITLE
Setup tests database in `dev-setup` script

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -16,5 +16,6 @@ docker compose run --rm webpack yarn install
 
 echo "$COLOR_LIGHT_BLUE 🧑‍🔧 Setting up database... $COLOR_REST"
 docker compose run --rm app mix ecto.setup
+docker compose run --rm -e MIX_ENV=test app mix ecto.setup
 
 echo "$COLOR_LIGHT_BLUE ✨ Everything ready! $COLOR_REST"


### PR DESCRIPTION
We have at least one old migration that's broken (`AddPromptSmsToQuestionnaireSteps`) since it depends on an app's model that changed. So in order to run the tests, we first need to create the test database from the SQL dump in the repo using `ecto.setup` - for the proper environment.