### PR TITLE
Fix: Debian Buster repositories were archived

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM elixir:1.10 AS dev
 # Cleanup expired Let's Encrypt CA (Sept 30, 2021)
 RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
 
-RUN apt -q update && \
-    apt -q install -y default-mysql-client inotify-tools festival && \
-    apt -q install -y --no-install-recommends ffmpeg libaacs0 && \
-    apt -q clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+
+RUN apt-get -q update && \
+    apt-get -q install -y default-mysql-client inotify-tools festival && \
+    apt-get -q install -y --no-install-recommends ffmpeg libaacs0 && \
+    apt-get -q clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mix local.hex --force
 RUN mix local.rebar --force


### PR DESCRIPTION
The `elixir:1.10` image depends on Buster.

We should of course upgrade that, but we'll patch it for now.