### PR TITLE
Fix: update respondent timeout upon contact

### DIFF
--- a/lib/ask.ex
+++ b/lib/ask.ex
@@ -57,7 +57,9 @@ defmodule Ask do
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Ask.Supervisor]
-    {:ok, _} = Logger.add_backend(Sentry.LoggerBackend)
+    if Mix.env() != :test do
+      {:ok, _} = Logger.add_backend(Sentry.LoggerBackend)
+    end
 
     Supervisor.start_link(children, opts)
   end

--- a/lib/ask/channel.ex
+++ b/lib/ask/channel.ex
@@ -119,6 +119,10 @@ defmodule Ask.Channel do
     end
   end
 
+  # Returns whether the channel sends delivery confirmations callbacks or not.
+  def has_delivery_confirmation?(%{type: "ivr"}), do: false
+  def has_delivery_confirmation?(%{type: "sms"}), do: true
+
   defp validate_patterns(changeset) do
     changeset
     |> validate_patterns_not_empty

--- a/lib/ask/retries_histogram.ex
+++ b/lib/ask/retries_histogram.ex
@@ -228,9 +228,12 @@ defmodule Ask.RetriesHistogram do
 
   defp end_flow(survey, flow) do
     fallback_delay = survey |> Survey.fallback_delay() |> minutes_to_hours()
-    [%{type: type}] = Enum.take(flow, -1)
+    [%{type: type, delay: last_delay}] = Enum.take(flow, -1)
 
-    end_flow_delay(type, fallback_delay)
+    # if last SMS delay is 0h, there was no retry - we default to the fallback_delay
+    # See Session.current_timeout/2 for reference
+    delay = if last_delay == 0, do: fallback_delay, else: last_delay
+    end_flow_delay(type, delay)
   end
 
   defp end_flow_delay("ivr", _), do: []

--- a/lib/ask/runtime/channel.ex
+++ b/lib/ask/runtime/channel.ex
@@ -3,10 +3,6 @@ defprotocol Ask.Runtime.Channel do
 
   @type t :: map()
 
-  # Returns whether the channel sends delivery confirmations callbacks or not.
-  @spec has_delivery_confirmation?(t()) :: boolean
-  def has_delivery_confirmation?(channel)
-
   # Configure the channel to start communicating with Surveda. For example setup
   # the callback URL on the remote service.
   @spec prepare(t()) :: any()

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -522,8 +522,8 @@ defmodule Ask.Runtime.ChannelBroker do
   end
 
   defp update_respondent_timeout(respondent) do
-    timeout_minutes = respondent.session |> Session.load() |> Session.current_timeout()
-    timeout_at = Respondent.next_actual_timeout(respondent, timeout_minutes, SystemTime.time().now)
+    session = respondent.session |> Session.load()
+    timeout_at = Respondent.next_actual_timeout(respondent, session.current_delay, SystemTime.time().now)
     Respondent.update(respondent, %{timeout_at: timeout_at}, true)
   end
 

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -32,10 +32,6 @@ defmodule Ask.Runtime.ChannelBroker do
     cast(channel_id, {:setup, channel_type, respondent, token, not_before, not_after})
   end
 
-  # FIXME: refactor this has_delivery_confirmation? that's defined multiple times - and used only once
-  def has_delivery_confirmation?(%{type: "ivr"}), do: false
-  def has_delivery_confirmation?(%{type: "sms"}), do: true
-
   def ask(channel_id, channel_type, respondent, token, reply, not_before \\ nil, not_after \\ nil) do
     cast(channel_id, {:ask, channel_type, respondent, token, reply, not_before, not_after})
   end
@@ -283,14 +279,6 @@ defmodule Ask.Runtime.ChannelBroker do
     info("handle_call[prepare]", channel_id: state.channel_id)
     new_state = refresh_runtime_channel(state)
     reply = Ask.Runtime.Channel.prepare(new_state.runtime_channel)
-    {:reply, reply, new_state, State.process_timeout(new_state)}
-  end
-
-  @impl true
-  def handle_call({:has_delivery_confirmation?}, _from, state) do
-    debug("handle_call[has_delivery_confirmation?]", channel_id: state.channel_id)
-    new_state = refresh_runtime_channel(state)
-    reply = Ask.Runtime.Channel.has_delivery_confirmation?(new_state.runtime_channel)
     {:reply, reply, new_state, State.process_timeout(new_state)}
   end
 

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -32,9 +32,9 @@ defmodule Ask.Runtime.ChannelBroker do
     cast(channel_id, {:setup, channel_type, respondent, token, not_before, not_after})
   end
 
-  def has_delivery_confirmation?(channel_id) do
-    call(channel_id, {:has_delivery_confirmation?})
-  end
+  # FIXME: refactor this has_delivery_confirmation? that's defined multiple times - and used only once
+  def has_delivery_confirmation?(%{type: "ivr"}), do: false
+  def has_delivery_confirmation?(%{type: "sms"}), do: true
 
   def ask(channel_id, channel_type, respondent, token, reply, not_before \\ nil, not_after \\ nil) do
     cast(channel_id, {:ask, channel_type, respondent, token, reply, not_before, not_after})

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -517,6 +517,10 @@ defmodule Ask.Runtime.ChannelBroker do
     end
   end
 
+  if Mix.env() == :test do
+    defp update_respondent_timeout(%{session: nil} = respondent), do: respondent
+  end
+
   defp update_respondent_timeout(respondent) do
     timeout_minutes = respondent.session |> Session.load() |> Session.current_timeout()
     timeout_at = Respondent.next_actual_timeout(respondent, timeout_minutes, SystemTime.time().now)

--- a/lib/ask/runtime/channel_broker.ex
+++ b/lib/ask/runtime/channel_broker.ex
@@ -1,9 +1,9 @@
 # NOTE: channels without channel_id (used in some unit tests) share a single process (channel_id: 0)
 defmodule Ask.Runtime.ChannelBroker do
-  alias Ask.Runtime.{ChannelBrokerSupervisor, SurveyLogger}
+  alias Ask.Runtime.{ChannelBrokerSupervisor, Session, SurveyLogger}
   alias Ask.Runtime.ChannelBrokerAgent, as: Agent
   alias Ask.Runtime.ChannelBrokerState, as: State
-  alias Ask.{Channel, Logger, Respondent, Repo, Stats}
+  alias Ask.{Channel, Logger, Respondent, Repo, Stats, SystemTime}
   import Ecto.Query
   use GenServer
 
@@ -458,7 +458,7 @@ defmodule Ask.Runtime.ChannelBroker do
   end
 
   defp log_contact(status, respondent) do
