### PR TITLE
Validate collaborators invited twice

### DIFF
--- a/assets/js/actions/guest.js
+++ b/assets/js/actions/guest.js
@@ -4,7 +4,12 @@ export const SET_CODE = "SET_CODE"
 export const GENERATE_CODE = "GENERATE_CODE"
 export const CLEAR = "CLEAR"
 
-export const changeEmail = (email, collaborators = []) => ({
+export const changeEmail = (email) => (dispatch: Function, getState: () => Store) => {
+  const { items: collaborators } = getState().collaborators
+  return dispatch(validateEmail(email, collaborators))
+}
+
+export const validateEmail = (email, collaborators) => ({
   type: CHANGE_EMAIL,
   email,
   collaborators,

--- a/assets/js/actions/guest.js
+++ b/assets/js/actions/guest.js
@@ -4,9 +4,10 @@ export const SET_CODE = "SET_CODE"
 export const GENERATE_CODE = "GENERATE_CODE"
 export const CLEAR = "CLEAR"
 
-export const changeEmail = (email) => ({
+export const changeEmail = (email, collaborators = []) => ({
   type: CHANGE_EMAIL,
   email,
+  collaborators,
 })
 
 export const changeLevel = (level) => ({

--- a/assets/js/actions/guest.js
+++ b/assets/js/actions/guest.js
@@ -4,12 +4,12 @@ export const SET_CODE = "SET_CODE"
 export const GENERATE_CODE = "GENERATE_CODE"
 export const CLEAR = "CLEAR"
 
-export const changeEmail = (email) => (dispatch: Function, getState: () => Store) => {
+export const updateEmail = (email) => (dispatch: Function, getState: () => Store) => {
   const { items: collaborators } = getState().collaborators
-  return dispatch(validateEmail(email, collaborators))
+  return dispatch(changeEmail(email, collaborators))
 }
 
-export const validateEmail = (email, collaborators) => ({
+export const changeEmail = (email, collaborators) => ({
   type: CHANGE_EMAIL,
   email,
   collaborators,

--- a/assets/js/components/collaborators/CollaboratorIndex.jsx
+++ b/assets/js/components/collaborators/CollaboratorIndex.jsx
@@ -24,16 +24,6 @@ class CollaboratorIndex extends Component {
     $("#addCollaborator").modal("open")
   }
 
-  loadCollaboratorToEdit(event, collaborator) {
-    event.preventDefault()
-    if (collaborator.invited) {
-      this.props.guestActions.changeEmail(collaborator.email)
-      this.props.guestActions.changeLevel(collaborator.role)
-      this.props.guestActions.setCode(collaborator.code)
-      $("#addCollaborator").modal("open")
-    }
-  }
-
   levelChanged(e, collaborator) {
     const { projectId, inviteActions, actions, t } = this.props
     const level = e.target.value
@@ -143,9 +133,8 @@ class CollaboratorIndex extends Component {
           modalId="addCollaborator"
           modalText={t("The access of project collaborators will be managed through roles")}
           header={t("Invite collaborators")}
-          confirmationText={t("Accept")}
-          onConfirm={(event) => event.preventDefault()}
           style={{ maxWidth: "800px" }}
+          collaborators={collaborators}
         />
         <div>
           <CardTable title={title}>

--- a/assets/js/components/collaborators/CollaboratorIndex.jsx
+++ b/assets/js/components/collaborators/CollaboratorIndex.jsx
@@ -134,7 +134,6 @@ class CollaboratorIndex extends Component {
           modalText={t("The access of project collaborators will be managed through roles")}
           header={t("Invite collaborators")}
           style={{ maxWidth: "800px" }}
-          collaborators={collaborators}
         />
         <div>
           <CardTable title={title}>

--- a/assets/js/components/collaborators/InviteModal.jsx
+++ b/assets/js/components/collaborators/InviteModal.jsx
@@ -97,7 +97,7 @@ export class InviteModal extends Component {
       </a>
     )
 
-    const emailError = this.getEmailError(guest);
+    const emailError = this.getEmailError(guest)
 
     const sendButton =
       guest.data.code && !emailError ? (
@@ -191,19 +191,19 @@ export class InviteModal extends Component {
   }
 
   getEmailError(guest) {
-    let errorCode = "invalid-email";
+    let errorCode = "invalid-email"
     if (guest.data.email) {
       errorCode = guest.errors.email
     }
 
     switch (errorCode) {
       case null:
-        return null;
+        return null
       case "existing-email":
-        return "Email already in project";
+        return "User is already a member"
       case "invalid-email":
       default:
-        return "Please enter a valid email";
+        return "Please enter a valid email"
     }
   }
 }
@@ -223,7 +223,6 @@ InviteModal.propTypes = {
   projectId: PropTypes.number,
   style: PropTypes.object,
   userLevel: PropTypes.string,
-  collaborators: PropTypes.array,
 }
 
 const mapDispatchToProps = (dispatch) => ({

--- a/assets/js/components/collaborators/InviteModal.jsx
+++ b/assets/js/components/collaborators/InviteModal.jsx
@@ -32,7 +32,7 @@ export class InviteModal extends Component {
   }
 
   emailOnChange(e) {
-    this.props.guestActions.changeEmail(e.target.value, this.props.collaborators)
+    this.props.guestActions.changeEmail(e.target.value)
   }
 
   emailOnBlur(e) {
@@ -42,7 +42,7 @@ export class InviteModal extends Component {
       return
     }
     if (newEmail != config.user) {
-      Promise.resolve(this.props.guestActions.changeEmail(newEmail, this.props.collaborators)).then(() => {
+      Promise.resolve(this.props.guestActions.changeEmail(newEmail)).then(() => {
         Promise.resolve(
           this.props.actions.getInviteByEmailAndProject(projectId, guest.data.email)
         ).then((dbGuest) => {

--- a/assets/js/components/collaborators/InviteModal.jsx
+++ b/assets/js/components/collaborators/InviteModal.jsx
@@ -236,7 +236,6 @@ const mapStateToProps = (state) => ({
   projectId: state.project.data.id,
   userLevel: state.project.data.level,
   guest: state.guest,
-  collaborators: state.collaborators.items,
 })
 
 export default translate()(connect(mapStateToProps, mapDispatchToProps)(InviteModal))

--- a/assets/js/components/collaborators/InviteModal.jsx
+++ b/assets/js/components/collaborators/InviteModal.jsx
@@ -32,7 +32,7 @@ export class InviteModal extends Component {
   }
 
   emailOnChange(e) {
-    this.props.guestActions.changeEmail(e.target.value)
+    this.props.guestActions.updateEmail(e.target.value)
   }
 
   emailOnBlur(e) {
@@ -42,7 +42,7 @@ export class InviteModal extends Component {
       return
     }
     if (newEmail != config.user) {
-      Promise.resolve(this.props.guestActions.changeEmail(newEmail)).then(() => {
+      Promise.resolve(this.props.guestActions.updateEmail(newEmail)).then(() => {
         Promise.resolve(
           this.props.actions.getInviteByEmailAndProject(projectId, guest.data.email)
         ).then((dbGuest) => {

--- a/assets/js/components/collaborators/InviteModal.jsx
+++ b/assets/js/components/collaborators/InviteModal.jsx
@@ -152,7 +152,7 @@ export class InviteModal extends Component {
                   </InputWithLabel>
                   {emailError ? (
                     <span className="small-text-bellow text-error">
-                      {t(emailError)}
+                      {emailError}
                     </span>
                   ) : (
                     <span />
@@ -191,6 +191,7 @@ export class InviteModal extends Component {
   }
 
   getEmailError(guest) {
+    const { t } = this.props
     let errorCode = "invalid-email"
     if (guest.data.email) {
       errorCode = guest.errors.email
@@ -200,10 +201,10 @@ export class InviteModal extends Component {
       case null:
         return null
       case "existing-email":
-        return "User is already a member"
+        return t("User is already a member")
       case "invalid-email":
       default:
-        return "Please enter a valid email"
+        return t("Please enter a valid email")
     }
   }
 }

--- a/assets/js/components/collaborators/InviteModal.jsx
+++ b/assets/js/components/collaborators/InviteModal.jsx
@@ -32,7 +32,7 @@ export class InviteModal extends Component {
   }
 
   emailOnChange(e) {
-    this.props.guestActions.changeEmail(e.target.value)
+    this.props.guestActions.changeEmail(e.target.value, this.props.collaborators)
   }
 
   emailOnBlur(e) {
@@ -42,7 +42,7 @@ export class InviteModal extends Component {
       return
     }
     if (newEmail != config.user) {
-      Promise.resolve(this.props.guestActions.changeEmail(newEmail)).then(() => {
+      Promise.resolve(this.props.guestActions.changeEmail(newEmail, this.props.collaborators)).then(() => {
         Promise.resolve(
           this.props.actions.getInviteByEmailAndProject(projectId, guest.data.email)
         ).then((dbGuest) => {
@@ -97,10 +97,10 @@ export class InviteModal extends Component {
       </a>
     )
 
-    const validEmail = guest.data.email && !guest.errors.email
+    const emailError = this.getEmailError(guest);
 
     const sendButton =
-      guest.data.code && validEmail ? (
+      guest.data.code && !emailError ? (
         <a
           href="#!"
           className=" modal-action modal-close waves-effect btn-medium blue"
@@ -150,9 +150,9 @@ export class InviteModal extends Component {
                       }}
                     />
                   </InputWithLabel>
-                  {!validEmail ? (
+                  {emailError ? (
                     <span className="small-text-bellow text-error">
-                      {t("Please enter a valid email")}
+                      {t(emailError)}
                     </span>
                   ) : (
                     <span />
@@ -189,6 +189,23 @@ export class InviteModal extends Component {
       </Modal>
     )
   }
+
+  getEmailError(guest) {
+    let errorCode = "invalid-email";
+    if (guest.data.email) {
+      errorCode = guest.errors.email
+    }
+
+    switch (errorCode) {
+      case null:
+        return null;
+      case "existing-email":
+        return "Email already in project";
+      case "invalid-email":
+      default:
+        return "Please enter a valid email";
+    }
+  }
 }
 
 InviteModal.propTypes = {
@@ -202,12 +219,11 @@ InviteModal.propTypes = {
   linkText: PropTypes.string,
   header: PropTypes.string.isRequired,
   modalText: PropTypes.string.isRequired,
-  confirmationText: PropTypes.string.isRequired,
-  onConfirm: PropTypes.func.isRequired,
   modalId: PropTypes.string.isRequired,
   projectId: PropTypes.number,
   style: PropTypes.object,
   userLevel: PropTypes.string,
+  collaborators: PropTypes.array,
 }
 
 const mapDispatchToProps = (dispatch) => ({
@@ -220,6 +236,7 @@ const mapStateToProps = (state) => ({
   projectId: state.project.data.id,
   userLevel: state.project.data.level,
   guest: state.guest,
+  collaborators: state.collaborators.items,
 })
 
 export default translate()(connect(mapStateToProps, mapDispatchToProps)(InviteModal))

--- a/assets/js/reducers/guest.js
+++ b/assets/js/reducers/guest.js
@@ -34,14 +34,14 @@ const validEmail = (email) => {
 }
 
 const changeEmail = (state, action) => {
-  const { email, collaborators } = action;
-  let emailError = null;
+  const { email, collaborators } = action
+  let emailError = null
   if (!validEmail(email)) {
-    emailError = "invalid-email";
+    emailError = "invalid-email"
   } else {
-    const collaborator = collaborators.find((c) => c.email === email);
+    const collaborator = collaborators.find((c) => c.email === email)
     if (collaborator) {
-      emailError = "existing-email";
+      emailError = "existing-email"
     }
   }
   return {
@@ -51,7 +51,7 @@ const changeEmail = (state, action) => {
       email: action.email,
     },
     errors: {
-      ...state.errors,  
+      ...state.errors,
       email: emailError,
     },
   }

--- a/assets/js/reducers/guest.js
+++ b/assets/js/reducers/guest.js
@@ -34,6 +34,16 @@ const validEmail = (email) => {
 }
 
 const changeEmail = (state, action) => {
+  const { email, collaborators } = action;
+  let emailError = null;
+  if (!validEmail(email)) {
+    emailError = "invalid-email";
+  } else {
+    const collaborator = collaborators.find((c) => c.email === email);
+    if (collaborator) {
+      emailError = "existing-email";
+    }
+  }
   return {
     ...state,
     data: {
@@ -41,8 +51,8 @@ const changeEmail = (state, action) => {
       email: action.email,
     },
     errors: {
-      ...state.errors,
-      email: !validEmail(action.email),
+      ...state.errors,  
+      email: emailError,
     },
   }
 }

--- a/config/test.exs
+++ b/config/test.exs
@@ -44,7 +44,7 @@ config :ask, Verboice,
     app_id: "AN_APP_ID"
   ]
 
-config :ask, Ask.Mailer, adapter: Swoosh.Adapters.Test
+config :ask, Ask.Mailer, adapter: Ask.Swoosh.Adapters.Test
 
 config :ask, AskWeb.Email,
   smtp_from_address: {:system, "SMTP_FROM_ADDRESS", "Test name <test@email>"}

--- a/config/test.exs
+++ b/config/test.exs
@@ -44,7 +44,7 @@ config :ask, Verboice,
     app_id: "AN_APP_ID"
   ]
 
-config :ask, Ask.Mailer, adapter: Ask.Swoosh.Adapters.Test
+config :ask, Ask.Mailer, adapter: Swoosh.Adapters.Test
 
 config :ask, AskWeb.Email,
   smtp_from_address: {:system, "SMTP_FROM_ADDRESS", "Test name <test@email>"}

--- a/locales/template/translation.json
+++ b/locales/template/translation.json
@@ -526,6 +526,7 @@
   "Use SHIFT+ENTER to split in multiple parts": "",
   "Use different expressions in order to standardize the source phone number.": "",
   "User": "",
+  "User is already a member": "",
   "Valid entries": "",
   "Value \"{{value}}\" already used in a previous response": "",
   "Value already used in a previous response": "",

--- a/test/ask_web/controllers/invite_controller_test.exs
+++ b/test/ask_web/controllers/invite_controller_test.exs
@@ -1071,7 +1071,7 @@ defmodule AskWeb.InviteControllerTest do
     end
   end
 
-  test "send invite to existing user", %{conn: conn, user: user} do
+  test "send invite to new user", %{conn: conn, user: user} do
     project = create_project_for_user(user)
     code = "ABC1234"
     level = "reader"
@@ -1090,5 +1090,29 @@ defmodule AskWeb.InviteControllerTest do
     assert_email_sent(subject: "#{user.name} has invited you to collaborate on #{project.name}.")
 
     assert json_response(conn, 200)
+  end
+
+  test "send invite to existing user", %{conn: conn, user: user} do
+    project = create_project_for_user(user)
+    code = "ABC1234"
+    level = "reader"
+    email = "user@instedd.org"
+
+    user2 = insert(:user, email: email)
+    insert(:project_membership, user_id: user2.id, project_id: project.id, level: "editor")
+
+    conn = get(
+      conn,
+      send_invitation_path(conn, :send_invitation, %{
+        "code" => code,
+        "level" => level,
+        "email" => user2.email,
+        "project_id" => project.id
+      })
+    )
+
+    assert_email_sent(subject: "#{user.name} has added you as a collaborator on #{project.name}.")
+
+    assert json_response(conn, 422)
   end
 end

--- a/test/ask_web/controllers/invite_controller_test.exs
+++ b/test/ask_web/controllers/invite_controller_test.exs
@@ -1089,7 +1089,7 @@ defmodule AskWeb.InviteControllerTest do
 
     assert json_response(conn, 200)
 
-    email_message = wait_for_email()
+    assert_received [:email, email_message]
 
     assert email_message.subject == "#{user.name} has invited you to collaborate on #{project.name}."
   end
@@ -1113,7 +1113,7 @@ defmodule AskWeb.InviteControllerTest do
 
     assert json_response(conn, 200)
 
-    email_message = wait_for_email()
+    assert_received [:email, email_message]
 
     assert email_message.subject == "#{user.name} has invited you to collaborate on #{project.name}."
 
@@ -1176,11 +1176,5 @@ defmodule AskWeb.InviteControllerTest do
     assert json_response(conn, 422)["errors"]["user_id"] == ["User already in project"]
 
     refute_received [:email, _email]
-  end
-
-  defp wait_for_email do
-    receive do
-      [:email, email] -> email
-    end
   end
 end

--- a/test/ask_web/controllers/invite_controller_test.exs
+++ b/test/ask_web/controllers/invite_controller_test.exs
@@ -1095,7 +1095,7 @@ defmodule AskWeb.InviteControllerTest do
   end
 
   test "send invite to existing user", %{conn: conn, user: user} do
-    Process.register self(), :mail_target
+    Process.register(self(), :mail_target)
     project = create_project_for_user(user)
     code = "ABC1234"
     level = "reader"

--- a/test/ask_web/controllers/invite_controller_test.exs
+++ b/test/ask_web/controllers/invite_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule AskWeb.InviteControllerTest do
   import Ecto.Query
+  import Swoosh.TestAssertions
 
   use AskWeb.ConnCase
   use Ask.TestHelpers
@@ -1068,5 +1069,26 @@ defmodule AskWeb.InviteControllerTest do
         invite_remove_path(conn, :remove, %{"project_id" => project.id, "email" => email})
       )
     end
+  end
+
+  test "send invite to existing user", %{conn: conn, user: user} do
+    project = create_project_for_user(user)
+    code = "ABC1234"
+    level = "reader"
+    email = "user@instedd.org"
+
+    conn = get(
+      conn,
+      send_invitation_path(conn, :send_invitation, %{
+        "code" => code,
+        "level" => level,
+        "email" => email,
+        "project_id" => project.id
+      })
+    )
+
+    assert_email_sent(subject: "#{user.name} has invited you to collaborate on #{project.name}.")
+
+    assert json_response(conn, 200)
   end
 end

--- a/test/js/reducers/guest.spec.js
+++ b/test/js/reducers/guest.spec.js
@@ -4,7 +4,6 @@ import expect from 'expect'
 import assert from 'assert'
 import reducer from '../../../assets/js/reducers/guest'
 import * as actions from '../../../assets/js/actions/guest'
-import { exec } from 'child_process'
 
 describe('guest reducer', () => {
   const initialState = reducer(undefined, {})

--- a/test/js/reducers/guest.spec.js
+++ b/test/js/reducers/guest.spec.js
@@ -105,4 +105,23 @@ describe('guest reducer', () => {
     ])
     assert(!result.errors.email)
   })
+
+  const emails = ['info@instedd.com', 'email@instedd.com', 'user@instedd.com']
+  const collaborators = emails.map((email) => ({ email }))
+
+  emails.map((email) => 
+    it(`generate an error when ${email} is a collaborator`, () => {
+      const result = playActions([
+        actions.changeEmail(email, collaborators)
+      ])
+      assert(result.errors.email)
+    })
+  )
+
+  it('does not generate an error if email is not a collaborator', () => {
+    const result = playActions([
+      actions.changeEmail('test@instedd.com', collaborators)
+    ])
+    assert(!result.errors.email)
+  })
 })

--- a/test/js/reducers/guest.spec.js
+++ b/test/js/reducers/guest.spec.js
@@ -4,6 +4,7 @@ import expect from 'expect'
 import assert from 'assert'
 import reducer from '../../../assets/js/reducers/guest'
 import * as actions from '../../../assets/js/actions/guest'
+import { exec } from 'child_process'
 
 describe('guest reducer', () => {
   const initialState = reducer(undefined, {})
@@ -11,7 +12,7 @@ describe('guest reducer', () => {
 
   it('should change email', () => {
     const email = 'user@instedd.org'
-    const result = playActions([actions.changeEmail(email)])
+    const result = playActions([actions.validateEmail(email, [])])
     expect(result.data.email).toEqual(email)
   })
 
@@ -35,7 +36,7 @@ describe('guest reducer', () => {
 
   it('should clear values', () => {
     const result = playActions([
-      actions.changeEmail('user@instedd.org'),
+      actions.validateEmail('user@instedd.org', []),
       actions.changeLevel('editor'),
       actions.clear()
     ])
@@ -54,7 +55,7 @@ describe('guest reducer', () => {
 
   it('does not generate code if level is not present', () => {
     const result = playActions([
-      actions.changeEmail('user@instedd.org'),
+      actions.validateEmail('user@instedd.org', []),
       actions.generateCode()
     ])
     expect(result.data.code).toEqual('')
@@ -62,7 +63,7 @@ describe('guest reducer', () => {
 
   it('does not generates code if email is invalid', () => {
     const result = playActions([
-      actions.changeEmail('invalid-email.com'),
+      actions.validateEmail('invalid-email.com', []),
       actions.changeLevel('editor'),
       actions.generateCode()
     ])
@@ -71,7 +72,7 @@ describe('guest reducer', () => {
 
   it('generates code if email is valid and level is present', () => {
     const result = playActions([
-      actions.changeEmail('email@instedd.org'),
+      actions.validateEmail('email@instedd.org', []),
       actions.changeLevel('editor'),
       actions.generateCode()
     ])
@@ -80,28 +81,28 @@ describe('guest reducer', () => {
 
   it('generates an error if email is invalid: two consecutive dots', () => {
     const result = playActions([
-      actions.changeEmail('invalid..email@instedd.com')
+      actions.validateEmail('invalid..email@instedd.com', [])
     ])
-    assert(result.errors.email)
+    expect(result.errors.email).toEqual("invalid-email")
   })
 
   it('generates an error if email is invalid: no @ symbol', () => {
     const result = playActions([
-      actions.changeEmail('email.com')
+      actions.validateEmail('email.com', [])
     ])
-    assert(result.errors.email)
+    expect(result.errors.email).toEqual("invalid-email")
   })
 
   it('generates an error if email is invalid: finishes with period', () => {
     const result = playActions([
-      actions.changeEmail('email@instedd.')
+      actions.validateEmail('email@instedd.', [])
     ])
-    assert(result.errors.email)
+    expect(result.errors.email).toEqual("invalid-email")
   })
 
   it('does not generate an error if email is valid', () => {
     const result = playActions([
-      actions.changeEmail('valid.email@instedd.com')
+      actions.validateEmail('valid.email@instedd.com', [])
     ])
     assert(!result.errors.email)
   })
@@ -112,15 +113,15 @@ describe('guest reducer', () => {
   emails.map((email) => 
     it(`generate an error when ${email} is a collaborator`, () => {
       const result = playActions([
-        actions.changeEmail(email, collaborators)
+        actions.validateEmail(email, collaborators)
       ])
-      assert(result.errors.email)
+      expect(result.errors.email).toEqual("existing-email")
     })
   )
 
   it('does not generate an error if email is not a collaborator', () => {
     const result = playActions([
-      actions.changeEmail('test@instedd.com', collaborators)
+      actions.validateEmail('test@instedd.com', collaborators)
     ])
     assert(!result.errors.email)
   })

--- a/test/js/reducers/guest.spec.js
+++ b/test/js/reducers/guest.spec.js
@@ -11,7 +11,7 @@ describe('guest reducer', () => {
 
   it('should change email', () => {
     const email = 'user@instedd.org'
-    const result = playActions([actions.validateEmail(email, [])])
+    const result = playActions([actions.changeEmail(email, [])])
     expect(result.data.email).toEqual(email)
   })
 
@@ -35,7 +35,7 @@ describe('guest reducer', () => {
 
   it('should clear values', () => {
     const result = playActions([
-      actions.validateEmail('user@instedd.org', []),
+      actions.changeEmail('user@instedd.org', []),
       actions.changeLevel('editor'),
       actions.clear()
     ])
@@ -54,7 +54,7 @@ describe('guest reducer', () => {
 
   it('does not generate code if level is not present', () => {
     const result = playActions([
-      actions.validateEmail('user@instedd.org', []),
+      actions.changeEmail('user@instedd.org', []),
       actions.generateCode()
     ])
     expect(result.data.code).toEqual('')
@@ -62,7 +62,7 @@ describe('guest reducer', () => {
 
   it('does not generates code if email is invalid', () => {
     const result = playActions([
-      actions.validateEmail('invalid-email.com', []),
+      actions.changeEmail('invalid-email.com', []),
       actions.changeLevel('editor'),
       actions.generateCode()
     ])
@@ -71,7 +71,7 @@ describe('guest reducer', () => {
 
   it('generates code if email is valid and level is present', () => {
     const result = playActions([
-      actions.validateEmail('email@instedd.org', []),
+      actions.changeEmail('email@instedd.org', []),
       actions.changeLevel('editor'),
       actions.generateCode()
     ])
@@ -80,28 +80,28 @@ describe('guest reducer', () => {
 
   it('generates an error if email is invalid: two consecutive dots', () => {
     const result = playActions([
-      actions.validateEmail('invalid..email@instedd.com', [])
+      actions.changeEmail('invalid..email@instedd.com', [])
     ])
     expect(result.errors.email).toEqual("invalid-email")
   })
 
   it('generates an error if email is invalid: no @ symbol', () => {
     const result = playActions([
-      actions.validateEmail('email.com', [])
+      actions.changeEmail('email.com', [])
     ])
     expect(result.errors.email).toEqual("invalid-email")
   })
 
   it('generates an error if email is invalid: finishes with period', () => {
     const result = playActions([
-      actions.validateEmail('email@instedd.', [])
+      actions.changeEmail('email@instedd.', [])
     ])
     expect(result.errors.email).toEqual("invalid-email")
   })
 
   it('does not generate an error if email is valid', () => {
     const result = playActions([
-      actions.validateEmail('valid.email@instedd.com', [])
+      actions.changeEmail('valid.email@instedd.com', [])
     ])
     assert(!result.errors.email)
   })
@@ -112,7 +112,7 @@ describe('guest reducer', () => {
   emails.map((email) => 
     it(`generate an error when ${email} is a collaborator`, () => {
       const result = playActions([
-        actions.validateEmail(email, collaborators)
+        actions.changeEmail(email, collaborators)
       ])
       expect(result.errors.email).toEqual("existing-email")
     })
@@ -120,7 +120,7 @@ describe('guest reducer', () => {
 
   it('does not generate an error if email is not a collaborator', () => {
     const result = playActions([
-      actions.validateEmail('test@instedd.com', collaborators)
+      actions.changeEmail('test@instedd.com', collaborators)
     ])
     assert(!result.errors.email)
   })


### PR DESCRIPTION
## Changes

* Back:
  * Return error message when trying to add an existing collaborator to a project
* Front:
  * Remove unused function `loadCollaboratorToEdit` from CollaboratorIndex and properties `confirmationText`, `onConfirm` from InviteModel
  * Modify `changeEmail` action and reducer to accept a list of collaborators to validate the email isn't included between the collaborators
  * Show error message resulting from the email validation

Closed #1786