### PR TITLE
Respect survey schedules before sending SMS

### DIFF
--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -430,7 +430,7 @@ defmodule Ask.Runtime.ChannelBroker do
               ivr_call(new_state, respondent, token, not_before, not_after)
           end
         end)
-      {respondent_id, token, reply, not_before, not_after} ->
+      {respondent_id, token, reply, _not_before, not_after} ->
         Respondent.with_lock(respondent_id, fn respondent ->
           cond do
             expired_contact_attempt?(not_after) ->

--- a/lib/ask/runtime/channel_broker_state.ex
+++ b/lib/ask/runtime/channel_broker_state.ex
@@ -94,7 +94,7 @@ defmodule Ask.Runtime.ChannelBrokerState do
   end
 
   # Adds an SMS contact to the queue with given priority (`:high`, `:normal`).
-  def queue_contact(state, {respondent, token, reply}, size, priority) do
+  def queue_contact(state, {respondent, token, reply, not_before, not_after}, size, priority) do
     Queue.upsert!(%{
       channel_id: state.channel_id,
       respondent_id: respondent.id,
@@ -102,8 +102,8 @@ defmodule Ask.Runtime.ChannelBrokerState do
       priority: priority,
       size: size,
       token: token,
-      not_before: nil,
-      not_after: nil,
+      not_before: not_before,
+      not_after: not_after,
       reply: reply
     })
 
@@ -173,7 +173,7 @@ defmodule Ask.Runtime.ChannelBrokerState do
   end
 
   defp to_item("sms", contact) do
-    {contact.respondent_id, contact.token, contact.reply}
+    {contact.respondent_id, contact.token, contact.reply, contact.not_before, contact.not_after}
   end
 
   # Increments the number of contacts for the respondent. Activates the contact

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -254,7 +254,7 @@ defmodule Ask.Runtime.Session do
     log_prompts(reply, channel, session.flow.mode, respondent)
 
     {not_before, not_after} = acceptable_contact_time_window(schedule)
-    
+
     ChannelBroker.ask(channel.id, channel.type, session.respondent, token, reply, not_before, not_after)
 
     # TODO: what happens with this when contact attempt falls outside acceptable window

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -254,6 +254,7 @@ defmodule Ask.Runtime.Session do
     log_prompts(reply, channel, session.flow.mode, respondent)
 
     {not_before, not_after} = acceptable_contact_time_window(schedule)
+    
     ChannelBroker.ask(channel.id, channel.type, session.respondent, token, reply, not_before, not_after)
 
     # TODO: what happens with this when contact attempt falls outside acceptable window

--- a/test/ask/runtime/channel_broker_state_test.exs
+++ b/test/ask/runtime/channel_broker_state_test.exs
@@ -69,9 +69,9 @@ defmodule Ask.Runtime.ChannelBrokerStateTest do
       mock_time(now)
 
       State.new(0, "sms", %{})
-      |> State.queue_contact({%{id: 2, disposition: :queued}, "secret", []}, 5)
+      |> State.queue_contact({%{id: 2, disposition: :queued}, "secret", [], nil, nil}, 5)
 
-      assert [%{respondent_id: 2, size: 5, queued_at: now, reply: []}] = Queue.queued_contacts(0)
+      assert [%{respondent_id: 2, size: 5, queued_at: now, reply: [], not_before: nil, not_after: nil}] = Queue.queued_contacts(0)
       assert [] = Queue.active_contacts(0)
     end
 
@@ -214,10 +214,10 @@ defmodule Ask.Runtime.ChannelBrokerStateTest do
 
       {_, contact} =
         State.new(0, "sms", %{})
-        |> State.queue_contact({respondent, "secret", []}, 2)
+        |> State.queue_contact({respondent, "secret", [], nil, nil}, 2)
         |> State.activate_next_in_queue()
 
-      assert {^respondent_id, "secret", []} = contact
+      assert {^respondent_id, "secret", [], nil, nil} = contact
     end
 
     @tag :time_mock

--- a/test/ask/runtime/channel_broker_state_test.exs
+++ b/test/ask/runtime/channel_broker_state_test.exs
@@ -68,10 +68,13 @@ defmodule Ask.Runtime.ChannelBrokerStateTest do
       now = DateTime.utc_now()
       mock_time(now)
 
-      State.new(0, "sms", %{})
-      |> State.queue_contact({%{id: 2, disposition: :queued}, "secret", [], nil, nil}, 5)
+      five_seconds_ago = DateTime.add(now, -5, :second)
+      in_one_minute = DateTime.add(now, 60, :second)
 
-      assert [%{respondent_id: 2, size: 5, queued_at: now, reply: [], not_before: nil, not_after: nil}] = Queue.queued_contacts(0)
+      State.new(0, "sms", %{})
+      |> State.queue_contact({%{id: 2, disposition: :queued}, "secret", [], five_seconds_ago, in_one_minute}, 5)
+
+      assert [%{respondent_id: 2, size: 5, queued_at: now, reply: [], not_before: five_seconds_ago, not_after: in_one_minute}] = Queue.queued_contacts(0)
       assert [] = Queue.active_contacts(0)
     end
 

--- a/test/ask/runtime/channel_broker_test.exs
+++ b/test/ask/runtime/channel_broker_test.exs
@@ -274,7 +274,6 @@ defmodule Ask.Runtime.ChannelBrokerTest do
           Enum.at(respondents, 4)
         ]
 