-    session = respondent.session |> Ask.Runtime.Session.load()
+    session = respondent.session |> Session.load()
     SurveyLogger.log(
       respondent.survey_id,
       session.flow.mode,
@@ -477,6 +477,8 @@ defmodule Ask.Runtime.ChannelBroker do
     response =
       state.runtime_channel
       |> Ask.Runtime.Channel.setup(respondent, token, not_before, not_after)
+
+    update_respondent_timeout(respondent)
 
     case response do
       {:ok, %{verboice_call_id: verboice_call_id}} ->
@@ -501,6 +503,8 @@ defmodule Ask.Runtime.ChannelBroker do
       state.runtime_channel
       |> Ask.Runtime.Channel.ask(respondent, token, reply, state.channel_id)
 
+    update_respondent_timeout(respondent)
+
     case result do
       {:ok, %{nuntium_token: nuntium_token}} ->
         channel_state = %{"nuntium_token" => nuntium_token}
@@ -511,6 +515,12 @@ defmodule Ask.Runtime.ChannelBroker do
         debug("channel_ask no nuntium_token", result: result)
         state
     end
+  end
+
+  defp update_respondent_timeout(respondent) do
+    timeout_minutes = respondent.session |> Session.load() |> Session.current_timeout()
+    timeout_at = Respondent.next_actual_timeout(respondent, timeout_minutes, SystemTime.time().now)
+    Respondent.update(respondent, %{timeout_at: timeout_at}, true)
   end
 
   # Don't schedule automatic GC runs in tests.

--- a/lib/ask/runtime/nuntium_channel.ex
+++ b/lib/ask/runtime/nuntium_channel.ex
@@ -469,7 +469,6 @@ defmodule Ask.Runtime.NuntiumChannel do
 
     def message_inactive?(_, _), do: false
 
-    def has_delivery_confirmation?(_), do: true
     def has_queued_message?(_, _), do: false
     def message_expired?(_, _), do: false
     def cancel_message(_, _), do: :ok

--- a/lib/ask/runtime/retries_histogram.ex
+++ b/lib/ask/runtime/retries_histogram.ex
@@ -41,7 +41,7 @@ defmodule Ask.Runtime.RetriesHistogram do
       %Session{} = session = Session.load(respondent.session)
 
       session =
-        reallocate_respondent(session, respondent, false, Session.current_timeout(session))
+        reallocate_respondent(session, respondent, false, session.current_delay)
 
       session.respondent
     end
@@ -56,7 +56,7 @@ defmodule Ask.Runtime.RetriesHistogram do
   def retry(session) do
     callback = fn ->
       %Session{respondent: %Respondent{} = respondent} = session
-      reallocate_respondent(session, respondent, ivr?(session), Session.current_timeout(session))
+      reallocate_respondent(session, respondent, ivr?(session), session.current_delay)
     end
 
     run_safe(%{
@@ -146,7 +146,7 @@ defmodule Ask.Runtime.RetriesHistogram do
        ) do
     # sms -> transition to active RetryStat
     if respondent.retry_stat_id,
-      do: reallocate_respondent(session, respondent, false, Session.current_timeout(session))
+      do: reallocate_respondent(session, respondent, false, session.current_delay)
   end
 
   defp do_next_step(_respondent, _session, {:reply, _reply, _}) do

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -768,7 +768,7 @@ defmodule Ask.Runtime.Session do
   end
 
   defp consume_retry(%{current_mode: %{retries: [current_delay | retries]}} = session) do
-    %{session | current_mode: %{session.current_mode | retries: retries, current_delay: current_delay}}
+    %{session | current_mode: %{session.current_mode | retries: retries}, current_delay: current_delay}
   end
 
   defp consume_retry(%{current_mode: %{retries: [], fallback_delay: fallback_delay}} = session) do

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -107,23 +107,20 @@ defmodule Ask.Runtime.Session do
         {:ok, session, %Reply{}, base_timeout(session) + current_timeout(session)}
 
       true ->
-        timeout(session, nil)
+        do_timeout(session)
     end
   end
 
-  # TODO: none of the three timeout/2 definitions use the second parameter
-  # I assume it's only there to differentiate it from "the first" timeout/1 definition.
-  # We should rename the timeout/2 function and remove the second parameter altogether?
-  def timeout(%{current_mode: %{retries: []}, fallback_mode: nil} = session, _) do
+  defp do_timeout(%{current_mode: %{retries: []}, fallback_mode: nil} = session) do
     session = %{session | respondent: RetriesHistogram.remove_respondent(session.respondent)}
     terminate(session)
   end
 
-  def timeout(%{current_mode: %{retries: []}} = session, _) do
+  defp do_timeout(%{current_mode: %{retries: []}} = session) do
     switch_to_fallback_mode(session)
   end
 
-  def timeout(%Session{} = session, _) do
+  defp do_timeout(%Session{} = session) do
     session = retry(session)
 
     {:ok, session, %Reply{}, session.current_delay}

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -109,6 +109,9 @@ defmodule Ask.Runtime.Session do
     end
   end
 
+  # TODO: none of the three timeout/2 definitions use the second parameter
+  # I assume it's only there to differentiate it from "the first" timeout/1 definition.
+  # We should rename the timeout/2 function and remove the second parameter altogether?
   def timeout(%{current_mode: %{retries: []}, fallback_mode: nil} = session, _) do
     session = %{session | respondent: RetriesHistogram.remove_respondent(session.respondent)}
     terminate(session)

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -640,7 +640,7 @@ defmodule Ask.Runtime.Session do
   defp log_prompts(reply, channel, mode, respondent, force \\ false, persist \\ true) do
     if persist do
       if force ||
-           !ChannelBroker.has_delivery_confirmation?(channel.id) do
+           !ChannelBroker.has_delivery_confirmation?(channel) do
         disposition = Reply.disposition(reply) || respondent.disposition
 
         Enum.each(Reply.steps(reply), fn step ->

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -3,6 +3,7 @@ defmodule Ask.Runtime.Session do
   import Ecto
 
   alias Ask.{
+    Channel,
     Repo,
     QuotaBucket,
     Respondent,
@@ -640,7 +641,7 @@ defmodule Ask.Runtime.Session do
   defp log_prompts(reply, channel, mode, respondent, force \\ false, persist \\ true) do
     if persist do
       if force ||
-           !ChannelBroker.has_delivery_confirmation?(channel) do
+           !Channel.has_delivery_confirmation?(channel) do
         disposition = Reply.disposition(reply) || respondent.disposition
 
         Enum.each(Reply.steps(reply), fn step ->

--- a/lib/ask/runtime/survey_broker.ex
+++ b/lib/ask/runtime/survey_broker.ex
@@ -224,6 +224,8 @@ defmodule Ask.Runtime.SurveyBroker do
   end
 
   def recontact_queued_respondents(respondent_ids) do
+    # TODO: it looks like this method is not used anymore since 46391a1430dbeb5b67498769080bc5a32f9cd135
+
     # We're recontacting respondants that were queued
     # in channel broker after it fails
     Repo.all(

--- a/lib/ask/runtime/survey_broker.ex
+++ b/lib/ask/runtime/survey_broker.ex
@@ -223,24 +223,6 @@ defmodule Ask.Runtime.SurveyBroker do
     )
   end
 
-  def recontact_queued_respondents(respondent_ids) do
-    # TODO: it looks like this method is not used anymore since 46391a1430dbeb5b67498769080bc5a32f9cd135
-
-    # We're recontacting respondants that were queued
-    # in channel broker after it fails
-    Repo.all(
-      from r in Respondent,
-        select: r.id,
-        where: r.id in ^respondent_ids
-    )
-    |> Enum.each(fn respondent_id ->
-      respondent = Respondent |> Repo.get(respondent_id)
-      session = respondent.session |> Session.load()
-      # We have loaded everything neccesary, now contact them without consuming a retry
-      Ask.Runtime.Session.contact_respondent(session)
-    end)
-  end
-
   defp retry_respondents(now) do
     # Select projects that have respondents to retry, then retry them respecting the project's batch limit
     Repo.all(

--- a/lib/ask/runtime/verboice_channel.ex
+++ b/lib/ask/runtime/verboice_channel.ex
@@ -479,7 +479,6 @@ defmodule Ask.Runtime.VerboiceChannel do
   def check_status(_), do: :up
 
   defimpl Ask.Runtime.Channel, for: Ask.Runtime.VerboiceChannel do
-    def has_delivery_confirmation?(_), do: false
     def ask(_, _, _, _, _), do: throw(:not_implemented)
     def prepare(_), do: :ok
     def messages_count(_, _, _, _, _), do: 1

--- a/test/ask/retries_histogram_test.exs
+++ b/test/ask/retries_histogram_test.exs
@@ -42,7 +42,7 @@ defmodule Ask.RetriesHistogramTest do
              %{type: mode, delay: 1, label: "1h"},
              %{type: mode, delay: 2, label: "2h"},
              %{type: mode, delay: 3, label: "3h"},
-             %{type: "end", delay: 5, label: "5h"}
+             %{type: "end", delay: 3, label: "3h"}
            ]
   end
 
@@ -99,7 +99,7 @@ defmodule Ask.RetriesHistogramTest do
              %{type: "sms", delay: 5, label: "5h"},
              %{type: "sms", delay: 6, label: "6h"},
              %{type: "sms", delay: 7, label: "7h"},
-             %{type: "end", delay: 4, label: "4h"}
+             %{type: "end", delay: 7, label: "7h"}
            ]
   end
 
@@ -130,7 +130,7 @@ defmodule Ask.RetriesHistogramTest do
              %{type: "sms", delay: 1, label: "1h"},
              %{type: "sms", delay: 2, label: "2h"},
              %{type: "sms", delay: 3, label: "3h"},
-             %{type: "end", delay: 4, label: "4h"}
+             %{type: "end", delay: 3, label: "3h"}
            ]
   end
 
@@ -310,11 +310,13 @@ defmodule Ask.RetriesHistogramTest do
 
     {:ok} = RetryStat.subtract(initial_stat_id)
 
+    assert histogram_actives(survey) == []
+
     {:ok, %{id: last_stat_id}} =
       RetryStat.add(%{
         attempt: 2,
         mode: [mode],
-        retry_time: retry_time(SystemTime.time().now, 3),
+        retry_time: retry_time(SystemTime.time().now, 2),
         ivr_active: false,
         survey_id: survey.id
       })
@@ -328,10 +330,7 @@ defmodule Ask.RetriesHistogramTest do
     assert histogram_actives(survey) == [%{hour: 4, respondents: 1}]
 
     time_passes(hours: 1)
-    assert histogram_actives(survey) == [%{hour: 5, respondents: 1}]
-
-    time_passes(hours: 1)
-    assert histogram_actives(survey) == [%{hour: 5, respondents: 1}]
+    assert histogram_actives(survey) == [%{hour: 4, respondents: 1}]
 
     {:ok} = RetryStat.subtract(last_stat_id)
 

--- a/test/ask/runtime/channel_broker_test.exs
+++ b/test/ask/runtime/channel_broker_test.exs
@@ -36,6 +36,23 @@ defmodule Ask.Runtime.ChannelBrokerTest do
       assert_made_calls(respondents, test_channel)
     end
 
+    @tag :time_mock
+    test "timeout_at gets updated after calling the respondent", %{} do
+      channel_capacity = nil
+      [test_channel, [respondent | _] = respondents, _channel] = initialize_survey("ivr", channel_capacity)
+
+      poll_time = ~U[2019-12-23 09:00:00Z]
+      mock_time(poll_time)
+      broker_poll()
+
+      assert_made_calls(respondents, test_channel)
+      Respondent.with_lock(respondent.id, fn respondent ->
+        %{timeout_at: timeout_at, session: %{"current_delay" => current_delay}} = respondent
+        assert DateTime.compare(timeout_at, Timex.shift(poll_time, minutes: current_delay)) == :eq
+      end)
+    end
+
+
     test "Calls aren't made while the channel capacity is full", %{conn: conn} do
       # Arrange
       channel_capacity = 5
@@ -291,6 +308,22 @@ defmodule Ask.Runtime.ChannelBrokerTest do
       broker_poll()
 
       assert_sent_smss(respondents, test_channel)
+    end
+
+    @tag :time_mock
+    test "timeout_at gets updated after sending an SMS", %{} do
+      channel_capacity = nil
+      [test_channel, [respondent | _] = respondents, _channel] = initialize_survey("sms", channel_capacity)
+
+      poll_time = ~U[2019-12-23 09:00:00Z]
+      mock_time(poll_time)
+      broker_poll()
+
+      assert_sent_smss(respondents, test_channel)
+      Respondent.with_lock(respondent.id, fn respondent ->
+        %{timeout_at: timeout_at, session: %{"current_delay" => current_delay}} = respondent
+        assert DateTime.compare(timeout_at, Timex.shift(poll_time, minutes: current_delay)) == :eq
+      end)
     end
 
     test "SMS aren't sent while the channel capacity is full", %{conn: conn} do

--- a/test/ask/runtime/channel_broker_test.exs
+++ b/test/ask/runtime/channel_broker_test.exs
@@ -19,6 +19,8 @@ defmodule Ask.Runtime.ChannelBrokerTest do
       ChannelBrokerAgent.clear()
     end)
 
+    Application.stop(:ask)
+    :ok = Application.start(:ask)
     {:ok, _} = ChannelStatusServer.start_link()
     {:ok, conn: conn}
   end

--- a/test/ask/runtime/survey_broker_test.exs
+++ b/test/ask/runtime/survey_broker_test.exs
@@ -33,6 +33,8 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       ChannelBrokerAgent.clear()
     end)
 
+    Application.stop(:ask)
+    :ok = Application.start(:ask)
     {:ok, channel_status_server} = ChannelStatusServer.start_link()
     {:ok, channel_status_server: channel_status_server}
   end
@@ -1722,6 +1724,14 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
+
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
 
     Respondent.with_lock(respondent.id, fn respondent ->
       assert respondent.disposition == :queued

--- a/test/ask/runtime/survey_broker_test.exs
+++ b/test/ask/runtime/survey_broker_test.exs
@@ -64,11 +64,13 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       ]
 
       # Set for immediate timeout
-      respondent = Repo.get!(Respondent, respondent.id)
-      assert respondent.stats.attempts["sms"] == 1
+      # respondent = Repo.get!(Respondent, respondent.id)
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.stats.attempts["sms"] == 1
 
-      Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+        Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       # Second poll, retry the question
       SurveyBroker.handle_info(:poll, nil)
@@ -84,16 +86,18 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       ]
 
       # Set for immediate timeout
-      respondent = Repo.get!(Respondent, respondent.id)
-
-      Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+      # respondent = Repo.get!(Respondent, respondent.id)
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       # Third poll, this time it should fail
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :failed
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :failed
+      end)
 
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :terminated
@@ -136,9 +140,11 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       # Assert activation
       {:ok, expected_timeout_at, _} = DateTime.from_iso8601("2019-12-09T09:00:00Z")
 
-      respondent = Repo.get!(Respondent, respondent.id)
-      assert DateTime.compare(respondent.timeout_at, expected_timeout_at) == :eq
-      assert respondent.stats.attempts["sms"] == 1
+      # respondent = Repo.get!(Respondent, respondent.id)
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert DateTime.compare(respondent.timeout_at, expected_timeout_at) == :eq
+        assert respondent.stats.attempts["sms"] == 1
+      end)
 
       # Set for immediate timeout
       {:ok, timeout_time, _} = DateTime.from_iso8601("2019-12-09T09:00:00Z")
@@ -160,9 +166,11 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       # Assert first retry
       {:ok, expected_timeout_at, _} = DateTime.from_iso8601("2019-12-09T11:00:00Z")
 
-      respondent = Repo.get!(Respondent, respondent.id)
-      assert DateTime.compare(respondent.timeout_at, expected_timeout_at) == :eq
-      assert respondent.stats.attempts["sms"] == 2
+      # respondent = Repo.get!(Respondent, respondent.id)
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert DateTime.compare(respondent.timeout_at, expected_timeout_at) == :eq
+        assert respondent.stats.attempts["sms"] == 2
+      end)
 
       # Set for immediate timeout
       {:ok, timeout_time, _} = DateTime.from_iso8601("2019-12-09T12:00:00Z")