-        # All respondents should be in broker queue, but only the first one contacted
         assert Enum.map(expected_active_respondents, fn r -> r.id end) == active_respondent_ids(state)
 
         assert_sent_smss(expected_active_respondents, test_channel)

--- a/test/ask/runtime/channel_broker_test.exs
+++ b/test/ask/runtime/channel_broker_test.exs
@@ -241,6 +241,50 @@ defmodule Ask.Runtime.ChannelBrokerTest do
   end
 
   describe "Nuntium" do
+    defp activate_respondent(state, "sms", respondent, not_before, not_after) do
+      {_, state, _} =
+        ChannelBroker.handle_cast(
+          {:ask, "sms", respondent, "token", "foo", not_before, not_after},
+          state
+        )
+
+      state
+    end
+
+    test "Respect schedules for SMS" do
+      %{state: state, respondents: respondents, test_channel: test_channel} = build_survey("sms")
+
+      now = SystemTime.time().now
+      not_before = DateTime.add(now, 5, :second)
+      not_after = DateTime.add(now, 60, :second)
+      expired = DateTime.add(now, -5, :second)
+
+      with_mock Ask.Runtime.Survey, [contact_attempt_expired: fn _ -> :ok end] do
+        state =
+          state
+          |> activate_respondent("sms", Enum.at(respondents, 0), now, not_after)
+          |> activate_respondent("sms", Enum.at(respondents, 1), not_before, expired)
+          |> activate_respondent("sms", Enum.at(respondents, 2), not_before, expired)
+          |> activate_respondent("sms", Enum.at(respondents, 3), not_before, not_after)
+          |> activate_respondent("sms", Enum.at(respondents, 4), not_before, not_after)
+
+        expected_active_respondents = [
+          Enum.at(respondents, 0),
+          Enum.at(respondents, 3),
+          Enum.at(respondents, 4)
+        ]
+
+        # All respondents should be in broker queue, but only the first one contacted
+        assert Enum.map(expected_active_respondents, fn r -> r.id end) == active_respondent_ids(state)
+
+        assert_sent_smss(expected_active_respondents, test_channel)
+        assert_not_sent_smss([
+          Enum.at(respondents, 1),
+          Enum.at(respondents, 2),
+        ], test_channel)
+      end
+    end
+
     test "Every SMS is sent when capacity isn't set", %{} do
       channel_capacity = nil
       [test_channel, respondents, _channel] = initialize_survey("sms", channel_capacity)
@@ -466,6 +510,12 @@ defmodule Ask.Runtime.ChannelBrokerTest do
     refute_received [:ask, ^test_channel, _respondent, _token, _reply, _channel_id]
   end
 
+  defp assert_not_sent_smss(respondents, test_channel) do
+    Enum.each(respondents, fn %{id: id} ->
+      refute_received [:ask, ^test_channel, %{id: ^id}, _token, _reply, _channel_id]
+    end)
+  end
+
   defp assert_some_sent_smss(amount, respondents, test_channel) do
     respondent_ids = Enum.map(respondents, & &1.id)
 
@@ -511,7 +561,7 @@ defmodule Ask.Runtime.ChannelBrokerTest do
       config: Config.channel_broker_config()
     }
 
-    %{state: state, respondents: respondents, channel: channel}
+    %{state: state, respondents: respondents, channel: channel, test_channel: test_channel}
   end
 
   defp start_survey(channel_type) do
@@ -547,7 +597,9 @@ defmodule Ask.Runtime.ChannelBrokerTest do
   end
 
   defp respondent_to_contact("sms", respondent) do
-    {respondent, "secret", []}
+    not_before = SystemTime.time().now |> DateTime.add(-3600, :second)
+    not_after = SystemTime.time().now |> DateTime.add(3600, :second)
+    {respondent, "secret", [], not_before, not_after}
   end
 
   defp channel_state("ivr", respondent) do


### PR DESCRIPTION
Fixes #2283 

The fix involves adding `not_before` and `not_after` fields to `ChannelBroker.ask` (aka, `sms`, btw why don't we rename this??), and honoring them (it was only sent with `ChannelBroker.setup` (aka, 'ivr', ditto).

The way to honor those fields involves:
- Making sure they get also saved in the queue (previously only for IVR, `nil` for SMS)
- Add expiration checks for SMS when `ChannelBroker` dequeues
- Mark contact attempts as expired accordingly (so it gets picked up the next day)

Pending work:

- [x] Make it work 
- [x] Make it nice (aka refactor)
- [x] Future proof (add some more test cases)
- [x] Update docs with new behaviors

Updated wiki: 

https://github.com/instedd/surveda/wiki/Chart:-Start-Survey-(with-Channel-Broker)/565d79ddc3ac0b23f322a6584eac6604b533793e