@@ -172,10 +180,12 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       SurveyBroker.handle_info(:poll, nil)
 
       # Assert is failed
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :failed
-      assert respondent.stats.attempts["sms"] == 2
-      refute respondent.timeout_at
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :failed
+        assert respondent.stats.attempts["sms"] == 2
+        refute respondent.timeout_at
+      end)
+
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :terminated
     end
@@ -209,13 +219,15 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :running
 
-      respondent = Repo.get!(Respondent, respondent.id)
-      assert respondent.stats.attempts["mobileweb"] == 1
-      assert respondent.state == :active
+      Respondent.with_lock(respondent.id, fn respondent ->
+        # respondent = Repo.get!(Respondent, respondent.id)
+        assert respondent.stats.attempts["mobileweb"] == 1
+        assert respondent.state == :active
 
-      # Set for immediate timeout
-      timeout_at = Timex.now() |> Timex.shift(hours: -1)
-      Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+        # Set for immediate timeout
+        timeout_at = Timex.now() |> Timex.shift(hours: -1)
+        Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+      end)
 
       # Second poll, retry the question
       SurveyBroker.poll()
@@ -237,19 +249,21 @@ defmodule Ask.Runtime.SurveyBrokerTest do
                  )
                }"
 
-      respondent = Repo.get!(Respondent, respondent.id)
+      Respondent.with_lock(respondent.id, fn respondent ->
+        # respondent = Repo.get!(Respondent, respondent.id)
 
-      # Set for immediate timeout
-      timeout_at = Timex.now() |> Timex.shift(hours: -1)
-      Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+        # Set for immediate timeout
+        timeout_at = Timex.now() |> Timex.shift(hours: -1)
+        Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+      end)
 
       # Third poll, this time it should fail
       SurveyBroker.poll()
 
-      respondent = Repo.get(Respondent, respondent.id)
-
-      assert respondent.state == :failed
-      refute respondent.timeout_at
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :failed
+        refute respondent.timeout_at
+      end)
 
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :terminated
@@ -275,10 +289,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       ]
 
       # Set for immediate timeout
-      respondent = Repo.get(Respondent, respondent.id)
-
-      Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       # Second poll, retry the question
       SurveyBroker.handle_info(:poll, nil)
@@ -291,16 +305,17 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       ]
 
       # Set for immediate timeout
-      respondent = Repo.get(Respondent, respondent.id)
-
-      Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       # Third poll, this time it should fail
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :failed
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :failed
+      end)
 
       survey = Repo.get(Survey, survey.id)
       assert Survey.completed?(survey)
@@ -414,11 +429,11 @@ defmodule Ask.Runtime.SurveyBrokerTest do
         _channel_id
       ]
 
-      respondent = Repo.get(Respondent, respondent.id)
-
-      # Set for immediate timeout
-      timeout_at = Timex.now() |> Timex.shift(hours: -1)
-      Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        # Set for immediate timeout
+        timeout_at = Timex.now() |> Timex.shift(hours: -1)
+        Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+      end)
 
       # Second poll, retry the question
       SurveyBroker.handle_info(:poll, nil)
@@ -434,11 +449,11 @@ defmodule Ask.Runtime.SurveyBrokerTest do
         _channel_id
       ]
 
-      respondent = Repo.get(Respondent, respondent.id)
-
-      # Set for immediate timeout
-      timeout_at = Timex.now() |> Timex.shift(hours: -1)
-      Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        # Set for immediate timeout
+        timeout_at = Timex.now() |> Timex.shift(hours: -1)
+        Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+      end)
 
       # Third poll, retry the question
       SurveyBroker.handle_info(:poll, nil)
@@ -453,11 +468,11 @@ defmodule Ask.Runtime.SurveyBrokerTest do
         _channel_id
       ]
 
-      respondent = Repo.get(Respondent, respondent.id)
-
-      # Set for immediate timeout
-      timeout_at = Timex.now() |> Timex.shift(hours: -1)
-      Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        # Set for immediate timeout
+        timeout_at = Timex.now() |> Timex.shift(hours: -1)
+        Respondent.changeset(respondent, %{timeout_at: timeout_at}) |> Repo.update()
+      end)
 
       # Fourth poll, this time fallback to IVR channel
       SurveyBroker.handle_info(:poll, nil)
@@ -524,10 +539,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       ]
 
       # Set for immediate timeout
-      respondent = Repo.get(Respondent, respondent.id)
-
-      Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       # Second poll, retry the question
       SurveyBroker.handle_info(:poll, nil)
@@ -540,10 +555,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       ]
 
       # Set for immediate timeout
-      respondent = Repo.get(Respondent, respondent.id)
-
-      Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       # Third poll, this time fallback to SMS channel
       SurveyBroker.handle_info(:poll, nil)
@@ -556,10 +571,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       ]
 
       # Set for immediate timeout
-      respondent = Repo.get(Respondent, respondent.id)
-
-      Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       # Fourth poll, this time fallback to SMS channel
       SurveyBroker.handle_info(:poll, nil)
@@ -595,11 +610,16 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       assert_respondents_by_state(survey, 1, 20)
 
       r = Repo.all(from r in Respondent, where: r.state == :active) |> hd
-      Repo.update(r |> change |> Respondent.changeset(%{state: :completed}))
+
+      Respondent.with_lock(r.id, fn respondent ->
+        Repo.update(respondent |> change |> Respondent.changeset(%{state: :completed}))
+      end)
 
       Repo.all(from r in Respondent, where: r.state == :active)
       |> Enum.map(fn respondent ->
-        Repo.update(respondent |> change |> Respondent.changeset(%{state: :failed}))
+        Respondent.with_lock(respondent.id, fn respondent ->
+          Repo.update(respondent |> change |> Respondent.changeset(%{state: :failed}))
+        end)
       end)
 
       SurveyBroker.handle_info(:poll, nil)
@@ -626,7 +646,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       Repo.all(from r in Respondent, where: r.state == :active, limit: 5)
       |> Enum.map(fn respondent ->
-        Repo.update(respondent |> change |> Respondent.changeset(%{state: :completed}))
+        Respondent.with_lock(respondent.id, fn respondent ->
+          Repo.update(respondent |> change |> Respondent.changeset(%{state: :completed}))
+        end)
       end)
 
       SurveyBroker.handle_info(:poll, nil)
@@ -635,7 +657,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       Repo.all(from r in Respondent, where: r.state == :active)
       |> Enum.map(fn respondent ->
-        Repo.update(respondent |> change |> Respondent.changeset(%{state: :completed}))
+        Respondent.with_lock(respondent.id, fn respondent ->
+          Repo.update(respondent |> change |> Respondent.changeset(%{state: :completed}))
+        end)
       end)
 
       SurveyBroker.handle_info(:poll, nil)
@@ -720,7 +744,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       Repo.all(from r in Respondent, where: r.state == :active)
       |> Enum.map(fn respondent ->
-        Repo.update(respondent |> change |> Respondent.changeset(%{state: :completed}))
+        Respondent.with_lock(respondent.id, fn respondent ->
+          Repo.update(respondent |> change |> Respondent.changeset(%{state: :completed}))
+        end)
       end)
 
       SurveyBroker.handle_info(:poll, nil)
@@ -799,7 +825,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       Repo.all(from r in Respondent, where: r.state == :active)
       |> Enum.map(fn respondent ->
-        Repo.update(respondent |> change |> Respondent.changeset(%{state: :failed}))
+        Respondent.with_lock(respondent.id, fn respondent ->
+          Repo.update(respondent |> change |> Respondent.changeset(%{state: :failed}))
+        end)
       end)
 
       SurveyBroker.handle_info(:poll, nil)
@@ -816,8 +844,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       assert_respondents_by_state(survey, 1, 0)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      Repo.update(respondent |> change |> Respondent.changeset(%{state: :failed}))
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Repo.update(respondent |> change |> Respondent.changeset(%{state: :failed}))
+      end)
 
       SurveyBroker.handle_info(:poll, nil)
 
@@ -1203,22 +1232,24 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :running
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :active
-      assert respondent.disposition == :queued
 
-      now = Timex.now()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :active
+        assert respondent.disposition == :queued
 
-      # After one hour it should be marked as failed
-      Respondent.changeset(respondent, %{timeout_at: now |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+        now = Timex.now()
+
+        # After one hour it should be marked as failed
+        Respondent.changeset(respondent, %{timeout_at: now |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :failed
-      assert respondent.disposition == :failed
-
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :failed
+        assert respondent.disposition == :failed
+      end)
     end
 
     test "contacted respondents are marked as unresponsive" do
@@ -1242,26 +1273,31 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       survey = Repo.get(Ask.Survey, survey.id)
       assert survey.state == :running
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :active
-      assert respondent.disposition == :queued
 
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :active
+        assert respondent.disposition == :queued
+      end)
+
+      respondent = Repo.get(Respondent, respondent.id)
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you smoke?")
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == :contacted
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.disposition == :contacted
 
-      now = Timex.now()
+        now = Timex.now()
 
-      # After one hour it should be marked as failed
-      Respondent.changeset(respondent, %{timeout_at: now |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+        # After one hour it should be marked as failed
+        Respondent.changeset(respondent, %{timeout_at: now |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :failed
-      assert respondent.disposition == :unresponsive
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :failed
+        assert respondent.disposition == :unresponsive
+      end)
     end
 
     test "started respondents are marked as breakoff" do
@@ -1285,36 +1321,45 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       survey = Repo.get(Ask.Survey, survey.id)
       assert survey.state == :running
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :active
-      assert respondent.disposition == :queued
 
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :active
+        assert respondent.disposition == :queued
+      end)
+
+      respondent = Repo.get(Respondent, respondent.id)
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you smoke?")
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :active
-      assert respondent.disposition == :contacted
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :active
+        assert respondent.disposition == :contacted
+      end)
 
       respondent = Repo.get(Respondent, respondent.id)
       Ask.Runtime.Survey.sync_step(respondent, Flow.Message.reply("yes"))
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :active
-      assert respondent.disposition == :started
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :active
+        assert respondent.disposition == :started
+      end)
 
+      respondent = Repo.get(Respondent, respondent.id)
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you exercise?")
 
       now = Timex.now()
 
       # After one hour it should be marked as failed
-      Respondent.changeset(respondent, %{timeout_at: now |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Respondent.changeset(respondent, %{timeout_at: now |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :failed
-      assert respondent.disposition == :breakoff
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :failed
+        assert respondent.disposition == :breakoff
+      end)
     end
 
     test "interim partial respondents are kept as partial (SMS)" do
@@ -1325,36 +1370,44 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       {:ok, _} = SurveyLogger.start_link()
       SurveyBroker.poll()
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :active
-      assert respondent.disposition == :queued
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :active
+        assert respondent.disposition == :queued
+      end)
 
+      respondent = Repo.get(Respondent, respondent.id)
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you smoke?")
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :active
-      assert respondent.disposition == :contacted
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :active
+        assert respondent.disposition == :contacted
+      end)
 
       respondent = Repo.get(Respondent, respondent.id)
       Ask.Runtime.Survey.sync_step(respondent, Flow.Message.reply("Yes"))
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :active
-      assert respondent.disposition == :"interim partial"
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :active
+        assert respondent.disposition == :"interim partial"
+      end)
 
+      respondent = Repo.get(Respondent, respondent.id)
       Ask.Runtime.Survey.delivery_confirm(respondent, "Do you exercise?")
 
-      now = Timex.now()
+      Respondent.with_lock(respondent.id, fn respondent ->
+        now = Timex.now()
 
-      # After one hour it should be marked as failed
-      Respondent.changeset(respondent, %{timeout_at: now |> Timex.shift(minutes: -1)})
-      |> Repo.update()
+        # After one hour it should be marked as failed
+        Respondent.changeset(respondent, %{timeout_at: now |> Timex.shift(minutes: -1)})
+        |> Repo.update()
+      end)
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :failed
-      assert respondent.disposition == :partial
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :failed
+        assert respondent.disposition == :partial
+      end)
     end
   end
 
@@ -1364,8 +1417,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == :completed
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.disposition == :completed
+      end)
     end
 
     test "set the respondent as complete (disposition) if disposition is interim partial" do
@@ -1373,8 +1427,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == :completed
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.disposition == :completed
+      end)
     end
 
     test "set the respondent from registered to queued" do
@@ -1384,8 +1439,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       survey = Repo.get(Ask.Survey, survey.id)
       assert survey.state == :running
-      updated_respondent = Repo.get(Respondent, respondent.id)
-      assert updated_respondent.disposition == :queued
+
+      Respondent.with_lock(respondent.id, fn updated_respondent ->
+        assert updated_respondent.disposition == :queued
+      end)
     end
 
     test "don't set the respondent as completed (disposition) if disposition is ineligible" do
@@ -1394,8 +1451,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == :ineligible
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.disposition == :ineligible
+      end)
     end
 
     test "don't set the respondent as completed (disposition) if disposition is refused" do
@@ -1403,8 +1461,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == :refused
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.disposition == :refused
+      end)
     end
 
     test "don't set the respondent as partial (disposition) if disposition is ineligible" do
@@ -1413,8 +1472,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == :ineligible
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.disposition == :ineligible
+      end)
     end
 
     test "don't set the respondent as partial (disposition) if disposition is refused" do
@@ -1423,8 +1483,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == :refused
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.disposition == :refused
+      end)
     end
 
     test "don't set the respondent as ineligible (disposition) if disposition is completed" do
@@ -1433,8 +1494,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.disposition == :completed
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.disposition == :completed
+      end)
     end
   end
 
@@ -1446,19 +1508,21 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       survey = Repo.get(Ask.Survey, survey.id)
       assert survey.state == :running
-      updated_respondent = Repo.get(Respondent, respondent.id)
-      assert updated_respondent.state == :active
 
-      now = Timex.now()
+      Respondent.with_lock(respondent.id, fn updated_respondent ->
+        assert updated_respondent.state == :active
 
-      interval =
-        Interval.new(
-          from: Timex.shift(now, minutes: 9),
-          until: Timex.shift(now, minutes: 11),
-          step: [seconds: 1]
-        )
+        now = Timex.now()
 
-      assert updated_respondent.timeout_at in interval
+        interval =
+          Interval.new(
+            from: Timex.shift(now, minutes: 9),
+            until: Timex.shift(now, minutes: 11),
+            step: [seconds: 1]
+          )
+
+        assert updated_respondent.timeout_at in interval
+      end)
     end
 
     test "set the respondent as completed when the questionnaire is empty" do
@@ -1466,8 +1530,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
       SurveyBroker.handle_info(:poll, nil)
 
-      respondent = Repo.get(Respondent, respondent.id)
-      assert respondent.state == :completed
+      Respondent.with_lock(respondent.id, fn respondent ->
+        assert respondent.state == :completed
+      end)
     end
   end
 
@@ -1554,7 +1619,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
     Repo.all(from r in Respondent, where: r.state == :active, limit: 5)
     |> Enum.map(fn respondent ->
-      Repo.update(respondent |> change |> Respondent.changeset(%{state: :completed}))
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Repo.update(respondent |> change |> Respondent.changeset(%{state: :completed}))
+      end)
     end)
 
     SurveyBroker.handle_info(:poll, nil)
@@ -1575,7 +1642,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
     assert_respondents_by_state(survey, 1, 20)
 
     r = Repo.all(from r in Respondent, where: r.state == :active) |> hd
-    Repo.update(r |> change |> Respondent.changeset(%{state: :completed}))
+
+    Respondent.with_lock(r.id, fn r ->
+      Repo.update(r |> change |> Respondent.changeset(%{state: :completed}))
+    end)
 
     SurveyBroker.handle_info(:poll, nil)
 
@@ -1599,7 +1669,9 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       Repo.all(from r in Respondent, where: r.state == :active)
       |> Enum.at(0)
 
-    Repo.update(active_respondent |> change |> Respondent.changeset(%{state: :failed}))
+    Respondent.with_lock(active_respondent.id, fn active_respondent ->
+      Repo.update(active_respondent |> change |> Respondent.changeset(%{state: :failed}))
+    end)
 
     assert_respondents_by_state(survey, 9, 11)
 
@@ -1651,18 +1723,20 @@ defmodule Ask.Runtime.SurveyBrokerTest do
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
 
-    respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.disposition == :queued
+    Respondent.with_lock(respondent.id, fn respondent ->
+      assert respondent.disposition == :queued
 
-    # Set for immediate timeout
-    Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
-    |> Repo.update()
+      # Set for immediate timeout
+      Respondent.changeset(respondent, %{timeout_at: Timex.now() |> Timex.shift(minutes: -1)})
+      |> Repo.update()
+    end)
 
     SurveyBroker.handle_info(:poll, nil)
 
-    respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.state == :failed
-    assert respondent.disposition == :failed
+    Respondent.with_lock(respondent.id, fn respondent ->
+      assert respondent.state == :failed
+      assert respondent.disposition == :failed
+    end)
 
     :ok = broker |> GenServer.stop()
   end
@@ -1690,9 +1764,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
     SurveyBroker.handle_info(:poll, nil)
 
-    respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.mode == mode
-    assert respondent.questionnaire_id == questionnaire.id
+    Respondent.with_lock(respondent.id, fn respondent ->
+      assert respondent.mode == mode
+      assert respondent.questionnaire_id == questionnaire.id
+    end)
   end
 
   test "set the respondent questionnaire and mode with comparisons" do
@@ -1738,10 +1813,11 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
     SurveyBroker.handle_info(:poll, nil)
 
-    respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.mode == ["ivr"]
-    assert respondent.questionnaire_id == quiz1.id
-    assert respondent.stats.attempts["ivr"] == 1
+    Respondent.with_lock(respondent.id, fn respondent ->
+      assert respondent.mode == ["ivr"]
+      assert respondent.questionnaire_id == quiz1.id
+      assert respondent.stats.attempts["ivr"] == 1
+    end)
   end
 
   test "doesn't break with nil as comparison ratio" do
@@ -1787,15 +1863,18 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
     SurveyBroker.handle_info(:poll, nil)
 
-    respondent = Repo.get(Respondent, respondent.id)
-    assert respondent.mode == ["ivr"]
-    assert respondent.questionnaire_id == quiz1.id
+    Respondent.with_lock(respondent.id, fn respondent ->
+      assert respondent.mode == ["ivr"]
+      assert respondent.questionnaire_id == quiz1.id
+    end)
   end
 
   defp mark_n_active_respondents_as(new_state, n) do
     Repo.all(from r in Respondent, where: r.state == :active, limit: ^n)
     |> Enum.map(fn respondent ->
-      Repo.update(respondent |> change |> Respondent.changeset(%{state: new_state}))
+      Respondent.with_lock(respondent.id, fn respondent ->
+        Repo.update(respondent |> change |> Respondent.changeset(%{state: new_state}))
+      end)
     end)
   end
 
@@ -1857,8 +1936,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
   end
 
   defp refute_respondent_state(respondent_id, state) do
-    respondent = Repo.get!(Respondent, respondent_id)
-    refute respondent.state == state
+    # respondent = Repo.get!(Respondent, respondent_id)
+    Respondent.with_lock(respondent_id, fn respondent ->
+      refute respondent.state == state
+    end)
   end
 
   def wait_all_cancellations(%{id: survey_id}) do

--- a/test/ask/runtime/survey_broker_test.exs
+++ b/test/ask/runtime/survey_broker_test.exs
@@ -109,11 +109,10 @@ defmodule Ask.Runtime.SurveyBrokerTest do
         create_running_survey_with_channel_and_respondent(
           @dummy_steps,
           "sms",
-          Schedule.business_day(),
-          "3h"
+          Schedule.business_day()
         )
 
-      survey |> Survey.changeset(%{sms_retry_configuration: "2h"}) |> Repo.update()
+      survey |> Survey.changeset(%{sms_retry_configuration: "3h"}) |> Repo.update()
 
       {:ok, edge_time, _} = DateTime.from_iso8601("2019-12-06T17:00:00Z")
       mock_time(edge_time)
@@ -164,7 +163,7 @@ defmodule Ask.Runtime.SurveyBrokerTest do
       ]
 
       # Assert first retry
-      {:ok, expected_timeout_at, _} = DateTime.from_iso8601("2019-12-09T11:00:00Z")
+      {:ok, expected_timeout_at, _} = DateTime.from_iso8601("2019-12-09T12:00:00Z")
 
       # respondent = Repo.get!(Respondent, respondent.id)
       Respondent.with_lock(respondent.id, fn respondent ->
@@ -1502,7 +1501,8 @@ defmodule Ask.Runtime.SurveyBrokerTest do
 
   describe "change the respondent state" do
     test "changes the respondent state from pending to running if neccessary" do
-      [survey, _, _, respondent, _] = create_running_survey_with_channel_and_respondent()
+      [survey, _, _, respondent, _] = create_running_survey_with_channel_and_respondent_with_options(mode: "sms")
+      survey |> Survey.changeset(%{sms_retry_configuration: "10m"}) |> Repo.update()
 
       SurveyBroker.handle_info(:poll, nil)
 

--- a/test/ask/runtime/survey_test.exs
+++ b/test/ask/runtime/survey_test.exs
@@ -885,7 +885,7 @@ defmodule Ask.Runtime.SurveyTest do
     end
 
     test "via ivr with an empty thank you message" do
-      [survey, _group, _test_channel, respondent, _phone_number] =
+      [survey, _group, test_channel, respondent, phone_number] =
         create_running_survey_with_channel_and_respondent(@dummy_steps, "ivr")
 
       hd((survey |> Ask.Repo.preload(:questionnaires)).questionnaires)
@@ -916,6 +916,14 @@ defmodule Ask.Runtime.SurveyTest do
       {:ok, logger} = SurveyLogger.start_link()
       {:ok, broker} = SurveyBroker.start_link()
       SurveyBroker.poll()
+
+      # wait for the ChannelBroker to contact the respondent
+      assert_receive [
+        :setup,
+        ^test_channel,
+        %Respondent{sanitized_phone_number: ^phone_number},
+        _channel_id
+      ]
 
       survey = Repo.get(Ask.Survey, survey.id)
       assert survey.state == :running
@@ -2270,11 +2278,19 @@ defmodule Ask.Runtime.SurveyTest do
   end
 
   test "changes the respondent disposition from queued to contacted on answer (IVR)" do
-    [_survey, _group, _test_channel, respondent, _phone_number] =
+    [_survey, _group, test_channel, respondent, phone_number] =
       create_running_survey_with_channel_and_respondent(@dummy_steps, "ivr")
 
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
+
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      ^test_channel,
+      %Respondent{sanitized_phone_number: ^phone_number},
+      _channel_id
+    ]
 
     Respondent.with_lock(respondent.id, fn respondent ->
       assert respondent.disposition == :queued
@@ -2759,6 +2775,14 @@ defmodule Ask.Runtime.SurveyTest do
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
 
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
+
     Respondent.with_lock(respondent.id, fn respondent ->
       Survey.sync_step(respondent, Flow.Message.answer())
 
@@ -2812,6 +2836,14 @@ defmodule Ask.Runtime.SurveyTest do
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
 
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
+
     Respondent.with_lock(respondent.id, fn respondent ->
       Survey.sync_step(respondent, Flow.Message.answer())
 
@@ -2858,6 +2890,14 @@ defmodule Ask.Runtime.SurveyTest do
     {:ok, broker} = SurveyBroker.start_link()
     {:ok, logger} = SurveyLogger.start_link()
     SurveyBroker.poll()
+
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
 
     Respondent.with_lock(respondent.id, fn respondent ->
       assert respondent.state == :active
@@ -2916,6 +2956,14 @@ defmodule Ask.Runtime.SurveyTest do
     {:ok, logger} = SurveyLogger.start_link()
     SurveyBroker.poll()
 
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
+
     Respondent.with_lock(respondent.id, fn respondent ->
       assert respondent.state == :active
       assert respondent.disposition == :queued
@@ -2972,6 +3020,14 @@ defmodule Ask.Runtime.SurveyTest do
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
 
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
+
     Respondent.with_lock(respondent.id, fn respondent ->
       assert respondent.state == :active
       assert respondent.disposition == :queued
@@ -3019,6 +3075,14 @@ defmodule Ask.Runtime.SurveyTest do
     {:ok, broker} = SurveyBroker.start_link()
     {:ok, logger} = SurveyLogger.start_link()
     SurveyBroker.poll()
+
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
 
     Respondent.with_lock(respondent.id, fn respondent ->
       assert respondent.state == :active
@@ -3108,6 +3172,14 @@ defmodule Ask.Runtime.SurveyTest do
 
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
+
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
 
     Respondent.with_lock(respondent.id, fn respondent ->
       reply = Survey.sync_step(respondent, Flow.Message.answer())
@@ -3304,6 +3376,15 @@ defmodule Ask.Runtime.SurveyTest do
 
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
+
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
+
     survey = Repo.get(Ask.Survey, survey.id)
     assert survey.state == :running
 
@@ -3355,6 +3436,14 @@ defmodule Ask.Runtime.SurveyTest do
 
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
+
+    # wait for the ChannelBroker to contact the respondent
+    assert_receive [
+      :setup,
+      _,
+      _,
+      _channel_id
+    ]
 
     survey = Repo.get(Ask.Survey, survey.id)
     assert survey.state == :running
@@ -3656,6 +3745,15 @@ defmodule Ask.Runtime.SurveyTest do
     {:ok, logger} = SurveyLogger.start_link()
     {:ok, broker} = SurveyBroker.start_link()
     SurveyBroker.poll()
+
+    assert_receive [
+      :ask,
+      _,
+      %Respondent{sanitized_phone_number: ^canonical_phone_number},
+      _,
+      _,
+      _channel_id
+    ]
 
     Respondent.with_lock(respondent.id, fn respondent ->
       Survey.delivery_confirm(respondent, "Do you smoke?")

--- a/test/ask/runtime/verboice_channel_test.exs
+++ b/test/ask/runtime/verboice_channel_test.exs
@@ -32,6 +32,8 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       ChannelBrokerAgent.clear()
     end)
 
+    Application.stop(:ask)
+    :ok = Application.start(:ask)
     GenServer.start_link(SurveyStub, [], name: SurveyStub.server_ref())
     {:ok, _} = ChannelStatusServer.start_link()
     Ask.Config.start_link()
@@ -442,6 +444,14 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       {:ok, broker} = SurveyBroker.start_link()
       SurveyBroker.poll()
 
+      # wait for the ChannelBroker to contact the respondent
+      assert_receive [
+        :setup,
+        ^test_channel,
+        _respondent,
+        _channel_id
+      ]
+
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :running
 
@@ -516,6 +526,14 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       {:ok, broker} = SurveyBroker.start_link()
       SurveyBroker.poll()
 
+      # wait for the ChannelBroker to contact the respondent
+      assert_receive [
+        :setup,
+        ^test_channel,
+        _respondent,
+        _channel_id
+      ]
+
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :running
 
@@ -566,6 +584,14 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       {:ok, logger} = SurveyLogger.start_link()
       {:ok, broker} = SurveyBroker.start_link()
       SurveyBroker.poll()
+
+      # wait for the ChannelBroker to contact the respondent
+      assert_receive [
+        :setup,
+        ^test_channel,
+        _respondent,
+        _channel_id
+      ]
 
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :running
@@ -618,6 +644,14 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       {:ok, broker} = SurveyBroker.start_link()
       SurveyBroker.poll()
 
+      # wait for the ChannelBroker to contact the respondent
+      assert_receive [
+        :setup,
+        ^test_channel,
+        _respondent,
+        _channel_id
+      ]
+
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :running
 
@@ -667,6 +701,14 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       {:ok, logger} = SurveyLogger.start_link()
       {:ok, broker} = SurveyBroker.start_link()
       SurveyBroker.poll()
+
+      # wait for the ChannelBroker to contact the respondent
+      assert_receive [
+        :setup,
+        ^test_channel,
+        _respondent,
+        _channel_id
+      ]
 
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :running
@@ -719,6 +761,14 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       {:ok, logger} = SurveyLogger.start_link()
       {:ok, broker} = SurveyBroker.start_link()
       SurveyBroker.poll()
+
+      # wait for the ChannelBroker to contact the respondent
+      assert_receive [
+        :setup,
+        ^test_channel,
+        _respondent,
+        _channel_id
+      ]
 
       survey = Repo.get(Survey, survey.id)
       assert survey.state == :running
@@ -876,6 +926,14 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       {:ok, logger} = SurveyLogger.start_link()
       {:ok, broker} = SurveyBroker.start_link()
       SurveyBroker.poll()
+
+      # wait for the ChannelBroker to contact the respondent
+      assert_receive [
+        :setup,
+        ^test_channel,
+        _respondent,
+        _channel_id
+      ]
 
       respondent = Repo.get(Respondent, respondent.id)
       assert respondent.state == :active

--- a/test/ask_web/controllers/mobile_survey_controller_test.exs
+++ b/test/ask_web/controllers/mobile_survey_controller_test.exs
@@ -642,6 +642,17 @@ defmodule AskWeb.MobileSurveyControllerTest do
     Ask.Config.start_link()
     SurveyBroker.poll()
 
+    respondent_phone = respondent.sanitized_phone_number
+    channel_id = channel.id
+    assert_receive [
+      :ask,
+      ^test_channel,
+      %Respondent{sanitized_phone_number: ^respondent_phone},
+      _,
+      _,
+      ^channel_id
+    ]
+
     Survey |> Repo.get(survey.id) |> Repo.delete()
 
     conn =

--- a/test/support/test_channel.ex
+++ b/test/support/test_channel.ex
@@ -123,8 +123,6 @@ defimpl Ask.Runtime.Channel, for: Ask.TestChannel do
 
   def messages_count(_, _, _, _, _), do: 1
 
-  def has_delivery_confirmation?(%{delivery: delivery}), do: delivery
-
   def has_queued_message?(%{has_queued_message: has_queued_message}, _), do: has_queued_message
 
   def message_expired?(%{message_expired: message_expired}, _), do: message_expired

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -156,8 +156,9 @@ defmodule Ask.TestHelpers do
       defp broker_poll(), do: SurveyBroker.handle_info(:poll, nil)
 
       defp respondent_reply(respondent_id, reply_message, mode) do
-        respondent = Repo.get!(Respondent, respondent_id)
-        Ask.Runtime.Survey.sync_step(respondent, Flow.Message.reply(reply_message), mode)
+        Respondent.with_lock(respondent_id, fn respondent ->
+          Ask.Runtime.Survey.sync_step(respondent, Flow.Message.reply(reply_message), mode)
+        end)
       end
 
       defp get_respondents_by_state(survey) do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -52,7 +52,6 @@ defmodule Ask.TestHelpers do
         steps = Keyword.get(options, :steps, @dummy_steps)
         mode = Keyword.get(options, :mode, "sms")
         schedule = Keyword.get(options, :schedule, Ask.Schedule.always())
-        fallback_delay = Keyword.get(options, :fallback_delay, "10m")
         user = Keyword.get(options, :user, nil)
         simulation = Keyword.get(options, :simulation, false)
         respondents_quantity = Keyword.get(options, :respondents_quantity, 1)
@@ -84,7 +83,6 @@ defmodule Ask.TestHelpers do
           state: :running,
           questionnaires: [quiz],
           mode: [[mode]],
-          fallback_delay: fallback_delay,
           simulation: simulation
         }
 
@@ -125,14 +123,12 @@ defmodule Ask.TestHelpers do
       defp create_running_survey_with_channel_and_respondent(
              steps \\ @dummy_steps,
              mode \\ "sms",
-             schedule \\ Ask.Schedule.always(),
-             fallback_delay \\ "10m"
+             schedule \\ Ask.Schedule.always()
            ) do
         create_running_survey_with_channel_and_respondent_with_options(
           steps: steps,
           mode: mode,
-          schedule: schedule,
-          fallback_delay: fallback_delay
+          schedule: schedule
         )
       end
 


### PR DESCRIPTION
Whenever the broker sends a contact to a channel provider, we update the respondent's timeout so the delay is from the actual contact attempt instead of when the SurveyBroker queued it in the ChannelBroker.

See #2368